### PR TITLE
Improve window name readability

### DIFF
--- a/src/web/script/ao.css
+++ b/src/web/script/ao.css
@@ -74,12 +74,13 @@ body.darkTheme .ui.header .sub.header{
     color:white;
     display: inline-block;
     position:absolute;
-    left:40.5px;
-    top:5px;
+    left:28.5px;
+    top:-1px;
     max-width: calc(100% - 140px);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    padding: 5px 10px;
 }
 
 .floatWindow .controls .moduleicon{
@@ -252,6 +253,6 @@ body.darkTheme .ui.header .sub.header{
 
 
 .fwdragger {
-    --text-outline-color: rgba(36, 36, 36, 0.75);
-    text-shadow: 1px 0 0 var(--text-outline-color), 0 -1px 0 var(--text-outline-color), 0 1px 0 var(--text-outline-color), -1px 0 0 var(--text-outline-color);
+    --text-outline-color: rgba(36, 36, 36, 0.9);
+    text-shadow: 0 0 10px var(--text-outline-color), 0px 0px 4px var(--text-outline-color), 0px 0px 2px var(--text-outline-color);
 }


### PR DESCRIPTION
This improves the readability of the window names, especially on white backgrounds.

**Before:**
<img width="444" height="398" alt="titles-before" src="https://github.com/user-attachments/assets/3556df8a-335e-4c9e-b088-32f5285a89d2" />

**After:**
<img width="371" height="358" alt="titles-after" src="https://github.com/user-attachments/assets/0c4d7ae6-bd98-4a94-9da7-5e41da823ff6" />
