### PR TITLE
Fix panic caused by reading error output unnecessarily.

### DIFF
--- a/src/mod/disk/diskspace/diskspace.go
+++ b/src/mod/disk/diskspace/diskspace.go
@@ -95,7 +95,7 @@ func GetAllLogicDiskInfo() []LogicalDiskSpaceInfo {
 		//Get drive status using df command
 		cmdin := `df -k | sed -e /Filesystem/d`
 		cmd := exec.Command("bash", "-c", cmdin)
-		dev, err := cmd.CombinedOutput()
+		dev, err := cmd.Output()
 		if err != nil {
 			dev = []byte{}
 		}

--- a/src/mod/info/hardwareinfo/sysinfo.go
+++ b/src/mod/info/hardwareinfo/sysinfo.go
@@ -39,7 +39,7 @@ func GetDriveStat(w http.ResponseWriter, r *http.Request) {
 	//Get drive status using df command
 	cmdin := `df -k | sed -e /Filesystem/d`
 	cmd := exec.Command("bash", "-c", cmdin)
-	dev, err := cmd.CombinedOutput()
+	dev, err := cmd.Output()
 	if err != nil {
 		dev = []byte{}
 	}


### PR DESCRIPTION
### Problem:

Using `CombinedOutput()` here causes arozos to try and parse stderr output from the df command. This not only does not seem to be necessary, but worse causes frequent panics of the goroutines that try to read an index (`driveInfoChunk[5]`) that is beyond the length of the slice. 

### Solution:
Using Output() here instead of CombinedOutput() fixes this issue as it does not try to parse erroneous output.