### PR TITLE
docs: Change simplified character errors in documents

### DIFF
--- a/docs/index-zh_cn.html
+++ b/docs/index-zh_cn.html
@@ -370,7 +370,7 @@
                 <div class="carousel-item ">
                   <div class="top-top">
 
-                    <h2>终於有属於自己的 NAS 了</h2>
+                    <h2>终于有属于自己的 NAS 了</h2>
                     <p>这还是我人生中第一次用 NAS，毕竟买一台 NAS 太贵了 </p>
                     <h4>Wei Vi</span></h4>
 

--- a/docs/index-zh_cn.html
+++ b/docs/index-zh_cn.html
@@ -113,7 +113,7 @@
 
             <img src="img/svg/cloud.svg" alt="img" class="img-fluid">
             <h4>云端桌面</h4>
-            <p>简单又优美的网页桌面界面，让你可以轻鬆完成日常生活上的简单工作</p>
+            <p>简单又优美的网页桌面界面，让你可以轻松完成日常生活上的简单工作</p>
 
           </div>
         </div>
@@ -123,7 +123,7 @@
 
             <img src="img/rpi.png" alt="img" class="img-fluid">
             <h4>为「树莓派」而设计</h4>
-            <p>系统适用於 树莓派 等资源有限的单片电脑，也能在一般电脑和伺服器上执行 </p>
+            <p>系统适用于 树莓派 等资源有限的单片电脑，也能在一般电脑和伺服器上执行 </p>
 
           </div>
         </div>
@@ -158,15 +158,15 @@
           <div class="about-content">
 
             <h2><span>ArozOS</span>主机<br> 网页桌面系统 </h2>
-            <p>快速让任何安装了瀏览器和连接互联网的电脑变成属於你的个人装置，随时随地存取你在云端上的档案。
+            <p>快速让任何安装了浏览器和连接互联网的电脑变成属于你的个人装置，随时随地存取你在云端上的档案。
             </p>
             
             <ul class="list-unstyled">
-              <li><i class="fa fa-angle-right"></i>无需要特别的使用者权限</li>
-              <li><i class="fa fa-angle-right"></i>支援 Chrome， Firefox 及 Safari 瀏览器</li>
-              <li><i class="fa fa-angle-right"></i>可透过网页桌面、FTP 及 WebDAV 存取档案</li>
-              <li><i class="fa fa-angle-right"></i>可能是世界上最好的网页档案管理员</li>
-              <li><i class="fa fa-angle-right"></i>基於 HTML5 的现代化 WebApps</li>
+              <li><i class="fa fa-angle-right"></i>不需要特别的使用者权限</li>
+              <li><i class="fa fa-angle-right"></i>支持 Chrome， Firefox 及 Safari 浏览器</li>
+              <li><i class="fa fa-angle-right"></i>可透过网页桌面、FTP 及 WebDAV 存取文件</li>
+              <li><i class="fa fa-angle-right"></i>可能是世界上最好的网页文件管理员</li>
+              <li><i class="fa fa-angle-right"></i>基于 HTML5 的现代化 WebApps</li>
               
             </ul>
 
@@ -187,13 +187,13 @@
           <div class="about-content">
 
             <h2><span>ArozOS</span>手机 <br>网页桌面系统 </h2>
-            <p>使用 PWA 技术，让你的桌面也能在手机上开啟，让装置之间传送档案更加方便快捷。
+            <p>使用 PWA 技术，让你的桌面也能在手机上开启，让装置之间传送文件更加方便快捷。
             </p>
 
             <ul class="list-unstyled">
               <li><i class="fa fa-angle-right"></i>无需安装任何 App</li>
-              <li><i class="fa fa-angle-right"></i>支援 Android 及 iOS 装置</li>
-              <li><i class="fa fa-angle-right"></i>支援 Chrome 及 Safari</li>
+              <li><i class="fa fa-angle-right"></i>支持 Android 及 iOS 装置</li>
+              <li><i class="fa fa-angle-right"></i>支持 Chrome 及 Safari</li>
               <li><i class="fa fa-angle-right"></i>类视窗型作业模式</li>
               <li><i class="fa fa-angle-right"></i>可在多台装置之间进行即时同步</li>
             </ul>
@@ -232,7 +232,7 @@
         <div class="col-md-6 col-lg-3">
           <div class="feature-block">
             <img src="img/icons/computer_cloud_storage.png" alt="img" class="img-fluid">
-            <h4>支援多媒体</h4>
+            <h4>支持多媒体</h4>
             <p>内置音乐、图片及音乐播放器，适合用作多媒体串流之用</p>
           </div>
         </div>
@@ -240,8 +240,8 @@
         <div class="col-md-6 col-lg-3">
           <div class="feature-block">
             <img src="img/icons/envelop_paper.png" alt="img" class="img-fluid">
-            <h4>档案管理员</h4>
-            <p>可能是你能在网页桌面环境裡找到的，最好的一个档案管理员</p>
+            <h4>文件管理员</h4>
+            <p>可能是你能在网页桌面环境里找到的，最好的一个文件管理员</p>
           </div>
         </div>
 
@@ -282,7 +282,7 @@
             <img src="img/svg/code.svg" alt="img" class="img-fluid">
             <h4>使用 Go 语言开发
             </h4>
-            <p>比起其他语言如 PHP，Go 更能榨乾树莓派的处理能力，使系统运行效率更佳</p>
+            <p>比起其他语言如 PHP，Go 更能榨干树莓派的处理能力，使系统运行效率更佳</p>
           </div>
         </div>
 


### PR DESCRIPTION
In simplified Chinese, '於' should be written as' 于 '