### PR TITLE
Added RAW preview feature in the share interface

### DIFF
--- a/src/mod/media/mediaserver/mediaserver.go
+++ b/src/mod/media/mediaserver/mediaserver.go
@@ -180,8 +180,20 @@ func (s *Instance) ServerMedia(w http.ResponseWriter, r *http.Request) {
 
 	targetFshAbs := targetFsh.FileSystemAbstraction
 
-	// Check if this is a RAW image file and render it as JPEG
-	if metadata.IsRawImageFile(realFilepath) {
+	//Check if downloadMode
+	downloadMode := false
+	dw, _ := utils.GetPara(r, "download")
+	if dw == "true" {
+		downloadMode = true
+	}
+
+	//New download implementations, allow /download to be used instead of &download=true
+	if strings.Contains(r.RequestURI, "media/download/?file=") {
+		downloadMode = true
+	}
+
+	// Check if this is a RAW image file and render it as JPEG (preview only, not download)
+	if !downloadMode && metadata.IsRawImageFile(realFilepath) {
 		jpegData, err := metadata.RenderRAWImage(targetFsh, realFilepath)
 		if err != nil {
 			// If RAW rendering fails, fall back to serving the raw file
@@ -193,18 +205,6 @@ func (s *Instance) ServerMedia(w http.ResponseWriter, r *http.Request) {
 			w.Write(jpegData)
 			return
 		}
-	}
-
-	//Check if downloadMode
-	downloadMode := false
-	dw, _ := utils.GetPara(r, "download")
-	if dw == "true" {
-		downloadMode = true
-	}
-
-	//New download implementations, allow /download to be used instead of &download=true
-	if strings.Contains(r.RequestURI, "media/download/?file=") {
-		downloadMode = true
 	}
 
 	//Serve the file

--- a/src/mod/share/share.go
+++ b/src/mod/share/share.go
@@ -768,8 +768,18 @@ func (s *Manager) HandleShareAccess(w http.ResponseWriter, r *http.Request) {
 			} else if directServe {
 				w.Header().Set("Access-Control-Allow-Origin", "*")
 				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-				w.Header().Set("Content-Type", contentType)
-				if targetFsh.RequireBuffer {
+				if metadata.IsRawImageFile(fileRuntimeAbsPath) {
+					// Convert RAW image to JPEG for browser display
+					jpegData, err := metadata.RenderRAWImage(targetFsh, fileRuntimeAbsPath)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte("500 - Failed to render RAW image: " + err.Error()))
+						return
+					}
+					w.Header().Set("Content-Type", "image/jpeg")
+					w.Write(jpegData)
+				} else if targetFsh.RequireBuffer {
+					w.Header().Set("Content-Type", contentType)
 					f, err := targetFshAbs.ReadStream(fileRuntimeAbsPath)
 					if err != nil {
 						w.WriteHeader(http.StatusInternalServerError)
@@ -779,6 +789,7 @@ func (s *Manager) HandleShareAccess(w http.ResponseWriter, r *http.Request) {
 					defer f.Close()
 					io.Copy(w, f)
 				} else {
+					w.Header().Set("Content-Type", contentType)
 					f, err := targetFshAbs.Open(fileRuntimeAbsPath)
 					if err != nil {
 						w.WriteHeader(http.StatusInternalServerError)
@@ -810,7 +821,7 @@ func (s *Manager) HandleShareAccess(w http.ResponseWriter, r *http.Request) {
 					previewTemplate = filepath.Join(templateRoot, "video.html")
 				} else if ext == ".mp3" || ext == ".wav" || ext == ".flac" || ext == ".ogg" {
 					previewTemplate = filepath.Join(templateRoot, "audio.html")
-				} else if ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".webp" {
+				} else if ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".webp" || metadata.IsRawImageFile(fileRuntimeAbsPath) {
 					previewTemplate = filepath.Join(templateRoot, "image.html")
 				} else if ext == ".pdf" {
 					previewTemplate = filepath.Join(templateRoot, "iframe.html")


### PR DESCRIPTION
<html>
<body>
<hr>
<h2>Add RAW image format support to the share interface</h2>
<p>RAW camera formats (<code>.dng</code>, <code>.cr2</code>, <code>.arw</code>, <code>.nef</code>, <code>.raf</code>, <code>.orf</code>) were previously unsupported in the share interface — shared RAW files fell through to the generic download page with no preview, and the <code>/share/preview/</code> endpoint served the raw binary directly, which browsers cannot display.</p>
<h3>Changes</h3>
<p><strong><code>src/mod/share/share.go</code></strong></p>
<ul>
<li>Route RAW files to the <code>image.html</code> preview template instead of <code>default.html</code></li>
<li>In the <code>/share/preview/</code> endpoint, detect RAW files and convert them to JPEG on the fly using the existing <code>metadata.RenderRAWImage()</code> pipeline before sending to the browser</li>
</ul>
<p><strong><code>src/mod/media/mediaserver/mediaserver.go</code></strong></p>
<ul>
<li>Fixed a bug where <code>/media/download/?file=...dng</code> was delivering a JPEG instead of the original RAW file — the RAW→JPEG conversion was happening before the download mode check, so downloads were silently converted. The conversion now only runs for preview requests.</li>
</ul>
<h3>Behaviour after this change</h3>

Endpoint | Before | After
-- | -- | --
Share page for a RAW file | Generic download page, no preview | Image preview (converted to JPEG)
/share/preview/{uuid} | Raw binary bytes, browser can't display | JPEG served with image/jpeg content type
/media/download/?file=...dng | JPEG (bug) | Original RAW file
/media/?file=...dng | JPEG | JPEG (unchanged)

</body></html><!--EndFragment-->
</body>
</html>

<img width="1286" height="706" alt="image" src="https://github.com/user-attachments/assets/f3654047-2359-4256-8721-5443ead44202" />
