### PR TITLE
Update installscript without sudo and run arozos as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ go build
 Install the latest version of Raspberry Pi OS / Armbian / Debian on an SD card / boot drive and boot it up. After setup and initialization is done, connect to it via SSH or use the Terminal App on your desktop to enter the following command
 
 ```bash
-wget -O install.sh https://raw.githubusercontent.com/tobychui/arozos/master/installer/install.sh && bash install.sh
+wget -O install.sh https://raw.githubusercontent.com/tobychui/arozos/master/installer/install.sh && sudo bash install.sh
 ```
 
 and follow the on-screen instruction to setup your arozos system. 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -158,8 +158,7 @@ EOF
         # Reload systemd daemon and enable service
         systemctl daemon-reload
         systemctl enable arozos.service
-	chmod +x /home/$(logname)/arozos/system/disk/smart/linux/smartctl_i386
-		systemctl start arozos.service
+	systemctl start arozos.service
         echo "ArozOS installation completed!"
 		ip_address=$(hostname -I | awk '{print $1}')
 		echo "Please continue the system setup at http://$ip_address:$arozport/"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -20,13 +20,13 @@ if [[ $agree != "y" ]]; then
 fi
 
 # Create the required folder structure to hold the installation
-cd ~/ || exit
+cd /home/$(logname)/ || exit
 mkdir arozos
 cd arozos || exit
 
 # Run apt-updates
-sudo apt-get update
-sudo apt-get install ffmpeg net-tools -y
+apt update
+apt install ffmpeg net-tools wget -y
 
 # Determine the CPU architecture of the host
 if [[ $(uname -m) == "x86_64" ]]; then
@@ -108,11 +108,11 @@ arozport=${arozport:-8080}
 if [[ -f "./launcher" ]]; then
   # Create start.sh with launcher command
   echo "#!/bin/bash" > start.sh
-  echo "sudo ./launcher -port=$arozport -hostname=\"$arozosname\"" >> start.sh
+  echo "./launcher -port=$arozport -hostname=\"$arozosname\"" >> start.sh
 else
   # Create start.sh with arozos command
   echo "#!/bin/bash" > start.sh
-  echo "sudo arozos -port=$arozport -hostname=\"$arozosname\"" >> start.sh
+  echo "arozos -port=$arozport -hostname=\"$arozosname\"" >> start.sh
 fi
 
 # Make start.sh executable
@@ -130,8 +130,8 @@ if [[ $(uname) == "Linux" ]]; then
         # Get current user
         CURRENT_USER=$(whoami)
 		
-		sudo touch /etc/systemd/system/arozos.service
-		sudo chmod 777 /etc/systemd/system/arozos.service
+		touch /etc/systemd/system/arozos.service
+		chmod 777 /etc/systemd/system/arozos.service
         # Create systemd service file
         cat <<EOF > /etc/systemd/system/arozos.service
 [Unit]
@@ -142,8 +142,10 @@ Wants=systemd-networkd-wait-online.service
 [Service]
 Type=simple
 ExecStartPre=/bin/sleep 10
-WorkingDirectory=/home/${CURRENT_USER}/arozos/
-ExecStart=/bin/bash /home/${CURRENT_USER}/arozos/start.sh
+WorkingDirectory=/home/$(logname)/arozos
+ExecStart=/bin/bash /home/$(logname)/arozos/start.sh
+User=root   
+Group=root
 
 Restart=always
 RestartSec=10
@@ -151,12 +153,13 @@ RestartSec=10
 [Install]
 WantedBy=multi-user.target
 EOF
-		sudo chmod 644 /etc/systemd/system/arozos.service
+		chmod 644 /etc/systemd/system/arozos.service
 		
         # Reload systemd daemon and enable service
-        sudo systemctl daemon-reload
-        sudo systemctl enable arozos.service
-		sudo systemctl start arozos.service
+        systemctl daemon-reload
+        systemctl enable arozos.service
+	chmod +x /home/$(logname)/arozos/system/disk/smart/linux/smartctl_i386
+		systemctl start arozos.service
         echo "ArozOS installation completed!"
 		ip_address=$(hostname -I | awk '{print $1}')
 		echo "Please continue the system setup at http://$ip_address:$arozport/"
@@ -164,5 +167,3 @@ EOF
 else
 	echo "ArozOS installation completed! Execute start.sh to startup your ArozOS system."
 fi
-
-


### PR DESCRIPTION
This updates the installscript, so arozos runs as root for network managing and so on.

The issue with the smartctl not working needs to be fixed in the package files. Those files are not existing until the first start of arozos.

Updated readme to run the script as root.