### PR TITLE
Replace standard log package calls with arozos logger package

### DIFF
--- a/src/desktop.go
+++ b/src/desktop.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -46,8 +46,8 @@ func DesktopInit() {
 	//Initialize desktop database
 	err := sysdb.NewTable("desktop")
 	if err != nil {
-		log.Println("Unable to create database table for Desktop. Please validation your installation.")
-		log.Fatal(err)
+		systemWideLogger.PrintAndLog("System", "Unable to create database table for Desktop. Please validation your installation.", nil)
+		systemWideLogger.PrintAndLog("System", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 

--- a/src/file_system.go
+++ b/src/file_system.go
@@ -5,10 +5,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"hash/crc32"
 	"io"
 	"io/fs"
-	"log"
 	"math"
 	"mime"
 	"net/http"
@@ -1004,7 +1004,7 @@ func system_fs_WebSocketScanTrashBin(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("500 - " + err.Error()))
-		log.Print("Websocket Upgrade Error:", err.Error())
+		systemWideLogger.PrintAndLog("System", fmt.Sprint("Websocket Upgrade Error:", err.Error()), nil)
 		return
 	}
 
@@ -1471,7 +1471,7 @@ func system_fs_handleWebSocketOpr(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("500 - " + err.Error()))
-		log.Print("Websocket Upgrade Error:", err.Error())
+		systemWideLogger.PrintAndLog("System", fmt.Sprint("Websocket Upgrade Error:", err.Error()), nil)
 		return
 	}
 

--- a/src/main.go
+++ b/src/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -90,8 +89,8 @@ func main() {
 	os.Mkdir(*tmp_directory, 0777)
 
 	//Print copyRight information
-	log.Println("ArozOS(C) " + strconv.Itoa(time.Now().Year()) + " " + deviceVendor + ".")
-	log.Println("ArozOS " + build_version + " Revision " + internal_version)
+	systemWideLogger.PrintAndLog("System", "ArozOS(C) " + strconv.Itoa(time.Now().Year()) + " " + deviceVendor + ".", nil)
+	systemWideLogger.PrintAndLog("System", "ArozOS " + build_version + " Revision " + internal_version, nil)
 
 	/*
 		New Implementation of the ArOZ Online System, Sept 2020
@@ -117,16 +116,16 @@ func main() {
 			if !*disable_http {
 				go func() {
 					address := fmt.Sprintf("%s:%d", *listen_host, *listen_port)
-					log.Println("Standard (HTTP) Web server listening at", address)
+					systemWideLogger.PrintAndLog("System", fmt.Sprint("Standard (HTTP) Web server listening at", address), nil)
 					http.ListenAndServe(address, nil)
 				}()
 			}
 			address := fmt.Sprintf("%s:%d", *listen_host, *tls_listen_port)
-			log.Println("Secure (HTTPS) Web server listening at", address)
+			systemWideLogger.PrintAndLog("System", fmt.Sprint("Secure (HTTPS) Web server listening at", address), nil)
 			http.ListenAndServeTLS(address, *tls_cert, *tls_key, nil)
 		} else {
 			address := fmt.Sprintf("%s:%d", *listen_host, *listen_port)
-			log.Println("Web server listening at", address)
+			systemWideLogger.PrintAndLog("System", fmt.Sprint("Web server listening at", address), nil)
 			http.ListenAndServe(address, nil)
 		}
 	}()

--- a/src/mod/agi/agi.appdata.go
+++ b/src/mod/agi/agi.appdata.go
@@ -3,7 +3,7 @@ package agi
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -28,7 +28,8 @@ var webRoot string = "./web" //The web folder root
 func (g *Gateway) AppdataLibRegister() {
 	err := g.RegisterLib("appdata", g.injectAppdataLibFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 

--- a/src/mod/agi/agi.audio.go
+++ b/src/mod/agi/agi.audio.go
@@ -1,7 +1,8 @@
 package agi
 
 import (
-	"log"
+	"fmt"
+	"os"
 
 	"imuslab.com/arozos/mod/agi/static"
 )
@@ -19,7 +20,8 @@ import (
 func (g *Gateway) AudioLibRegister() {
 	err := g.RegisterLib("audio", g.injectAudioFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 

--- a/src/mod/agi/agi.ffmpeg.go
+++ b/src/mod/agi/agi.ffmpeg.go
@@ -2,7 +2,7 @@ package agi
 
 import (
 	"errors"
-	"log"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,11 +27,13 @@ import (
 func (g *Gateway) FFmpegLibRegister() {
 	_, err := exec.LookPath("ffmpeg")
 	if err != nil {
-		log.Fatal("ffmpeg not found in PATH")
+		agiLogger.PrintAndLog("Agi", "ffmpeg not found in PATH", nil)
+		os.Exit(1)
 	}
 	err = g.RegisterLib("ffmpeg", g.injectFFmpegFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 

--- a/src/mod/agi/agi.file.go
+++ b/src/mod/agi/agi.file.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +30,8 @@ import (
 func (g *Gateway) FileLibRegister() {
 	err := g.RegisterLib("filelib", g.injectFileLibFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 
@@ -281,7 +282,7 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 			}
 
 			if !fssort.SortModeIsSupported(userSortMode) {
-				log.Println("[AGI] Sort mode: " + userSortMode + " not supported. Using default")
+				agiLogger.PrintAndLog("Agi", "[AGI] Sort mode: "+userSortMode+" not supported. Using default", nil)
 				userSortMode = "default"
 			}
 
@@ -359,7 +360,7 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 		}
 
 		if !fssort.SortModeIsSupported(userSortMode) {
-			log.Println("[AGI] Sort mode: " + userSortMode + " not supported. Using default")
+			agiLogger.PrintAndLog("Agi", "[AGI] Sort mode: "+userSortMode+" not supported. Using default", nil)
 			userSortMode = "default"
 		}
 
@@ -436,7 +437,7 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 		}
 
 		if !fssort.SortModeIsSupported(userSortMode) {
-			log.Println("[AGI] Sort mode: " + userSortMode + " not supported. Using default")
+			agiLogger.PrintAndLog("Agi", "[AGI] Sort mode: "+userSortMode+" not supported. Using default", nil)
 			userSortMode = "default"
 		}
 
@@ -624,14 +625,14 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 		//Translate the path to realpath
 		fsh, rdir, err := static.VirtualPathToRealPath(vdir, u)
 		if err != nil {
-			log.Println(err.Error())
+			agiLogger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 
 		//Create the directory at rdir location
 		err = fsh.FileSystemAbstraction.MkdirAll(rdir, 0755)
 		if err != nil {
-			log.Println(err.Error())
+			agiLogger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 
@@ -731,13 +732,13 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 
 		fsh, rpath, err := static.VirtualPathToRealPath(vpath, u)
 		if err != nil {
-			log.Println(err.Error())
+			agiLogger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 
 		info, err := fsh.FileSystemAbstraction.Stat(rpath)
 		if err != nil {
-			log.Println(err.Error())
+			agiLogger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 
@@ -779,7 +780,7 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 		//Get the target vpath
 		fsh, rpath, err := static.VirtualPathToRealPath(vpath, u)
 		if err != nil {
-			log.Println(err.Error())
+			agiLogger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 

--- a/src/mod/agi/agi.go
+++ b/src/mod/agi/agi.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -116,12 +115,12 @@ func (g *Gateway) RegisterNightlyOperations() {
 					if static.CheckUserAccessToScript(userinfo, scriptFile, "") {
 						//This user can access the module that provide this script.
 						//Execute this script on his account.
-						log.Println("[AGI_Nightly] WIP (" + scriptFile + ")")
+						agiLogger.PrintAndLog("Agi", "[AGI_Nightly] WIP ("+scriptFile+")", nil)
 					}
 				}
 			} else {
 				//Invalid script. Skipping
-				log.Println("[AGI_Nightly] Invalid script file: " + scriptFile)
+				agiLogger.PrintAndLog("Agi", "[AGI_Nightly] Invalid script file: "+scriptFile, nil)
 			}
 		}
 	})
@@ -132,7 +131,7 @@ func (g *Gateway) InitiateAllWebAppModules() {
 	for _, script := range startupScripts {
 		scriptContentByte, _ := os.ReadFile(script)
 		scriptContent := string(scriptContentByte)
-		log.Println("[AGI] Gateway script loaded (" + script + ")")
+		agiLogger.PrintAndLog("Agi", "[AGI] Gateway script loaded ("+script+")", nil)
 		//Create a new vm for this request
 		vm := otto.New()
 
@@ -143,8 +142,8 @@ func (g *Gateway) InitiateAllWebAppModules() {
 		})
 		_, err := vm.Run(scriptContent)
 		if err != nil {
-			log.Println("[AGI] Load Failed: " + script + ". Skipping.")
-			log.Println(err)
+			agiLogger.PrintAndLog("Agi", "[AGI] Load Failed: "+script+". Skipping.", nil)
+			agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 			continue
 		}
 	}
@@ -159,7 +158,7 @@ func (g *Gateway) RunScript(script string) error {
 
 	_, err := vm.Run(script)
 	if err != nil {
-		log.Println("[AGI] Script Execution Failed: ", err.Error())
+		agiLogger.PrintAndLog("Agi", fmt.Sprint("[AGI] Script Execution Failed: ", err.Error()), nil)
 		return err
 	}
 
@@ -170,7 +169,7 @@ func (g *Gateway) RaiseError(err error) {
 	if err == nil {
 		return
 	}
-	log.Println("[AGI] Runtime Error " + err.Error())
+	agiLogger.PrintAndLog("Agi", "[AGI] Runtime Error "+err.Error(), nil)
 
 	//To be implemented
 }
@@ -323,7 +322,7 @@ func (g *Gateway) ExecuteAGIScript(scriptContent string, fsh *filesystem.FileSys
 		if thisuser != nil {
 			username = thisuser.Username
 		}
-		log.Printf("[AGI] Script error in %s (user: %s): %s", scriptFile, username, err.Error())
+		agiLogger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Script error in %s (user: %s): %s", scriptFile, username, err.Error()), nil)
 
 		if devMode {
 			// Return a detailed JSON error payload for developer inspection
@@ -393,14 +392,14 @@ func (g *Gateway) ExecuteAGIScriptAsUser(fsh *filesystem.FileSystemHandler, scri
 	defer func() {
 		if caught := recover(); caught != nil {
 			if caught == errTimeout {
-				log.Printf("[AGI] Execution timeout: %s (user: %s)", scriptFile, targetUser.Username)
+				agiLogger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Execution timeout: %s (user: %s)", scriptFile, targetUser.Username), nil)
 				return
 			} else if caught == errExitcall {
 				//Exit gracefully
 				return
 			} else {
 				//Something screwed. Return Internal Server Error
-				log.Printf("[AGI] VM crash in %s (user: %s): %v", scriptFile, targetUser.Username, caught)
+				agiLogger.PrintAndLog("Agi", fmt.Sprintf("[AGI] VM crash in %s (user: %s): %v", scriptFile, targetUser.Username, caught), nil)
 				if w != nil {
 					devMode := r != nil && r.URL.Query().Get("agi_devmode") == "true"
 					if devMode {
@@ -446,7 +445,7 @@ func (g *Gateway) ExecuteAGIScriptAsUser(fsh *filesystem.FileSystemHandler, scri
 
 	_, err = vm.Run(scriptContent)
 	if err != nil {
-		log.Printf("[AGI] Script error in %s (user: %s): %s", scriptFile, targetUser.Username, err.Error())
+		agiLogger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Script error in %s (user: %s): %s", scriptFile, targetUser.Username, err.Error()), nil)
 		return execID, "", err
 	}
 

--- a/src/mod/agi/agi.http.go
+++ b/src/mod/agi/agi.http.go
@@ -5,10 +5,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"github.com/robertkrimen/otto"
@@ -27,7 +28,8 @@ import (
 func (g *Gateway) HTTPLibRegister() {
 	err := g.RegisterLib("http", g.injectHTTPFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 
@@ -94,7 +96,7 @@ func (g *Gateway) injectHTTPFunctions(payload *static.AgiLibInjectionPayload) {
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		if err != nil {
-			log.Println(err)
+			agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 			return otto.NullValue()
 		}
 		defer resp.Body.Close()
@@ -249,7 +251,7 @@ func (g *Gateway) injectHTTPFunctions(payload *static.AgiLibInjectionPayload) {
 
 		r, err := otto.ToValue(string(sEnc))
 		if err != nil {
-			log.Println(err.Error())
+			agiLogger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.NullValue()
 		}
 		return r

--- a/src/mod/agi/agi.image.go
+++ b/src/mod/agi/agi.image.go
@@ -12,7 +12,6 @@ import (
 	"image/png"
 	_ "image/png"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +36,8 @@ import (
 func (g *Gateway) ImageLibRegister() {
 	err := g.RegisterLib("imagelib", g.injectImageLibFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 

--- a/src/mod/agi/agi.iot.go
+++ b/src/mod/agi/agi.iot.go
@@ -2,7 +2,8 @@ package agi
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
+	"os"
 
 	"github.com/robertkrimen/otto"
 	"imuslab.com/arozos/mod/agi/static"
@@ -21,7 +22,8 @@ import (
 func (g *Gateway) IoTLibRegister() {
 	err := g.RegisterLib("iot", g.injectIoTFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 
@@ -119,7 +121,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 		//Just leave it to the front end to handle :P
 		devStatus, err := dev.Handler.Status(dev)
 		if err != nil {
-			log.Println("*AGI IoT* " + err.Error())
+			agiLogger.PrintAndLog("Agi", "*AGI IoT* "+err.Error(), nil)
 			return otto.FalseValue()
 		}
 
@@ -151,7 +153,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 		dev := g.Option.IotManager.GetDeviceByID(devID)
 		if dev == nil {
 			//Device not found
-			log.Println("*AGI IoT* Given device ID do not match any IoT devices")
+			agiLogger.PrintAndLog("Agi", "*AGI IoT* Given device ID do not match any IoT devices", nil)
 			return otto.FalseValue()
 		}
 
@@ -168,7 +170,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 
 		if targetEp == nil {
 			//Endpoint not found
-			log.Println("*AGI IoT* Failed to get endpoint by name in this device")
+			agiLogger.PrintAndLog("Agi", "*AGI IoT* Failed to get endpoint by name in this device", nil)
 			return otto.FalseValue()
 		}
 
@@ -180,7 +182,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 
 			err = json.Unmarshal([]byte(payload), &payloadMap)
 			if err != nil {
-				log.Println("*AGI IoT* Failed to parse input payload: " + err.Error())
+				agiLogger.PrintAndLog("Agi", "*AGI IoT* Failed to parse input payload: "+err.Error(), nil)
 				return otto.FalseValue()
 			}
 
@@ -193,7 +195,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 		}
 
 		if err != nil {
-			log.Println("*AGI IoT* Failed to execute request to device: " + err.Error())
+			agiLogger.PrintAndLog("Agi", "*AGI IoT* Failed to execute request to device: "+err.Error(), nil)
 			return otto.FalseValue()
 		}
 
@@ -289,6 +291,6 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 	`)
 
 	if err != nil {
-		log.Println("*AGI* IoT Functions Injection Error", err.Error())
+		agiLogger.PrintAndLog("Agi", fmt.Sprint("*AGI* IoT Functions Injection Error", err.Error()), nil)
 	}
 }

--- a/src/mod/agi/agi.scheduler.go
+++ b/src/mod/agi/agi.scheduler.go
@@ -1,7 +1,7 @@
 package agi
 
 import (
-	"log"
+	"fmt"
 	"time"
 
 	"github.com/robertkrimen/otto"
@@ -68,7 +68,7 @@ func (g *Gateway) RegisterSchedulerLib(callbacks *SchedulerCallbacks) {
 	})
 	if err != nil {
 		// Library already registered – not fatal, just warn
-		log.Println("[AGI] scheduler lib already registered:", err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint("[AGI] scheduler lib already registered:", err), nil)
 	}
 }
 

--- a/src/mod/agi/agi.share.go
+++ b/src/mod/agi/agi.share.go
@@ -1,7 +1,8 @@
 package agi
 
 import (
-	"log"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/robertkrimen/otto"
@@ -11,7 +12,8 @@ import (
 func (g *Gateway) ShareLibRegister() {
 	err := g.RegisterLib("share", g.injectShareFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 
@@ -40,7 +42,7 @@ func (g *Gateway) injectShareFunctions(payload *static.AgiLibInjectionPayload) {
 		vpathSourceFsh := u.GetRootFSHFromVpathInUserScope(vpath)
 		shareID, err := g.Option.ShareManager.CreateNewShare(u, vpathSourceFsh, vpath)
 		if err != nil {
-			log.Println("[AGI] Create Share Failed: " + err.Error())
+			agiLogger.PrintAndLog("Agi", "[AGI] Create Share Failed: "+err.Error(), nil)
 			return otto.New().MakeCustomError("Share failed", err.Error())
 		}
 
@@ -48,7 +50,7 @@ func (g *Gateway) injectShareFunctions(payload *static.AgiLibInjectionPayload) {
 			go func(timeout int) {
 				time.Sleep(time.Duration(timeout) * time.Second)
 				g.Option.ShareManager.RemoveShareByUUID(u, shareID.UUID)
-				log.Println("[AGI] Share auto-removed: " + shareID.UUID)
+				agiLogger.PrintAndLog("Agi", "[AGI] Share auto-removed: "+shareID.UUID, nil)
 			}(int(timeout))
 		}
 
@@ -63,7 +65,7 @@ func (g *Gateway) injectShareFunctions(payload *static.AgiLibInjectionPayload) {
 		}
 		err = g.Option.ShareManager.RemoveShareByUUID(u, shareUUID)
 		if err != nil {
-			log.Println("[AGI] Share remove failed: " + err.Error())
+			agiLogger.PrintAndLog("Agi", "[AGI] Share remove failed: "+err.Error(), nil)
 			return otto.New().MakeCustomError("Failed to remove share", err.Error())
 		}
 
@@ -73,13 +75,13 @@ func (g *Gateway) injectShareFunctions(payload *static.AgiLibInjectionPayload) {
 	vm.Set("_share_getShareUUID", func(call otto.FunctionCall) otto.Value {
 		vpath, err := call.Argument(0).ToString()
 		if err != nil {
-			log.Println("[AGI] Failed to get share UUID: filepath not given")
+			agiLogger.PrintAndLog("Agi", "[AGI] Failed to get share UUID: filepath not given", nil)
 			return otto.NullValue()
 		}
 
 		shareObject := g.Option.ShareManager.GetShareObjectFromUserAndVpath(u, vpath)
 		if shareObject == nil {
-			log.Println("[AGI] Failed to get share UUID: File not shared")
+			agiLogger.PrintAndLog("Agi", "[AGI] Failed to get share UUID: File not shared", nil)
 			return otto.NullValue()
 		}
 

--- a/src/mod/agi/agi.sysinfo.go
+++ b/src/mod/agi/agi.sysinfo.go
@@ -2,7 +2,8 @@ package agi
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -40,7 +41,8 @@ var (
 func (g *Gateway) SysinfoLibRegister() {
 	err := g.RegisterLib("sysinfo", g.injectSysinfoLibFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 

--- a/src/mod/agi/agi.system.go
+++ b/src/mod/agi/agi.system.go
@@ -3,7 +3,7 @@ package agi
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -337,7 +337,7 @@ func (g *Gateway) injectStandardLibs(vm *otto.Otto, scriptFile string, scriptSco
 			_, err = vm.Run(string(scriptContent))
 			if err != nil {
 				//Script execution failed
-				log.Println("Script Execution Failed: ", err.Error())
+				agiLogger.PrintAndLog("Agi", fmt.Sprint("Script Execution Failed: ", err.Error()), nil)
 				g.RaiseError(err)
 				return otto.FalseValue()
 			}

--- a/src/mod/agi/agi.user.go
+++ b/src/mod/agi/agi.user.go
@@ -3,7 +3,7 @@ package agi
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -29,17 +29,17 @@ func (g *Gateway) injectUserFunctions(vm *otto.Otto, fsh *filesystem.FileSystemH
 
 	//File system and path related
 	vm.Set("decodeVirtualPath", func(call otto.FunctionCall) otto.Value {
-		log.Println("Call to deprecated function decodeVirtualPath")
+		agiLogger.PrintAndLog("Agi", "Call to deprecated function decodeVirtualPath", nil)
 		return otto.FalseValue()
 	})
 
 	vm.Set("decodeAbsoluteVirtualPath", func(call otto.FunctionCall) otto.Value {
-		log.Println("Call to deprecated function decodeAbsoluteVirtualPath")
+		agiLogger.PrintAndLog("Agi", "Call to deprecated function decodeAbsoluteVirtualPath", nil)
 		return otto.FalseValue()
 	})
 
 	vm.Set("encodeRealPath", func(call otto.FunctionCall) otto.Value {
-		log.Println("Call to deprecated function encodeRealPath")
+		agiLogger.PrintAndLog("Agi", "Call to deprecated function encodeRealPath", nil)
 		return otto.FalseValue()
 	})
 
@@ -229,7 +229,7 @@ func (g *Gateway) injectUserFunctions(vm *otto.Otto, fsh *filesystem.FileSystemH
 				return otto.TrueValue()
 			} else {
 				//Lib not exists
-				log.Println("Lib not found: " + libname)
+				agiLogger.PrintAndLog("Agi", "Lib not found: "+libname, nil)
 				return otto.FalseValue()
 			}
 		}
@@ -275,7 +275,7 @@ func (g *Gateway) injectUserFunctions(vm *otto.Otto, fsh *filesystem.FileSystemH
 			_, err = vm.Run(string(scriptContent))
 			if err != nil {
 				//Script execution failed
-				log.Println("Script Execution Failed: ", err.Error())
+				agiLogger.PrintAndLog("Agi", fmt.Sprint("Script Execution Failed: ", err.Error()), nil)
 				g.RaiseError(err)
 			}
 		}()

--- a/src/mod/agi/agi.websocket.go
+++ b/src/mod/agi/agi.websocket.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -15,12 +16,37 @@ import (
 /*
 AJGI WebSocket Request Library
 
-This is a library for allowing AGI based connection upgrade to WebSocket
-Different from other agi module, this do not use the register lib interface
-deal to it special nature.
+This is a library for allowing AGI based connection upgrade to WebSocket.
+Different from other agi modules, this does not use the register lib interface
+due to its special nature.
+
+New functions exposed to AGI scripts:
+
+  websocket.upgrade(timeoutSec)
+    Upgrades the connection and overrides delay() with a message-pumping version
+    so that websocket.onMessage fires naturally during pauses.
+
+  websocket.send(text)         → bool
+  websocket.read(timeoutMs?)   → string | null | false
+    timeoutMs = 0 / omitted → block until message arrives or connection closes
+    timeoutMs > 0           → return null on timeout (connection still open)
+    returns false           → connection is closed
+
+  websocket.available()        → int
+    Number of messages currently waiting in the inbound buffer. Non-blocking.
+
+  websocket.isClosed()         → bool
+    true when the connection is no longer active.
+
+  websocket.onMessage          → assign function(msg) to receive messages
+    msg = { data: string, timestamp: int64 ms, type: int }
+    Fired inside delay() on the script's own goroutine — Otto-safe.
+
+  websocket.close()
 
 Author: tobychui
 */
+
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
@@ -28,207 +54,349 @@ var upgrader = websocket.Upgrader{
 		return true
 	},
 }
+
+// wsMsg is a single inbound WebSocket frame delivered to the AGI script.
+type wsMsg struct {
+	Data      string // text payload
+	Timestamp int64  // arrival time as unix milliseconds
+	Type      int    // gorilla message type (1 = text, 2 = binary)
+}
+
+// wsConn wraps a gorilla websocket.Conn with a buffered inbound message channel.
+// All fields shared across goroutines are accessed via atomics or the channel itself.
+// The Otto VM is NEVER touched from any goroutine other than the main script goroutine.
+type wsConn struct {
+	conn        *websocket.Conn
+	msgChan     chan wsMsg // filled by the background reader goroutine
+	closed      int32     // 1 when closed; use atomic load/store
+	lastOprTime int64     // unix seconds of last activity; use atomic load/store
+}
+
+func newWsConn(c *websocket.Conn) *wsConn {
+	wsc := &wsConn{
+		conn:    c,
+		msgChan: make(chan wsMsg, 128),
+	}
+	atomic.StoreInt64(&wsc.lastOprTime, time.Now().Unix())
+	return wsc
+}
+
+func (w *wsConn) isClosed() bool    { return atomic.LoadInt32(&w.closed) == 1 }
+func (w *wsConn) markClosed()       { atomic.StoreInt32(&w.closed, 1) }
+func (w *wsConn) touchLastOpr()     { atomic.StoreInt64(&w.lastOprTime, time.Now().Unix()) }
+func (w *wsConn) getLastOpr() int64 { return atomic.LoadInt64(&w.lastOprTime) }
+
 var connections = sync.Map{}
 
-// This is a very special function to check if the connection has been updated or not
-// Return upgrade status (true for already upgraded) and connection uuid
-func checkWebSocketConnectionUpgradeStatus(vm *otto.Otto) (bool, string, *websocket.Conn) {
-	if value, err := vm.Get("_websocket_conn_id"); err == nil {
-		//Exists!
-		//Check if this is undefined
-		if value == otto.UndefinedValue() {
-			//WebSocket connection has closed
-			return false, "", nil
-		}
-
-		//Connection is still live. Try convert it to string
-		connId, err := value.ToString()
-		if err != nil {
-			return false, "", nil
-		}
-
-		//Load the conenction from SyncMap
-		if c, ok := connections.Load(connId); ok {
-			//Return the conncetion object
-			return true, connId, c.(*websocket.Conn)
-		}
-
-		//Connection object not found (Maybe already closed?)
+// checkWebSocketConnectionUpgradeStatus returns whether the current VM has an
+// active WebSocket connection.  Returns (active, connID, *wsConn).
+func checkWebSocketConnectionUpgradeStatus(vm *otto.Otto) (bool, string, *wsConn) {
+	value, err := vm.Get("_websocket_conn_id")
+	if err != nil || value.IsUndefined() || value.IsNull() {
 		return false, "", nil
-
 	}
-	return false, "", nil
+	connId, err := value.ToString()
+	if err != nil || connId == "" {
+		return false, "", nil
+	}
+	raw, ok := connections.Load(connId)
+	if !ok {
+		return false, "", nil
+	}
+	wsc := raw.(*wsConn)
+	if wsc.isClosed() {
+		return false, connId, nil
+	}
+	return true, connId, wsc
+}
+
+// cleanupWsConn sends a close frame, closes the raw connection, and removes the
+// connection from both the sync.Map and the VM.
+// MUST be called from the main (script) goroutine so vm.Set is safe.
+func cleanupWsConn(vm *otto.Otto, connID string, wsc *wsConn) {
+	if !wsc.isClosed() {
+		wsc.markClosed()
+		wsc.conn.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+		)
+		time.Sleep(150 * time.Millisecond)
+		wsc.conn.Close()
+	}
+	vm.Set("_websocket_conn_id", otto.UndefinedValue())
+	connections.Delete(connID)
+}
+
+// dispatchOnMessage calls websocket.onMessage(msg) on the script goroutine.
+// Passing data through vm.Set avoids the complexities of otto.Value.Call.
+// MUST be called from the main (script) goroutine.
+func dispatchOnMessage(vm *otto.Otto, msg wsMsg) {
+	vm.Set("_ws_incoming", map[string]interface{}{
+		"data":      msg.Data,
+		"timestamp": msg.Timestamp,
+		"type":      msg.Type,
+	})
+	if _, err := vm.Run(`
+		if (typeof websocket !== 'undefined' && typeof websocket.onMessage === 'function') {
+			websocket.onMessage(_ws_incoming);
+		}
+	`); err != nil {
+		agiLogger.PrintAndLog("Agi", fmt.Sprint("*AGI WebSocket* onMessage handler error:", err), nil)
+	}
+	vm.Set("_ws_incoming", otto.UndefinedValue())
 }
 
 func (g *Gateway) injectWebSocketFunctions(vm *otto.Otto, u *user.User, w http.ResponseWriter, r *http.Request) {
 
+	// ── websocket.upgrade(timeoutSeconds) ────────────────────────────────────
 	vm.Set("_websocket_upgrade", func(call otto.FunctionCall) otto.Value {
-		//Check if the user specified any timeout time in seconds
-		//Default to 5 minutes
 		timeout, err := call.Argument(0).ToInteger()
-		if err != nil {
+		if err != nil || timeout <= 0 {
 			timeout = 300
 		}
 
-		//Check if the connection has already been updated
-		connState, _, _ := checkWebSocketConnectionUpgradeStatus(vm)
-		if connState {
-			//Already upgraded
-			return otto.TrueValue()
+		if connState, _, _ := checkWebSocketConnectionUpgradeStatus(vm); connState {
+			return otto.TrueValue() // already upgraded
 		}
 
-		//Not upgraded. Upgrade it now
 		c, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", fmt.Sprint("*AGI WebSocket*  WebSocket upgrade failed:", err), nil)
+			agiLogger.PrintAndLog("Agi", fmt.Sprint("*AGI WebSocket* upgrade failed:", err), nil)
 			return otto.FalseValue()
 		}
 
-		//Generate a UUID for this connection
+		wsc := newWsConn(c)
 		connUUID := uuid.NewV4().String()
+		connections.Store(connUUID, wsc)
 		vm.Set("_websocket_conn_id", connUUID)
-		connections.Store(connUUID, c)
 
-		//Record its creation time as opr time
-		vm.Set("_websocket_conn_lastopr", time.Now().Unix())
-
-		//Create a go routine to monitor the connection status and disconnect it if timeup
-		if timeout > 0 {
-			go func() {
-				time.Sleep(1 * time.Second)
-				//Check if the last edit time > timeout time
-				connStatus, connID, conn := checkWebSocketConnectionUpgradeStatus(vm)
-				for connStatus {
-					//For this connection exists
-					if value, err := vm.Get("_websocket_conn_lastopr"); err == nil {
-						lastOprTime, err := value.ToInteger()
-						if err != nil {
-							continue
-						}
-						//log.Println(time.Now().Unix(), lastOprTime)
-						if time.Now().Unix()-lastOprTime > timeout {
-							//Timeout! Kill this socket
-							conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "Timeout"))
-							time.Sleep(300)
-							conn.Close()
-
-							//Clean up the connection in sync map and vm
-							vm.Set("_websocket_conn_id", otto.UndefinedValue())
-							connections.Delete(connID)
-
-							agiLogger.PrintAndLog("Agi", "*AGI WebSocket* Closing connection due to timeout", nil)
-							break
-						}
-					}
-					time.Sleep(1 * time.Second)
-					connStatus, _, _ = checkWebSocketConnectionUpgradeStatus(vm)
-				}
-
+		// Background reader — feeds all inbound frames into msgChan.
+		// Never touches the Otto VM; only updates wsc atomics and the channel.
+		go func() {
+			defer func() {
+				wsc.markClosed()
+				close(wsc.msgChan)
+				// Do NOT call vm.Set here — Otto is not goroutine-safe.
 			}()
-		}
+			for {
+				msgType, message, err := c.ReadMessage()
+				if err != nil {
+					return // connection closed or error
+				}
+				wsc.touchLastOpr()
+				select {
+				case wsc.msgChan <- wsMsg{
+					Data:      string(message),
+					Timestamp: time.Now().UnixMilli(),
+					Type:      msgType,
+				}:
+				default:
+					agiLogger.PrintAndLog("Agi", "*AGI WebSocket* inbound buffer full, dropping frame", nil)
+				}
+			}
+		}()
+
+		// Idle-timeout watcher — closes the raw connection when no activity.
+		// Does NOT touch the VM; closing the connection causes the reader to exit.
+		go func() {
+			ticker := time.NewTicker(1 * time.Second)
+			defer ticker.Stop()
+			for range ticker.C {
+				if wsc.isClosed() {
+					return
+				}
+				if time.Now().Unix()-wsc.getLastOpr() > timeout {
+					agiLogger.PrintAndLog("Agi", "*AGI WebSocket* idle timeout — closing connection", nil)
+					c.Close()
+					return
+				}
+			}
+		}()
+
+		// Override delay() so that websocket.onMessage callbacks fire naturally
+		// inside pauses without the user needing an explicit poll() call.
+		vm.Run(`
+			var _ws_orig_delay = (typeof delay === 'function') ? delay : function(ms){};
+			delay = function(ms){ _websocket_pump_messages(ms); };
+		`)
 
 		return otto.TrueValue()
 	})
 
+	// ── websocket.send(text) ─────────────────────────────────────────────────
 	vm.Set("_websocket_send", func(call otto.FunctionCall) otto.Value {
-		//Get the content to send
 		content, err := call.Argument(0).ToString()
 		if err != nil {
 			g.RaiseError(err)
 			return otto.FalseValue()
 		}
-
-		//Send it
-		connState, connID, conn := checkWebSocketConnectionUpgradeStatus(vm)
+		connState, connID, wsc := checkWebSocketConnectionUpgradeStatus(vm)
 		if !connState {
-			//Already upgraded
-			//log.Println("*AGI WebSocket* Connection id not found in VM")
 			return otto.FalseValue()
 		}
-
-		err = conn.WriteMessage(1, []byte(content))
-		if err != nil {
-
-			//Client connection could have been closed. Close the connection
-			conn.Close()
-
-			//Clean up the connection in sync map and vm
-			vm.Set("_websocket_conn_id", otto.UndefinedValue())
-			connections.Delete(connID)
+		if err := wsc.conn.WriteMessage(websocket.TextMessage, []byte(content)); err != nil {
+			cleanupWsConn(vm, connID, wsc)
 			return otto.FalseValue()
 		}
-
-		//Write succeed
-
-		//Update last opr time
-		vm.Set("_websocket_conn_lastopr", time.Now().Unix())
-
+		wsc.touchLastOpr()
 		return otto.TrueValue()
 	})
 
+	// ── websocket.read(timeout ms) ───────────────────────────────────────────
+	// timeoutMs = 0 or omitted → block until a message arrives or socket closes
+	// timeoutMs > 0            → return null if no message within that many ms
+	// Returns: string on message · null on timeout · false if connection closed
 	vm.Set("_websocket_read", func(call otto.FunctionCall) otto.Value {
-		connState, connID, conn := checkWebSocketConnectionUpgradeStatus(vm)
-		if connState == true {
-			_, message, err := conn.ReadMessage()
-			if err != nil {
-				//Client connection could have been closed. Close the connection
-				conn.Close()
+		timeoutMs, _ := call.Argument(0).ToInteger()
 
-				//Clean up the connection in sync map and vm
+		connState, connID, wsc := checkWebSocketConnectionUpgradeStatus(vm)
+		if !connState {
+			if connID != "" {
+				// Stale entry — tidy up from the main goroutine
 				vm.Set("_websocket_conn_id", otto.UndefinedValue())
 				connections.Delete(connID)
-
-				agiLogger.PrintAndLog("Agi", "*AGI WebSocket* Trying to read from a closed socket", nil)
-				return otto.FalseValue()
 			}
-			//Update last opr time
-			vm.Set("_websocket_conn_lastopr", time.Now().Unix())
-
-			//Parse the incoming message
-			incomingString, err := otto.ToValue(string(message))
-			if err != nil {
-				agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
-				//Unable to parse to JavaScript. Something out of the scope of otto?
-				return otto.NullValue()
-			}
-
-			//Return the incoming string to the AGI script
-			return incomingString
-		} else {
-			//WebSocket not exists
-			//log.Println("*AGI WebSocket* Trying to read from a closed socket")
 			return otto.FalseValue()
 		}
+
+		var msg wsMsg
+		var ok bool
+
+		if timeoutMs > 0 {
+			select {
+			case msg, ok = <-wsc.msgChan:
+			case <-time.After(time.Duration(timeoutMs) * time.Millisecond):
+				return otto.NullValue() // timed out; connection still open
+			}
+		} else {
+			msg, ok = <-wsc.msgChan // block until message or channel close
+		}
+
+		if !ok {
+			// Channel closed — background reader exited (connection gone)
+			cleanupWsConn(vm, connID, wsc)
+			return otto.FalseValue()
+		}
+
+		wsc.touchLastOpr()
+		v, err := otto.ToValue(msg.Data)
+		if err != nil {
+			return otto.NullValue()
+		}
+		return v
 	})
 
+	// ── websocket.available() ────────────────────────────────────────────────
+	// Returns the number of messages currently waiting in the inbound buffer.
+	// Non-blocking — safe to poll in a tight loop.
+	vm.Set("_websocket_available", func(call otto.FunctionCall) otto.Value {
+		_, _, wsc := checkWebSocketConnectionUpgradeStatus(vm)
+		count := 0
+		if wsc != nil {
+			count = len(wsc.msgChan)
+		}
+		v, _ := otto.ToValue(count)
+		return v
+	})
+
+	// ── websocket.isClosed() ─────────────────────────────────────────────────
+	// Returns true when the WebSocket connection is no longer active.
+	vm.Set("_websocket_is_closed", func(call otto.FunctionCall) otto.Value {
+		connState, _, _ := checkWebSocketConnectionUpgradeStatus(vm)
+		if connState {
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
+	// ── _websocket_pump_messages(ms) ─────────────────────────────────────────
+	// Replaces delay() after upgrade.  Sleeps for ms milliseconds while
+	// dispatching any queued messages to websocket.onMessage.
+	// All JS execution happens on this (main script) goroutine — Otto-safe.
+	//
+	// Important: messages are only consumed from the buffer when onMessage is
+	// actually a function.  When it is null/undefined the function falls back to
+	// a plain sleep so that websocket.available() / websocket.read() can still
+	// see the queued frames afterwards (Mode 2 / manual-read patterns).
+	vm.Set("_websocket_pump_messages", func(call otto.FunctionCall) otto.Value {
+		ms, err := call.Argument(0).ToInteger()
+		if err != nil || ms < 0 {
+			ms = 0
+		}
+
+		_, _, wsc := checkWebSocketConnectionUpgradeStatus(vm)
+		if wsc == nil {
+			// No active WebSocket — fall back to plain sleep
+			if ms > 0 {
+				time.Sleep(time.Duration(ms) * time.Millisecond)
+			}
+			return otto.UndefinedValue()
+		}
+
+		// Check once whether a handler is registered.  We evaluate in JS so
+		// that the typeof check is unambiguous regardless of Otto internals.
+		hasHandlerVal, _ := vm.Run(`typeof websocket !== 'undefined' && typeof websocket.onMessage === 'function'`)
+		hasHandler, _ := hasHandlerVal.ToBoolean()
+		if !hasHandler {
+			// No handler — plain sleep; leave messages in the buffer untouched.
+			if ms > 0 {
+				time.Sleep(time.Duration(ms) * time.Millisecond)
+			}
+			return otto.UndefinedValue()
+		}
+
+		const tickSize = 20 * time.Millisecond
+		deadline := time.Now().Add(time.Duration(ms) * time.Millisecond)
+
+		for {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				break
+			}
+			tick := tickSize
+			if remaining < tick {
+				tick = remaining
+			}
+
+			select {
+			case msg, ok := <-wsc.msgChan:
+				if !ok {
+					// Connection closed while waiting — stop pumping
+					return otto.UndefinedValue()
+				}
+				wsc.touchLastOpr()
+				dispatchOnMessage(vm, msg)
+
+			case <-time.After(tick):
+				// No message in this 20 ms slice — keep waiting
+			}
+		}
+		return otto.UndefinedValue()
+	})
+
+	// ── websocket.close() ────────────────────────────────────────────────────
 	vm.Set("_websocket_close", func(call otto.FunctionCall) otto.Value {
-		connState, connID, conn := checkWebSocketConnectionUpgradeStatus(vm)
-		if connState == true {
-			//Close the Websocket gracefully
-			conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-			time.Sleep(300)
-			conn.Close()
-
-			//Clean up the connection in sync map and vm
-			vm.Set("_websocket_conn_id", otto.UndefinedValue())
-			connections.Delete(connID)
-
-			//Return true value
-			return otto.TrueValue()
-		} else {
-			//Connection not opened or closed already
+		connState, connID, wsc := checkWebSocketConnectionUpgradeStatus(vm)
+		if !connState {
 			return otto.FalseValue()
 		}
-
+		cleanupWsConn(vm, connID, wsc)
+		return otto.TrueValue()
 	})
 
-	//Wrap all the native code function into an imagelib class
+	// ── JS wrapper ───────────────────────────────────────────────────────────
 	vm.Run(`
 		var websocket = {};
-		websocket.upgrade = _websocket_upgrade;
-		websocket.send = _websocket_send;
-		websocket.read = _websocket_read;
-		websocket.close = _websocket_close;
-		
+		websocket.upgrade   = _websocket_upgrade;
+		websocket.send      = _websocket_send;
+		websocket.read      = _websocket_read;
+		websocket.close     = _websocket_close;
+		websocket.available = _websocket_available;
+		websocket.isClosed  = _websocket_is_closed;
+
+		// Assign a function(msg) here to receive messages asynchronously.
+		// msg = { data: string, timestamp: number, type: number }
+		// The handler fires inside delay() after websocket.upgrade() is called.
+		websocket.onMessage = null;
 	`)
 }

--- a/src/mod/agi/agi.websocket.go
+++ b/src/mod/agi/agi.websocket.go
@@ -1,7 +1,7 @@
 package agi
 
 import (
-	"log"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -80,7 +80,7 @@ func (g *Gateway) injectWebSocketFunctions(vm *otto.Otto, u *user.User, w http.R
 		//Not upgraded. Upgrade it now
 		c, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
-			log.Print("*AGI WebSocket*  WebSocket upgrade failed:", err)
+			agiLogger.PrintAndLog("Agi", fmt.Sprint("*AGI WebSocket*  WebSocket upgrade failed:", err), nil)
 			return otto.FalseValue()
 		}
 
@@ -116,7 +116,7 @@ func (g *Gateway) injectWebSocketFunctions(vm *otto.Otto, u *user.User, w http.R
 							vm.Set("_websocket_conn_id", otto.UndefinedValue())
 							connections.Delete(connID)
 
-							log.Println("*AGI WebSocket* Closing connection due to timeout")
+							agiLogger.PrintAndLog("Agi", "*AGI WebSocket* Closing connection due to timeout", nil)
 							break
 						}
 					}
@@ -178,7 +178,7 @@ func (g *Gateway) injectWebSocketFunctions(vm *otto.Otto, u *user.User, w http.R
 				vm.Set("_websocket_conn_id", otto.UndefinedValue())
 				connections.Delete(connID)
 
-				log.Println("*AGI WebSocket* Trying to read from a closed socket")
+				agiLogger.PrintAndLog("Agi", "*AGI WebSocket* Trying to read from a closed socket", nil)
 				return otto.FalseValue()
 			}
 			//Update last opr time
@@ -187,7 +187,7 @@ func (g *Gateway) injectWebSocketFunctions(vm *otto.Otto, u *user.User, w http.R
 			//Parse the incoming message
 			incomingString, err := otto.ToValue(string(message))
 			if err != nil {
-				log.Println(err)
+				agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 				//Unable to parse to JavaScript. Something out of the scope of otto?
 				return otto.NullValue()
 			}

--- a/src/mod/agi/agi.zip.go
+++ b/src/mod/agi/agi.zip.go
@@ -4,7 +4,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +27,8 @@ import (
 func (g *Gateway) ZipLibRegister() {
 	err := g.RegisterLib("ziplib", g.injectZipFileLibFunctions)
 	if err != nil {
-		log.Fatal(err)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 }
 

--- a/src/mod/agi/externalReqHandler.go
+++ b/src/mod/agi/externalReqHandler.go
@@ -2,7 +2,7 @@ package agi
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -212,7 +212,7 @@ func (g *Gateway) ExtAPIHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !fsh.FileSystemAbstraction.FileExists(realPath) {
-		log.Println("[Remote AGI] ", pathFromDb, " cannot be found on "+realPath)
+		agiLogger.PrintAndLog("Agi", fmt.Sprint("[Remote AGI] ", pathFromDb, " cannot be found on "+realPath), nil)
 		http.Error(w, "invalid request: backend script not exists", http.StatusBadRequest)
 		return
 	}
@@ -227,7 +227,7 @@ func (g *Gateway) ExtAPIHandler(w http.ResponseWriter, r *http.Request) {
 	g.recordExecution(endpointUUID, pathFromDb, execID, r.Method, durationMs, execErr)
 
 	if execErr != nil {
-		log.Println("[Remote AGI] ", pathFromDb, " failed to execute", execErr.Error())
+		agiLogger.PrintAndLog("Agi", fmt.Sprint("[Remote AGI] ", pathFromDb, " failed to execute", execErr.Error()), nil)
 		utils.SendErrorResponse(w, execErr.Error())
 		return
 	}

--- a/src/mod/agi/moduleManager.go
+++ b/src/mod/agi/moduleManager.go
@@ -2,7 +2,6 @@ package agi
 
 import (
 	"errors"
-	"log"
 
 	"imuslab.com/arozos/mod/agi/static"
 	apt "imuslab.com/arozos/mod/apt"
@@ -61,7 +60,7 @@ func (g *Gateway) LoadAllFunctionalModules() {
 	if ffmpegExists {
 		g.FFmpegLibRegister()
 	} else {
-		log.Println("[AGI] ffmpeg not installed on host OS. Bypassing module.")
+		agiLogger.PrintAndLog("Agi", "[AGI] ffmpeg not installed on host OS. Bypassing module.", nil)
 	}
 
 }

--- a/src/mod/agi/zz_logger.go
+++ b/src/mod/agi/zz_logger.go
@@ -1,0 +1,5 @@
+package agi
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var agiLogger, _ = logger.NewTmpLogger()

--- a/src/mod/apt/apt.go
+++ b/src/mod/apt/apt.go
@@ -3,7 +3,6 @@ package apt
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -39,7 +38,7 @@ func (a *AptPackageManager) InstallIfNotExists(pkgname string, mustComply bool) 
 
 	installed, err := PackageExists(pkgname)
 	if err != nil {
-		log.Println(err.Error())
+		aptLogger.PrintAndLog("Apt", err.Error(), nil)
 	}
 
 	//log.Println(packageInfo)
@@ -48,7 +47,7 @@ func (a *AptPackageManager) InstallIfNotExists(pkgname string, mustComply bool) 
 	}
 
 	//Package not installed. Install if now if running in sudo mode
-	log.Println("Installing package " + pkgname + "...")
+	aptLogger.PrintAndLog("Apt", "Installing package "+pkgname+"...", nil)
 	cmd := exec.Command("apt-get", "install", "-y", pkgname)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -56,10 +55,10 @@ func (a *AptPackageManager) InstallIfNotExists(pkgname string, mustComply bool) 
 	if err != nil {
 		if mustComply {
 			//Panic and terminate server process
-			log.Println("Installation failed on package: " + pkgname)
+			aptLogger.PrintAndLog("Apt", "Installation failed on package: "+pkgname, nil)
 			os.Exit(1)
 		} else {
-			log.Println("Installation failed on package: " + pkgname)
+			aptLogger.PrintAndLog("Apt", "Installation failed on package: "+pkgname, nil)
 		}
 		return err
 	}

--- a/src/mod/apt/zz_logger.go
+++ b/src/mod/apt/zz_logger.go
@@ -1,0 +1,5 @@
+package apt
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var aptLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/accesscontrol/blacklist/blacklist.go
+++ b/src/mod/auth/accesscontrol/blacklist/blacklist.go
@@ -2,7 +2,6 @@ package blacklist
 
 import (
 	"errors"
-	"log"
 	"strings"
 
 	"imuslab.com/arozos/mod/auth/accesscontrol"
@@ -31,7 +30,7 @@ func NewBlacklistManager(sysdb *db.Database) *BlackList {
 	if sysdb.KeyExists("ipblacklist", "enable") {
 		err := sysdb.Read("ipblacklist", "enable", &blacklistEnabled)
 		if err != nil {
-			log.Println("[Auth/Blacklist] Unable to load previous enable state from database. Using default.")
+			blacklistLogger.PrintAndLog("Blacklist", "[Auth/Blacklist] Unable to load previous enable state from database. Using default.", nil)
 		}
 	}
 
@@ -41,7 +40,7 @@ func NewBlacklistManager(sysdb *db.Database) *BlackList {
 	}
 }
 
-//Check if a given IP is banned
+// Check if a given IP is banned
 func (bl *BlackList) IsBanned(ip string) bool {
 	if bl.Enabled == false {
 		return false
@@ -77,7 +76,7 @@ func (bl *BlackList) ListBannedIpRanges() []string {
 	return results
 }
 
-//Set the ban state of a ip or ip range
+// Set the ban state of a ip or ip range
 func (bl *BlackList) Ban(ipRange string) error {
 	//Check if the IP range is correct
 	err := accesscontrol.ValidateIpRange(ipRange)
@@ -91,7 +90,7 @@ func (bl *BlackList) Ban(ipRange string) error {
 	return bl.database.Write("ipblacklist", ipRange, true)
 }
 
-//Unban an IP or IP range
+// Unban an IP or IP range
 func (bl *BlackList) UnBan(ipRange string) error {
 	//Check if the IP range is correct
 	err := accesscontrol.ValidateIpRange(ipRange)

--- a/src/mod/auth/accesscontrol/blacklist/zz_logger.go
+++ b/src/mod/auth/accesscontrol/blacklist/zz_logger.go
@@ -1,0 +1,5 @@
+package blacklist
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var blacklistLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/accesscontrol/whitelist/whitelist.go
+++ b/src/mod/auth/accesscontrol/whitelist/whitelist.go
@@ -2,7 +2,6 @@ package whitelist
 
 import (
 	"errors"
-	"log"
 	"strings"
 
 	"imuslab.com/arozos/mod/auth/accesscontrol"
@@ -26,7 +25,7 @@ func NewWhitelistManager(sysdb *database.Database) *WhiteList {
 	if sysdb.KeyExists("ipwhitelist", "enable") {
 		err := sysdb.Read("ipwhitelist", "enable", &whitelistEnabled)
 		if err != nil {
-			log.Println("[Auth/Whitelist] Unable to load previous enable state from database. Using default.")
+			whitelistLogger.PrintAndLog("Whitelist", "[Auth/Whitelist] Unable to load previous enable state from database. Using default.", nil)
 		}
 	}
 

--- a/src/mod/auth/accesscontrol/whitelist/zz_logger.go
+++ b/src/mod/auth/accesscontrol/whitelist/zz_logger.go
@@ -1,0 +1,5 @@
+package whitelist
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var whitelistLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/accountSwitch.go
+++ b/src/mod/auth/accountSwitch.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"time"
 
@@ -76,7 +75,7 @@ func NewSwitchableAccountPoolManager(sysdb *database.Database, parent *AuthAgent
 func (m *SwitchableAccountPoolManager) RunNightlyCleanup() {
 	pools, err := m.GetAllPools()
 	if err != nil {
-		log.Println("[auth] Unable to load account switching pools. Cleaning skipped: " + err.Error())
+		authLogger.PrintAndLog("Auth", "[auth] Unable to load account switching pools. Cleaning skipped: "+err.Error(), nil)
 		return
 	}
 

--- a/src/mod/auth/auth.go
+++ b/src/mod/auth/auth.go
@@ -28,7 +28,6 @@ import (
 	"sync"
 
 	"encoding/hex"
-	"log"
 	"time"
 
 	"github.com/gorilla/sessions"
@@ -86,7 +85,7 @@ func NewAuthenticationAgent(sessionName string, key []byte, sysdb *db.Database, 
 	store := sessions.NewCookieStore(key)
 	err := sysdb.NewTable("auth")
 	if err != nil {
-		log.Println("Failed to create auth database. Terminating.")
+		authLogger.PrintAndLog("Auth", "Failed to create auth database. Terminating.", nil)
 		panic(err)
 	}
 
@@ -179,7 +178,7 @@ func (a *AuthAgent) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	username, err := utils.PostPara(r, "username")
 	if err != nil {
 		//Username not defined
-		log.Println("[System Auth] Someone trying to login with username: " + username)
+		authLogger.PrintAndLog("Auth", "[System Auth] Someone trying to login with username: "+username, nil)
 		//Write to log
 		a.Logger.LogAuth(r, false)
 		sendErrorResponse(w, "Username not defined or empty.")
@@ -233,12 +232,12 @@ func (a *AuthAgent) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		a.SwitchableAccountManager.MatchPoolCreatorOrResetPoolID(username, w, r)
 
 		//Print the login message to console
-		log.Println(username + " logged in.")
+		authLogger.PrintAndLog("Auth", username+" logged in.", nil)
 		a.Logger.LogAuth(r, true)
 		sendOK(w)
 	} else {
 		//Password incorrect
-		log.Println(username + " login request rejected: " + rejectionReason)
+		authLogger.PrintAndLog("Auth", username+" login request rejected: "+rejectionReason, nil)
 
 		//Add to retry count
 		a.ExpDelayHandler.AddUserRetrycount(username, r)
@@ -333,7 +332,7 @@ func (a *AuthAgent) LoginUserByRequest(w http.ResponseWriter, r *http.Request, u
 func (a *AuthAgent) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	username, _ := a.GetUserName(w, r)
 	if username != "" {
-		log.Println(username + " logged out.")
+		authLogger.PrintAndLog("Auth", username+" logged out.", nil)
 	}
 
 	//Clear user switchable account pools
@@ -432,7 +431,7 @@ func (a *AuthAgent) HandleRegister(w http.ResponseWriter, r *http.Request) {
 
 	//Return to the client with OK
 	sendOK(w)
-	log.Println("[System Auth] New user " + newusername + " added to system.")
+	authLogger.PrintAndLog("Auth", "[System Auth] New user "+newusername+" added to system.", nil)
 	return
 }
 
@@ -479,7 +478,7 @@ func (a *AuthAgent) HandleUnregister(w http.ResponseWriter, r *http.Request) {
 
 	//Return to the client with OK
 	sendOK(w)
-	log.Println("[system_auth] User " + username + " has been removed from the system.")
+	authLogger.PrintAndLog("Auth", "[system_auth] User "+username+" has been removed from the system.", nil)
 	return
 }
 
@@ -516,7 +515,7 @@ func (a *AuthAgent) GetUserCounts() int {
 	}
 
 	if usercount == 0 {
-		log.Println("There are no user in the database.")
+		authLogger.PrintAndLog("Auth", "There are no user in the database.", nil)
 	}
 	return usercount
 }

--- a/src/mod/auth/authlogger/authlogger.go
+++ b/src/mod/auth/authlogger/authlogger.go
@@ -3,7 +3,6 @@ package authlogger
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -36,7 +35,7 @@ type LoginRecord struct {
 	Port           int
 }
 
-//New Logger create a new logger object
+// New Logger create a new logger object
 func NewLogger() (*Logger, error) {
 	os.MkdirAll("./system/auth/", 0775)
 	db, err := database.NewDatabase("./system/auth/authlog.db", false)
@@ -48,7 +47,7 @@ func NewLogger() (*Logger, error) {
 	}, nil
 }
 
-//Log the current authentication to record, Require the request object and login status
+// Log the current authentication to record, Require the request object and login status
 func (l *Logger) LogAuth(r *http.Request, loginStatus bool) error {
 	username, _ := utils.PostPara(r, "username")
 	timestamp := time.Now().Unix()
@@ -65,7 +64,7 @@ func (l *Logger) LogAuth(r *http.Request, loginStatus bool) error {
 	return l.LogAuthByRequestInfo(username, remoteIP, timestamp, loginStatus, "web")
 }
 
-//Log the current authentication to record by custom filled information. Use LogAuth if your module is authenticating via web interface
+// Log the current authentication to record by custom filled information. Use LogAuth if your module is authenticating via web interface
 func (l *Logger) LogAuthByRequestInfo(username string, remoteAddr string, timestamp int64, loginSucceed bool, authType string) error {
 	//Get the current month as the table name, create table if not exists
 	current := time.Now().UTC()
@@ -113,8 +112,8 @@ func (l *Logger) LogAuthByRequestInfo(username string, remoteAddr string, timest
 	entryKey := strconv.Itoa(int(time.Now().UnixNano()))
 	err := l.database.Write(tableName, entryKey, thisRecord)
 	if err != nil {
-		log.Println("*ERROR* Failed to write authentication log. Is the storage fulled?")
-		log.Println(err.Error())
+		authloggerLogger.PrintAndLog("Authlogger", "*ERROR* Failed to write authentication log. Is the storage fulled?", nil)
+		authloggerLogger.PrintAndLog("Authlogger", err.Error(), nil)
 		return err
 	}
 
@@ -122,12 +121,12 @@ func (l *Logger) LogAuthByRequestInfo(username string, remoteAddr string, timest
 
 }
 
-//Close the database when system shutdown
+// Close the database when system shutdown
 func (l *Logger) Close() {
 	l.database.Close()
 }
 
-//List the total number of months recorded in the database
+// List the total number of months recorded in the database
 func (l *Logger) ListSummary() []string {
 	tableNames := []string{}
 	l.database.Tables.Range(func(tableName, _ interface{}) bool {
@@ -159,8 +158,8 @@ func (l *Logger) ListRecords(key string) ([]LoginRecord, error) {
 	}
 }
 
-//Extract the address information from the request object, the first one is the remote address from the last hop,
-//and the 2nd one is the source address filled in by the client (not accurate)
+// Extract the address information from the request object, the first one is the remote address from the last hop,
+// and the 2nd one is the source address filled in by the client (not accurate)
 func getIpAddressFromRequest(r *http.Request) (string, []string) {
 	lastHopAddress := r.RemoteAddr
 	possibleSourceAddress := []string{}

--- a/src/mod/auth/authlogger/handlers.go
+++ b/src/mod/auth/authlogger/handlers.go
@@ -2,7 +2,7 @@ package authlogger
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 	"regexp"
 	"sort"
@@ -23,16 +23,16 @@ func (s summaryDate) Less(i, j int) bool {
 	layout := "Jan-2006"
 	timei, err := time.Parse(layout, s[i])
 	if err != nil {
-		log.Println(err)
+		authloggerLogger.PrintAndLog("Authlogger", fmt.Sprint(err), nil)
 	}
 	timej, err := time.Parse(layout, s[j])
 	if err != nil {
-		log.Println(err)
+		authloggerLogger.PrintAndLog("Authlogger", fmt.Sprint(err), nil)
 	}
 	return timei.Unix() > timej.Unix()
 }
 
-//Handle of listing of the logger index (months)
+// Handle of listing of the logger index (months)
 func (l *Logger) HandleIndexListing(w http.ResponseWriter, r *http.Request) {
 	indexes := l.ListSummary()
 	sort.Sort(summaryDate(indexes))
@@ -45,7 +45,7 @@ func (l *Logger) HandleIndexListing(w http.ResponseWriter, r *http.Request) {
 	utils.SendJSONResponse(w, string(js))
 }
 
-//Handle of the listing of a given index (month)
+// Handle of the listing of a given index (month)
 func (l *Logger) HandleTableListing(w http.ResponseWriter, r *http.Request) {
 	//Get the record name request for listing
 	month, err := utils.PostPara(r, "record")

--- a/src/mod/auth/authlogger/zz_logger.go
+++ b/src/mod/auth/authlogger/zz_logger.go
@@ -1,0 +1,5 @@
+package authlogger
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var authloggerLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/autologin.go
+++ b/src/mod/auth/autologin.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -108,7 +107,7 @@ func (a *AuthAgent) HandleAutologinTokenLogin(w http.ResponseWriter, r *http.Req
 	if a.AllowAutoLogin == false {
 		w.WriteHeader(http.StatusForbidden)
 		w.Write([]byte("403 - Forbidden"))
-		log.Println("Someone is requesting autologin while this function is turned off.")
+		authLogger.PrintAndLog("Auth", "Someone is requesting autologin while this function is turned off.", nil)
 		return
 	}
 
@@ -154,7 +153,7 @@ func (a *AuthAgent) HandleAutologinTokenLogin(w http.ResponseWriter, r *http.Req
 	session.Values["username"] = username
 	session.Values["rememberMe"] = false
 
-	log.Println(username + " logged in via auto-login token")
+	authLogger.PrintAndLog("Auth", username+" logged in via auto-login token", nil)
 
 	//Check if remember me is clicked. If yes, set the maxage to 1 week.
 	session.Options = &sessions.Options{

--- a/src/mod/auth/batch.go
+++ b/src/mod/auth/batch.go
@@ -11,7 +11,7 @@ package auth
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -19,11 +19,11 @@ import (
 )
 
 /*
-	CreateUserAccountsFromCSV
+CreateUserAccountsFromCSV
 
-	This function allow mass import of user accounts for organization purpses.
-	Must be in the format of:{ username, default password, default group } format.
-	Each user occupied one new line
+This function allow mass import of user accounts for organization purpses.
+Must be in the format of:{ username, default password, default group } format.
+Each user occupied one new line
 */
 func (a *AuthAgent) HandleCreateUserAccountsFromCSV(w http.ResponseWriter, r *http.Request) {
 	csvContent, err := utils.PostPara(r, "csv")
@@ -62,12 +62,12 @@ func (a *AuthAgent) HandleCreateUserAccountsFromCSV(w http.ResponseWriter, r *ht
 }
 
 /*
-	HandleUserDeleteByGroup handles user batch delete request by group name
-	Set exact = true will only delete users which the user is
-	1. inside the given group and
-	2. that group is his / her only group
+HandleUserDeleteByGroup handles user batch delete request by group name
+Set exact = true will only delete users which the user is
+1. inside the given group and
+2. that group is his / her only group
 
-	Require paramter: group, exact
+Require paramter: group, exact
 */
 func (a *AuthAgent) HandleUserDeleteByGroup(w http.ResponseWriter, r *http.Request) {
 	group, err := utils.PostPara(r, "group")
@@ -113,8 +113,8 @@ func (a *AuthAgent) HandleUserDeleteByGroup(w http.ResponseWriter, r *http.Reque
 }
 
 /*
-	Export all the users into a csv file. Should only be usable via command line as a form of db backup.
-	DO NOT EXPOSE THIS TO HTTP SERVER
+Export all the users into a csv file. Should only be usable via command line as a form of db backup.
+DO NOT EXPOSE THIS TO HTTP SERVER
 */
 func (a *AuthAgent) ExportUserListAsCSV() string {
 	entries, _ := a.Database.ListTable("auth")
@@ -131,7 +131,7 @@ func (a *AuthAgent) ExportUserListAsCSV() string {
 			//Get usergroup
 			usergroup := []string{}
 			a.Database.Read("auth", "group/"+username, &usergroup)
-			log.Println(usergroup)
+			authLogger.PrintAndLog("Auth", fmt.Sprint(usergroup), nil)
 			//Get user password hash
 			passhash := string(keypairs[1])
 

--- a/src/mod/auth/ldap/ldap.go
+++ b/src/mod/auth/ldap/ldap.go
@@ -1,7 +1,7 @@
 package ldap
 
 import (
-	"log"
+	"fmt"
 	"regexp"
 
 	"github.com/go-ldap/ldap"
@@ -41,7 +41,7 @@ type UserAccount struct {
 	EquivGroup []string `json:"equiv_group"`
 }
 
-//syncorizeUserReturnInterface not designed to be used outside
+// syncorizeUserReturnInterface not designed to be used outside
 type syncorizeUserReturnInterface struct {
 	Userinfo    []UserAccount `json:"userinfo"`
 	TotalLength int           `json:"total_length"`
@@ -49,13 +49,13 @@ type syncorizeUserReturnInterface struct {
 	Error       string        `json:"error"`
 }
 
-//NewLdapHandler xxx
+// NewLdapHandler xxx
 func NewLdapHandler(authAgent *auth.AuthAgent, register *reg.RegisterHandler, coreDb *db.Database, permissionHandler *permission.PermissionHandler, userHandler *user.UserHandler, nightlyManager *nightly.TaskManager, iconSystem string) *ldapHandler {
 	//ldap handler init
-	log.Println("Starting LDAP client...")
+	ldapLogger.PrintAndLog("Ldap", "Starting LDAP client...", nil)
 	err := coreDb.NewTable("ldap")
 	if err != nil {
-		log.Println("Failed to create LDAP database. Terminating.")
+		ldapLogger.PrintAndLog("Ldap", "Failed to create LDAP database. Terminating.", nil)
 		panic(err)
 	}
 
@@ -82,7 +82,7 @@ func NewLdapHandler(authAgent *auth.AuthAgent, register *reg.RegisterHandler, co
 	return &LDAPHandler
 }
 
-//@para limit: -1 means unlimited
+// @para limit: -1 means unlimited
 func (ldap *ldapHandler) getAllUser(limit int) ([]UserAccount, int, error) {
 	//read the user account from ldap, if limit is -1 then it will read all USERS
 	var accounts []UserAccount
@@ -143,7 +143,7 @@ func (ldap *ldapHandler) NightlySync() {
 	if checkLDAPenabled == "true" {
 		err := ldap.SynchronizeUserFromLDAP()
 		if err != nil {
-			log.Println(err)
+			ldapLogger.PrintAndLog("Ldap", fmt.Sprint(err), nil)
 		}
 	}
 }

--- a/src/mod/auth/ldap/web_login.go
+++ b/src/mod/auth/ldap/web_login.go
@@ -2,8 +2,9 @@ package ldap
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 
 	"imuslab.com/arozos/mod/utils"
@@ -74,7 +75,8 @@ func (ldap *ldapHandler) HandleNewPasswordPage(w http.ResponseWriter, r *http.Re
 		"key":          key,
 	})
 	if err != nil {
-		log.Fatal(err)
+		ldapLogger.PrintAndLog("Ldap", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	w.Write([]byte(template))
@@ -90,7 +92,7 @@ func (ldap *ldapHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	username, err := utils.PostPara(r, "username")
 	if err != nil {
 		//Username not defined
-		log.Println("[System Auth] Someone trying to login with username: " + username)
+		ldapLogger.PrintAndLog("Ldap", "[System Auth] Someone trying to login with username: "+username, nil)
 		//Write to log
 		ldap.ag.Logger.LogAuth(r, false)
 		utils.SendErrorResponse(w, "Username not defined or empty.")
@@ -118,7 +120,7 @@ func (ldap *ldapHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		ldap.ag.Logger.LogAuth(r, false)
 		utils.SendErrorResponse(w, "Unable to connect to LDAP server")
-		log.Println("LDAP Authentication error, " + err.Error())
+		ldapLogger.PrintAndLog("Ldap", "LDAP Authentication error, "+err.Error(), nil)
 		return
 	}
 	//The database contain this user information. Check its password if it is correct
@@ -132,13 +134,13 @@ func (ldap *ldapHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 			// Set user as authenticated
 			ldap.ag.LoginUserByRequest(w, r, username, rememberme)
 			//Print the login message to console
-			log.Println(username + " logged in.")
+			ldapLogger.PrintAndLog("Ldap", username+" logged in.", nil)
 			ldap.ag.Logger.LogAuth(r, true)
 			utils.SendOK(w)
 		}
 	} else {
 		//Password incorrect
-		log.Println(username + " has entered an invalid username or password")
+		ldapLogger.PrintAndLog("Ldap", username+" has entered an invalid username or password", nil)
 		utils.SendErrorResponse(w, "Invalid username or password")
 		ldap.ag.Logger.LogAuth(r, false)
 		return
@@ -196,7 +198,7 @@ func (ldap *ldapHandler) HandleSetPassword(w http.ResponseWriter, r *http.Reques
 		}
 	} else {
 		utils.SendErrorResponse(w, "Improper key detected")
-		log.Println(r.RemoteAddr + " attempted to use invaild key to create new user but failed")
+		ldapLogger.PrintAndLog("Ldap", r.RemoteAddr+" attempted to use invaild key to create new user but failed", nil)
 		return
 	}
 }

--- a/src/mod/auth/ldap/zz_logger.go
+++ b/src/mod/auth/ldap/zz_logger.go
@@ -1,0 +1,5 @@
+package ldap
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var ldapLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/oauth2/oauth2.go
+++ b/src/mod/auth/oauth2/oauth2.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -63,7 +62,7 @@ type Config struct {
 // NewOauthHandler creates and initialises the OAuth2 handler.
 func NewOauthHandler(authAgent *auth.AuthAgent, register *reg.RegisterHandler, coreDb *db.Database) *OauthHandler {
 	if err := coreDb.NewTable("oauth"); err != nil {
-		log.Println("Failed to create oauth database. Terminating.")
+		oauth2Logger.PrintAndLog("Oauth2", "Failed to create oauth database. Terminating.", nil)
 		panic(err)
 	}
 	return &OauthHandler{
@@ -180,7 +179,7 @@ func (oh *OauthHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	log.Println(username + " logged in via OAuth.")
+	oauth2Logger.PrintAndLog("Oauth2", username+" logged in via OAuth.", nil)
 	oh.ag.LoginUserByRequest(w, r, username, true)
 
 	remoteIP := r.Header.Get("X-FORWARDED-FOR")

--- a/src/mod/auth/oauth2/zz_logger.go
+++ b/src/mod/auth/oauth2/zz_logger.go
@@ -1,0 +1,5 @@
+package oauth2
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var oauth2Logger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/register/register.go
+++ b/src/mod/auth/register/register.go
@@ -12,8 +12,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/mail"
 	"os"
@@ -102,7 +102,7 @@ func (h *RegisterHandler) HandleRegisterInterface(w http.ResponseWriter, r *http
 			"vendor_logo": imagecontent,
 		})
 		if err != nil {
-			log.Println("Template not found: system/auth/register.html")
+			registerLogger.PrintAndLog("Register", "Template not found: system/auth/register.html", nil)
 			http.NotFound(w, r)
 			return
 		}
@@ -245,7 +245,7 @@ func (h *RegisterHandler) HandleRegisterRequest(w http.ResponseWriter, r *http.R
 	defaultGroup := h.DefaultUserGroup
 	if h.permissionHandler.GroupExists(defaultGroup) == false {
 		//Public registry user group not exists. Raise 500 Error
-		log.Println("[CRITICAL] PUBLIC REGISTRY USER GROUP NOT FOUND! PLEASE RESTART YOUR SYSTEM!")
+		registerLogger.PrintAndLog("Register", "[CRITICAL] PUBLIC REGISTRY USER GROUP NOT FOUND! PLEASE RESTART YOUR SYSTEM!", nil)
 		utils.SendErrorResponse(w, "Internal Server Error")
 		return
 	}
@@ -261,7 +261,7 @@ func (h *RegisterHandler) HandleRegisterRequest(w http.ResponseWriter, r *http.R
 	h.database.Write("register", "user/email/"+username, email)
 
 	utils.SendOK(w)
-	log.Println("New User Registered: ", email, username, strings.Repeat("*", len(password)))
+	registerLogger.PrintAndLog("Register", fmt.Sprint("New User Registered: ", email, username, strings.Repeat("*", len(password))), nil)
 
 }
 

--- a/src/mod/auth/register/zz_logger.go
+++ b/src/mod/auth/register/zz_logger.go
@@ -1,0 +1,5 @@
+package register
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var registerLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/zz_logger.go
+++ b/src/mod/auth/zz_logger.go
@@ -1,0 +1,5 @@
+package auth
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var authLogger, _ = logger.NewTmpLogger()

--- a/src/mod/database/database_core.go
+++ b/src/mod/database/database_core.go
@@ -6,7 +6,6 @@ package database
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"sync"
 
 	"github.com/boltdb/bolt"
@@ -41,7 +40,7 @@ func (d *Database) dump(filename string) ([]string, error) {
 	d.Tables.Range(func(tableName, v interface{}) bool {
 		entries, err := d.ListTable(tableName.(string))
 		if err != nil {
-			log.Println("Reading table " + tableName.(string) + " failed: " + err.Error())
+			databaseLogger.PrintAndLog("Database", "Reading table "+tableName.(string)+" failed: "+err.Error(), nil)
 			return false
 		}
 		for _, keypairs := range entries {
@@ -134,7 +133,7 @@ func (d *Database) keyExists(tableName string, key string) bool {
 	resultIsNil := false
 	if !d.TableExists(tableName) {
 		//Table not exists. Do not proceed accessing key
-		log.Println("[DB] ERROR: Requesting key from table that didn't exist!!!")
+		databaseLogger.PrintAndLog("Database", "[DB] ERROR: Requesting key from table that didn't exist!!!", nil)
 		return false
 	}
 	err := d.Db.(*bolt.DB).View(func(tx *bolt.Tx) error {

--- a/src/mod/database/database_openwrt.go
+++ b/src/mod/database/database_openwrt.go
@@ -6,7 +6,6 @@ package database
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +33,7 @@ func newDatabase(dbfile string, readOnlyMode bool) (*Database, error) {
 		}
 	}
 
-	log.Println("Filesystem Emulated Key-value Database Service Started: " + dbRootPath)
+	databaseLogger.PrintAndLog("Database", "Filesystem Emulated Key-value Database Service Started: "+dbRootPath, nil)
 	return &Database{
 		Db:       dbRootPath,
 		Tables:   tableMap,

--- a/src/mod/database/zz_logger.go
+++ b/src/mod/database/zz_logger.go
@@ -1,0 +1,5 @@
+package database
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var databaseLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/diskfs/diskfs.go
+++ b/src/mod/disk/diskfs/diskfs.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -229,7 +228,7 @@ func UnmountDevice(devicePath string) error {
 	// Run the command
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Println("[RAID] Unable to unmount device: " + string(output))
+		diskfsLogger.PrintAndLog("Diskfs", "[RAID] Unable to unmount device: "+string(output), nil)
 		return fmt.Errorf("error unmounting device: %v", err)
 	}
 

--- a/src/mod/disk/diskfs/zz_logger.go
+++ b/src/mod/disk/diskfs/zz_logger.go
@@ -1,0 +1,5 @@
+package diskfs
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var diskfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/diskmg/diskmg.go
+++ b/src/mod/disk/diskmg/diskmg.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os/exec"
 	"path/filepath"
@@ -112,7 +111,7 @@ func HandleView(w http.ResponseWriter, r *http.Request) {
 			utils.SendJSONResponse(w, string(js))
 
 		} else {
-			log.Println("system/disk/diskmg/DiskmgWin.exe NOT FOUND. Unable to load Window's disk information")
+			diskmgLogger.PrintAndLog("Diskmg", "system/disk/diskmg/DiskmgWin.exe NOT FOUND. Unable to load Window's disk information", nil)
 			utils.SendErrorResponse(w, "DiskmgWin.exe not found")
 			return
 		}
@@ -298,7 +297,7 @@ func HandleFormat(w http.ResponseWriter, r *http.Request, fsHandlers []*fs.FileS
 	mounted, err := checkDeviceMounted(devID)
 	if err != nil {
 		//Fail to check if disk mounted
-		log.Println(err.Error())
+		diskmgLogger.PrintAndLog("Diskmg", err.Error(), nil)
 		utils.SendErrorResponse(w, "Failed to check disk mount status")
 		return
 	}
@@ -312,7 +311,7 @@ func HandleFormat(w http.ResponseWriter, r *http.Request, fsHandlers []*fs.FileS
 			return
 		}
 
-		log.Println("Unmounting " + mountpt + " for format")
+		diskmgLogger.PrintAndLog("Diskmg", "Unmounting "+mountpt+" for format", nil)
 		//Unmount the devices
 		out, err := Unmount(mountpt, fsHandlers)
 		if err != nil {
@@ -338,16 +337,16 @@ func HandleFormat(w http.ResponseWriter, r *http.Request, fsHandlers []*fs.FileS
 	}
 
 	//Execute format comamnd
-	log.Println("Formatting of " + "/dev/" + devID + " Started")
+	diskmgLogger.PrintAndLog("Diskmg", "Formatting of "+"/dev/"+devID+" Started", nil)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Println("Format failed: " + string(output))
+		diskmgLogger.PrintAndLog("Diskmg", "Format failed: "+string(output), nil)
 		utils.SendErrorResponse(w, string(output))
 		return
 	}
 
 	//Reply ok
-	log.Println(string(output))
+	diskmgLogger.PrintAndLog("Diskmg", string(output), nil)
 
 	//Let the system to reload the disk
 	time.Sleep(2 * time.Second)
@@ -364,11 +363,11 @@ func Mount(devID string, mountpt string, mountingTool string, fsHandlers []*fs.F
 		}
 	}
 
-	log.Println("Executing Mount Command: ", "mount", "-t", mountingTool, "/dev/"+devID, mountpt)
+	diskmgLogger.PrintAndLog("Diskmg", fmt.Sprint("Executing Mount Command: ", "mount", "-t", mountingTool, "/dev/"+devID, mountpt), nil)
 	cmd := exec.Command("mount", "-t", mountingTool, "/dev/"+devID, mountpt)
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Println("Failed to mount "+devID, string(o))
+		diskmgLogger.PrintAndLog("Diskmg", fmt.Sprint("Failed to mount "+devID, string(o)), nil)
 	}
 	return string(o), err
 }
@@ -382,7 +381,7 @@ func Unmount(mountpt string, fsHandlers []*fs.FileSystemHandler) (string, error)
 			fsh.Closed = true
 		}
 	}
-	log.Println("Executing Umount Command: ", "umount", mountpt)
+	diskmgLogger.PrintAndLog("Diskmg", fmt.Sprint("Executing Umount Command: ", "umount", mountpt), nil)
 	cmd := exec.Command("umount", mountpt)
 	o, err := cmd.CombinedOutput()
 	return string(o), err

--- a/src/mod/disk/diskmg/zz_logger.go
+++ b/src/mod/disk/diskmg/zz_logger.go
@@ -1,0 +1,5 @@
+package diskmg
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var diskmgLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/diskspace/diskspace.go
+++ b/src/mod/disk/diskspace/diskspace.go
@@ -2,7 +2,6 @@ package diskspace
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"os/exec"
 	"runtime"
@@ -39,7 +38,7 @@ func GetAllLogicDiskInfo() []LogicalDiskSpaceInfo {
 		cmd := exec.Command("wmic", "logicaldisk", "get", "caption,size,freespace")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Println("wmic not supported.")
+			diskspaceLogger.PrintAndLog("Diskspace", "wmic not supported.", nil)
 			return []LogicalDiskSpaceInfo{}
 		}
 		lines := strings.Split(string(out), "\n")

--- a/src/mod/disk/diskspace/zz_logger.go
+++ b/src/mod/disk/diskspace/zz_logger.go
@@ -1,0 +1,5 @@
+package diskspace
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var diskspaceLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/raid/handler.go
+++ b/src/mod/disk/raid/handler.go
@@ -2,7 +2,6 @@ package raid
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -49,7 +48,7 @@ func (m *Manager) HandleRemoveDiskFromRAIDVol(w http.ResponseWriter, r *http.Req
 	//Check if the disk is already failed
 	diskAlreadyFailed, err := m.DiskIsFailed(mdDev, sdXDev)
 	if err != nil {
-		log.Println("[RAID] Unable to validate if disk failed: " + err.Error())
+		raidLogger.PrintAndLog("Raid", "[RAID] Unable to validate if disk failed: "+err.Error(), nil)
 		utils.SendErrorResponse(w, err.Error())
 		return
 	}
@@ -71,7 +70,7 @@ func (m *Manager) HandleRemoveDiskFromRAIDVol(w http.ResponseWriter, r *http.Req
 		utils.SendErrorResponse(w, err.Error())
 		return
 	}
-	log.Println("[RAID] Memeber disk " + sdXDev + " removed from RAID volume " + mdDev)
+	raidLogger.PrintAndLog("Raid", "[RAID] Memeber disk "+sdXDev+" removed from RAID volume "+mdDev, nil)
 	utils.SendOK(w)
 }
 
@@ -142,7 +141,7 @@ func (m *Manager) HandleAddDiskToRAIDVol(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	log.Println("[RAID] Device " + sdXDev + " added to RAID volume " + mdDev)
+	raidLogger.PrintAndLog("Raid", "[RAID] Device "+sdXDev+" added to RAID volume "+mdDev, nil)
 
 	utils.SendOK(w)
 }
@@ -202,7 +201,7 @@ func (m *Manager) HandlListChildrenDeviceInfo(w http.ResponseWriter, r *http.Req
 	for _, blockdevice := range raidDevice.Members {
 		bdm, err := diskfs.GetBlockDeviceMeta("/dev/" + blockdevice.Name)
 		if err != nil {
-			log.Println("[RAID] Unable to load block device info: " + err.Error())
+			raidLogger.PrintAndLog("Raid", "[RAID] Unable to load block device info: "+err.Error(), nil)
 			results[blockdevice.Name] = &diskfs.BlockDeviceMeta{
 				Name: blockdevice.Name,
 				Size: -1,
@@ -507,7 +506,7 @@ func (m *Manager) HandleRemoveRaideDevice(w http.ResponseWriter, r *http.Request
 		m.Options.Logger.PrintAndLog("RAID", targetDevice+" is mounted. Trying to unmount...", nil)
 		err = diskfs.UnmountDevice(targetDevice)
 		if err != nil {
-			log.Println("[RAID] Unmount failed: " + err.Error())
+			raidLogger.PrintAndLog("Raid", "[RAID] Unmount failed: "+err.Error(), nil)
 			utils.SendErrorResponse(w, err.Error())
 			return
 		}

--- a/src/mod/disk/raid/mdadm.go
+++ b/src/mod/disk/raid/mdadm.go
@@ -3,7 +3,6 @@ package raid
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -199,7 +198,7 @@ func (m *Manager) GetRAIDDevicesFromProcMDStat() ([]RAIDDevice, error) {
 			seqInt, err := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(tmp[1]), "]"))
 			if err != nil {
 				//Not an integer?
-				log.Println("[RAID] Unable to parse " + disk + " sequence ID")
+				raidLogger.PrintAndLog("Raid", "[RAID] Unable to parse "+disk+" sequence ID", nil)
 				continue
 			}
 			member := RAIDMember{

--- a/src/mod/disk/raid/mdadmConf.go
+++ b/src/mod/disk/raid/mdadmConf.go
@@ -2,7 +2,6 @@ package raid
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -36,17 +35,17 @@ func (m *Manager) FlushReload() error {
 		//Check if it is mounted. If yes, skip this
 		devMounted, err := diskfs.DeviceIsMounted("/dev/" + rd.Name)
 		if devMounted || err != nil {
-			log.Println("[RAID] " + "/dev/" + rd.Name + " is in use. Skipping.")
+			raidLogger.PrintAndLog("Raid", "[RAID] "+"/dev/"+rd.Name+" is in use. Skipping.", nil)
 			continue
 		}
-		log.Println("[RAID] Stopping " + rd.Name)
+		raidLogger.PrintAndLog("Raid", "[RAID] Stopping "+rd.Name, nil)
 
 		cmdMdadm := exec.Command("sudo", "mdadm", "--stop", "/dev/"+rd.Name)
 
 		// Run the command and capture its output
 		_, err = cmdMdadm.Output()
 		if err != nil {
-			log.Println("[RAID] Unable to stop " + rd.Name + ". Skipping")
+			raidLogger.PrintAndLog("Raid", "[RAID] Unable to stop "+rd.Name+". Skipping", nil)
 			continue
 		}
 	}
@@ -158,10 +157,10 @@ func (m *Manager) UpdateMDADMConfig() error {
 		for _, volumeUUID := range poolUUIDToBeRemoved {
 			err = m.RemoveVolumeFromMDADMConfig(volumeUUID)
 			if err != nil {
-				log.Println("[RAID] Error when trying to remove old RAID volume from config: " + err.Error())
+				raidLogger.PrintAndLog("Raid", "[RAID] Error when trying to remove old RAID volume from config: "+err.Error(), nil)
 				return err
 			} else {
-				log.Println("[RAID] RAID volume " + volumeUUID + " removed from config file")
+				raidLogger.PrintAndLog("Raid", "[RAID] RAID volume "+volumeUUID+" removed from config file", nil)
 			}
 		}
 
@@ -169,7 +168,7 @@ func (m *Manager) UpdateMDADMConfig() error {
 
 	if len(newConfigLines) == 0 {
 		//Nothing to write
-		log.Println("[RAID] Nothing to write. Skipping mdadm config update.")
+		raidLogger.PrintAndLog("Raid", "[RAID] Nothing to write. Skipping mdadm config update.", nil)
 		return nil
 	}
 

--- a/src/mod/disk/raid/zz_logger.go
+++ b/src/mod/disk/raid/zz_logger.go
@@ -1,0 +1,5 @@
+package raid
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var raidLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/smart/helper.go
+++ b/src/mod/disk/smart/helper.go
@@ -1,7 +1,7 @@
 package smart
 
 import (
-	"log"
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -10,7 +10,7 @@ func execCommand(executable string, args ...string) string {
 	shell := exec.Command(executable, args...) // Run command
 	output, err := shell.CombinedOutput()      // Response from cmdline
 	if err != nil && string(output) == "" {    // If done w/ errors then
-		log.Println(err)
+		smartLogger.PrintAndLog("Smart", fmt.Sprint(err), nil)
 		return ""
 	}
 

--- a/src/mod/disk/smart/smart.go
+++ b/src/mod/disk/smart/smart.go
@@ -12,7 +12,7 @@ package smart
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -35,7 +35,7 @@ type SMARTListener struct {
 func NewSmartListener() (*SMARTListener, error) {
 	smartExec := getBinary()
 
-	log.Println("Starting SMART mointoring")
+	smartLogger.PrintAndLog("Smart", "Starting SMART mointoring", nil)
 
 	if smartExec == "" {
 		return &SMARTListener{}, errors.New("not supported platform")
@@ -139,12 +139,12 @@ func (s *SMARTListener) GetSMART(w http.ResponseWriter, r *http.Request) {
 func getBinary() string {
 	// Prefer system-installed smartctl (more up-to-date, supports newer drives).
 	if path, err := exec.LookPath("smartctl"); err == nil {
-		log.Println("[SMART] Using system-installed smartctl:", path)
+		smartLogger.PrintAndLog("Smart", fmt.Sprint("[SMART] Using system-installed smartctl:", path), nil)
 		return path
 	}
 
 	// Fall back to the pre-built binary bundled with arozos.
-	log.Println("[SMART] System smartctl not found, falling back to bundled binary")
+	smartLogger.PrintAndLog("Smart", "[SMART] System smartctl not found, falling back to bundled binary", nil)
 	switch runtime.GOOS {
 	case "windows":
 		return ".\\system\\disk\\smart\\win\\smartctl.exe"

--- a/src/mod/disk/smart/zz_logger.go
+++ b/src/mod/disk/smart/zz_logger.go
@@ -1,0 +1,5 @@
+package smart
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var smartLogger, _ = logger.NewTmpLogger()

--- a/src/mod/fileservers/servers/samba/handlers.go
+++ b/src/mod/fileservers/servers/samba/handlers.go
@@ -2,7 +2,6 @@ package samba
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -391,14 +390,14 @@ func (s *ShareManager) ActivateUserAccount(w http.ResponseWriter, r *http.Reques
 			//Try to create the share
 			fshShareAbsolutePath, err := filepath.Abs(fshSharePath)
 			if err != nil {
-				log.Println("[Samba] Unable to generate share config for path: " + fshSharePath)
+				sambaLogger.PrintAndLog("Samba", "[Samba] Unable to generate share config for path: "+fshSharePath, nil)
 				continue
 			}
 
 			//Check if that folder exists
 			if !utils.FileExists(fshShareAbsolutePath) {
 				//Folder not exists. Continue
-				log.Println("[Samba] Path not exists for file system handler: " + fshSharePath)
+				sambaLogger.PrintAndLog("Samba", "[Samba] Path not exists for file system handler: "+fshSharePath, nil)
 				continue
 			}
 
@@ -413,7 +412,7 @@ func (s *ShareManager) ActivateUserAccount(w http.ResponseWriter, r *http.Reques
 			})
 
 			if err != nil {
-				log.Println("[Samba] Failed to create share: " + err.Error())
+				sambaLogger.PrintAndLog("Samba", "[Samba] Failed to create share: "+err.Error(), nil)
 				utils.SendErrorResponse(w, err.Error())
 				return
 			}
@@ -421,7 +420,7 @@ func (s *ShareManager) ActivateUserAccount(w http.ResponseWriter, r *http.Reques
 			//Share exists. Add this user to such share
 			err = s.AddUserToSambaShare(fshID, userInfo.Username)
 			if err != nil {
-				log.Println("[Samba] Failed to add user " + userInfo.Username + " to share " + fshID + ": " + err.Error())
+				sambaLogger.PrintAndLog("Samba", "[Samba] Failed to add user "+userInfo.Username+" to share "+fshID+": "+err.Error(), nil)
 				utils.SendErrorResponse(w, err.Error())
 				return
 			}
@@ -492,7 +491,7 @@ func (s *ShareManager) DeactiveUserAccount(w http.ResponseWriter, r *http.Reques
 	for _, userAccessibleShare := range userAccessibleShares {
 		err = s.RemoveUserFromSambaShare(userAccessibleShare.Name, userInfo.Username)
 		if err != nil {
-			log.Println("[Samba] Unable to remove user " + userInfo.Username + " from share: " + err.Error())
+			sambaLogger.PrintAndLog("Samba", "[Samba] Unable to remove user "+userInfo.Username+" from share: "+err.Error(), nil)
 			continue
 		}
 	}
@@ -532,7 +531,7 @@ func (s *ShareManager) HandleAccessUserUpdate(w http.ResponseWriter, r *http.Req
 	newUserList := []string{}
 	err = json.Unmarshal([]byte(newUserListJSON), &newUserList)
 	if err != nil {
-		log.Println("[Samba] Parse new user list failed: " + err.Error())
+		sambaLogger.PrintAndLog("Samba", "[Samba] Parse new user list failed: "+err.Error(), nil)
 		utils.SendErrorResponse(w, "failed to parse the new user list")
 		return
 	}

--- a/src/mod/fileservers/servers/samba/required.go
+++ b/src/mod/fileservers/servers/samba/required.go
@@ -2,7 +2,6 @@ package samba
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 
 	"strings"
@@ -21,7 +20,7 @@ func (m *ShareManager) ServerToggle(enabled bool) error {
 func (m *ShareManager) IsEnabled() bool {
 	smbdRunning, err := checkSmbdRunning()
 	if err != nil {
-		log.Println("Unable to get smbd state: " + err.Error())
+		sambaLogger.PrintAndLog("Samba", "Unable to get smbd state: "+err.Error(), nil)
 		return false
 	}
 

--- a/src/mod/fileservers/servers/samba/zz_logger.go
+++ b/src/mod/fileservers/servers/samba/zz_logger.go
@@ -1,0 +1,5 @@
+package samba
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var sambaLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/abstractions/ftpfs/ftpfs.go
+++ b/src/mod/filesystem/abstractions/ftpfs/ftpfs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"io/fs"
-	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -50,7 +49,7 @@ func NewFTPFSAbstraction(uuid string, hierarchy string, hostname string, usernam
 			}
 		}()
 	*/
-	log.Println("[FTP FS] " + hostname + " mounted via FTP-FS")
+	ftpfsLogger.PrintAndLog("Ftpfs", "[FTP FS] "+hostname+" mounted via FTP-FS", nil)
 	return FTPFSAbstraction{
 		uuid:      uuid,
 		hierarchy: hierarchy,
@@ -84,7 +83,7 @@ func (l FTPFSAbstraction) makeConn() (*ftp.ServerConn, error) {
 	}
 
 	if !succ && lastError != nil {
-		log.Println("[FTPFS] Unable to dial TCP: " + lastError.Error())
+		ftpfsLogger.PrintAndLog("Ftpfs", "[FTPFS] Unable to dial TCP: "+lastError.Error(), nil)
 		return nil, lastError
 	}
 
@@ -341,7 +340,7 @@ func (l FTPFSAbstraction) ReadStream(filename string) (io.ReadCloser, error) {
 
 func (l FTPFSAbstraction) Walk(root string, walkFn filepath.WalkFunc) error {
 	root = filterFilepath(root)
-	log.Println("[FTP FS] Walking a root on FTP is extremely slow. Please consider rewritting this function. Scanning: " + root)
+	ftpfsLogger.PrintAndLog("Ftpfs", "[FTP FS] Walking a root on FTP is extremely slow. Please consider rewritting this function. Scanning: "+root, nil)
 	c, err := l.makeConn()
 	if err != nil {
 		return err

--- a/src/mod/filesystem/abstractions/ftpfs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/ftpfs/zz_logger.go
@@ -1,0 +1,5 @@
+package ftpfs
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var ftpfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/abstractions/s3fs/s3fs.go
+++ b/src/mod/filesystem/abstractions/s3fs/s3fs.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -123,7 +123,7 @@ func NewS3FSAbstraction(uuid, hierarchy, endpoint, bucket, prefix, accessKey, se
 	if bucketRegion, rerr := manager.GetBucketRegion(discoverCtx, client, bucket); rerr == nil && bucketRegion != "" && bucketRegion != "us-east-1" {
 		if rc, rerr2 := newClient(bucketRegion); rerr2 == nil {
 			client = rc
-			log.Printf("[S3 FS] Auto-discovered region %q for bucket %q\n", bucketRegion, bucket)
+			s3fsLogger.PrintAndLog("S3fs", fmt.Sprintf("[S3 FS] Auto-discovered region %q for bucket %q\n", bucketRegion, bucket), nil)
 		}
 	}
 
@@ -145,7 +145,7 @@ func NewS3FSAbstraction(uuid, hierarchy, endpoint, bucket, prefix, accessKey, se
 	uploader := manager.NewUploader(client)
 
 	prefix = strings.Trim(prefix, "/")
-	log.Printf("[S3 FS] Mounted s3://%s/%s (endpoint=%s ssl=%v)\n", bucket, prefix, endpoint, useSSL)
+	s3fsLogger.PrintAndLog("S3fs", fmt.Sprintf("[S3 FS] Mounted s3://%s/%s (endpoint=%s ssl=%v)\n", bucket, prefix, endpoint, useSSL), nil)
 
 	return &S3FSAbstraction{
 		uuid:      uuid,

--- a/src/mod/filesystem/abstractions/s3fs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/s3fs/zz_logger.go
@@ -1,0 +1,5 @@
+package s3fs
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var s3fsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/abstractions/sftpfs/sftpfs.go
+++ b/src/mod/filesystem/abstractions/sftpfs/sftpfs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -49,7 +48,7 @@ func NewSFTPFileSystemAbstraction(uuid string, hierarchy string, serverUrl strin
 
 	// Parse Host and Port
 
-	log.Println("[SFTP FS] Establishing connection with " + serverUrl + "...")
+	sftpfsLogger.PrintAndLog("Sftpfs", "[SFTP FS] Establishing connection with "+serverUrl+"...", nil)
 
 	var auths []ssh.AuthMethod
 
@@ -72,18 +71,18 @@ func NewSFTPFileSystemAbstraction(uuid string, hierarchy string, serverUrl strin
 	// Connect to server
 	conn, err := ssh.Dial("tcp", addr, &config)
 	if err != nil {
-		log.Printf("[SFTP FS] Failed to connect to [%s] %v\n", addr, err)
+		sftpfsLogger.PrintAndLog("Sftpfs", fmt.Sprintf("[SFTP FS] Failed to connect to [%s] %v\n", addr, err), nil)
 		return SFTPFileSystemAbstraction{}, err
 	}
 
 	// Create new SFTP client
 	sc, err := sftp.NewClient(conn)
 	if err != nil {
-		log.Printf("[SFTP FS] Unable to start SFTP subsystem: %v\n", err)
+		sftpfsLogger.PrintAndLog("Sftpfs", fmt.Sprintf("[SFTP FS] Unable to start SFTP subsystem: %v\n", err), nil)
 		return SFTPFileSystemAbstraction{}, err
 	}
 
-	log.Println("[SFTP FS] Connected to remote: " + addr)
+	sftpfsLogger.PrintAndLog("Sftpfs", "[SFTP FS] Connected to remote: "+addr, nil)
 	return SFTPFileSystemAbstraction{
 		uuid:        uuid,
 		hierarchy:   hierarchy,

--- a/src/mod/filesystem/abstractions/sftpfs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/sftpfs/zz_logger.go
@@ -1,0 +1,5 @@
+package sftpfs
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var sftpfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/abstractions/smbfs/smbfs.go
+++ b/src/mod/filesystem/abstractions/smbfs/smbfs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -39,16 +38,16 @@ type ServerMessageBlockFileSystemAbstraction struct {
 }
 
 func NewServerMessageBlockFileSystemAbstraction(uuid string, hierarchy string, ipaddr string, rootShare string, username string, password string) (ServerMessageBlockFileSystemAbstraction, error) {
-	log.Println("[SMB-FS] Connecting to " + uuid + ":/ (" + ipaddr + ")")
+	smbfsLogger.PrintAndLog("Smbfs", "[SMB-FS] Connecting to "+uuid+":/ ("+ipaddr+")", nil)
 	//Patch the ip address if port not found
 	if !strings.Contains(ipaddr, ":") {
-		log.Println("[SMB-FS] Port not set. Using default SMB port (:445)")
+		smbfsLogger.PrintAndLog("Smbfs", "[SMB-FS] Port not set. Using default SMB port (:445)", nil)
 		ipaddr = ipaddr + ":445" //Default port for SMB
 	}
 	nd := net.Dialer{Timeout: 10 * time.Second}
 	conn, err := nd.Dial("tcp", ipaddr)
 	if err != nil {
-		log.Println("[SMB-FS] Unable to connect to remote: ", err.Error())
+		smbfsLogger.PrintAndLog("Smbfs", fmt.Sprint("[SMB-FS] Unable to connect to remote: ", err.Error()), nil)
 		return ServerMessageBlockFileSystemAbstraction{}, err
 	}
 
@@ -61,7 +60,7 @@ func NewServerMessageBlockFileSystemAbstraction(uuid string, hierarchy string, i
 
 	s, err := d.Dial(conn)
 	if err != nil {
-		log.Println("[SMB-FS] Unable to connect to remote: ", err.Error())
+		smbfsLogger.PrintAndLog("Smbfs", fmt.Sprint("[SMB-FS] Unable to connect to remote: ", err.Error()), nil)
 		return ServerMessageBlockFileSystemAbstraction{}, err
 	}
 
@@ -76,10 +75,10 @@ func NewServerMessageBlockFileSystemAbstraction(uuid string, hierarchy string, i
 	//Mound remote storage
 	fs, err := s.Mount(thisSmbRoot)
 	if err != nil {
-		log.Println("[SMB-FS] Unable to connect to remote: ", err.Error())
+		smbfsLogger.PrintAndLog("Smbfs", fmt.Sprint("[SMB-FS] Unable to connect to remote: ", err.Error()), nil)
 		return ServerMessageBlockFileSystemAbstraction{}, err
 	}
-	log.Println("[SMB-FS] Mounted SMB Root Share: " + thisSmbRoot)
+	smbfsLogger.PrintAndLog("Smbfs", "[SMB-FS] Mounted SMB Root Share: "+thisSmbRoot, nil)
 
 	done := make(chan bool)
 	fsAbstraction := ServerMessageBlockFileSystemAbstraction{

--- a/src/mod/filesystem/abstractions/smbfs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/smbfs/zz_logger.go
@@ -1,0 +1,5 @@
+package smbfs
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var smbfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/abstractions/webdavfs/webdavfs.go
+++ b/src/mod/filesystem/abstractions/webdavfs/webdavfs.go
@@ -2,9 +2,9 @@ package webdavfs
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -37,10 +37,10 @@ func NewWebDAVMount(UUID string, Hierarchy string, root string, user string, pas
 	c := gowebdav.NewClient(root, user, password)
 	err := c.Connect()
 	if err != nil {
-		log.Println("[WebDAV FS] Unable to connect to remote: ", err.Error())
+		webdavfsLogger.PrintAndLog("Webdavfs", fmt.Sprint("[WebDAV FS] Unable to connect to remote: ", err.Error()), nil)
 		return nil, err
 	} else {
-		log.Println("[WebDAV FS] Connected to remote: " + root)
+		webdavfsLogger.PrintAndLog("Webdavfs", "[WebDAV FS] Connected to remote: "+root, nil)
 	}
 	return &WebDAVFileSystem{
 		UUID:      UUID,
@@ -178,7 +178,7 @@ func (e WebDAVFileSystem) GetFileSize(filename string) int64 {
 	filename = filterFilepath(filepath.ToSlash(filepath.Clean(filename)))
 	s, err := e.Stat(filename)
 	if err != nil {
-		log.Println(err)
+		webdavfsLogger.PrintAndLog("Webdavfs", fmt.Sprint(err), nil)
 		return 0
 	}
 

--- a/src/mod/filesystem/abstractions/webdavfs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/webdavfs/zz_logger.go
@@ -1,0 +1,5 @@
+package webdavfs
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var webdavfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/fileOpr.go
+++ b/src/mod/filesystem/fileOpr.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -748,7 +747,7 @@ func FileMove(srcFsh *FileSystemHandler, src string, destFsh *FileSystemHandler,
 			time.Sleep(1 * time.Second)
 			os.Remove(src)
 			counter++
-			log.Println("Retrying to remove file: " + src)
+			filesystemLogger.PrintAndLog("Filesystem", "Retrying to remove file: "+src, nil)
 			if counter > 10 {
 				return errors.New("Source file remove failed.")
 			}
@@ -821,7 +820,7 @@ func dirCopy(srcFsh *FileSystemHandler, src string, destFsh *FileSystemHandler, 
 			//Move the file using BLFC
 			f, err := srcFshAbs.ReadStream(fileSrc)
 			if err != nil {
-				log.Println(err)
+				filesystemLogger.PrintAndLog("Filesystem", fmt.Sprint(err), nil)
 				return err
 			}
 			defer f.Close()
@@ -918,7 +917,8 @@ func IsDir(path string) bool {
 	}
 	fi, err := os.Stat(path)
 	if err != nil {
-		log.Fatal(err)
+		filesystemLogger.PrintAndLog("Filesystem", fmt.Sprint(err), nil)
+		os.Exit(1)
 		return false
 	}
 	switch mode := fi.Mode(); {

--- a/src/mod/filesystem/filesystem.go
+++ b/src/mod/filesystem/filesystem.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -126,7 +125,7 @@ func NewFileSystemHandlersFromJSON(jsonContent []byte, runtimePersistenceConfig 
 	for _, option := range options {
 		thisHandler, err := NewFileSystemHandler(option, runtimePersistenceConfig)
 		if err != nil {
-			log.Println("[File System] Failed to create system handler for " + option.Name)
+			filesystemLogger.PrintAndLog("Filesystem", "[File System] Failed to create system handler for "+option.Name, nil)
 			//log.Println(err.Error())
 			continue
 		}
@@ -148,10 +147,10 @@ func NewFileSystemHandler(option FileSystemOption, RuntimePersistenceConfig Runt
 			actualMountDev := option.Mountdev
 			if option.DiskUUID != "" {
 				if resolvedPath, err := ResolveDeviceByUUID(option.DiskUUID); err == nil {
-					log.Println("[Storage] Resolved device by UUID " + option.DiskUUID + " -> " + resolvedPath)
+					filesystemLogger.PrintAndLog("Filesystem", "[Storage] Resolved device by UUID "+option.DiskUUID+" -> "+resolvedPath, nil)
 					actualMountDev = resolvedPath
 				} else {
-					log.Println("[Storage] UUID lookup failed for " + option.DiskUUID + ", falling back to device path " + option.Mountdev)
+					filesystemLogger.PrintAndLog("Filesystem", "[Storage] UUID lookup failed for "+option.DiskUUID+", falling back to device path "+option.Mountdev, nil)
 				}
 			}
 			err := MountDevice(option.Mountpt, actualMountDev, option.Filesystem)
@@ -217,7 +216,7 @@ func NewFileSystemHandler(option FileSystemOption, RuntimePersistenceConfig Runt
 		pathChunks := strings.Split(strings.ReplaceAll(option.Path, "\\", "/"), "/")
 
 		if len(pathChunks) < 2 {
-			log.Println("[File System] Invalid configured smb filepath: Path format not matching [ip_addr]:[port]/[root_share path]")
+			filesystemLogger.PrintAndLog("Filesystem", "[File System] Invalid configured smb filepath: Path format not matching [ip_addr]:[port]/[root_share path]", nil)
 			return nil, errors.New("Invalid configured smb filepath: Path format not matching [ip_addr]:[port]/[root_share path]")
 		}
 
@@ -385,7 +384,7 @@ func NewFileSystemHandler(option FileSystemOption, RuntimePersistenceConfig Runt
 
 	} else if option.Filesystem == "virtual" {
 		//Virtual filesystem, deprecated
-		log.Println("[File System] Deprecated file system type: Virtual")
+		filesystemLogger.PrintAndLog("Filesystem", "[File System] Deprecated file system type: Virtual", nil)
 	}
 
 	return nil, errors.New("Not supported file system: " + fstype)
@@ -516,7 +515,7 @@ func (fsh *FileSystemHandler) GetDirctorySizeFromVpath(vpath string, username st
 
 // Reload the target file system abstraction
 func (fsh *FileSystemHandler) ReloadFileSystelAbstraction() error {
-	log.Println("[File System] Reloading File System Abstraction for " + fsh.Name)
+	filesystemLogger.PrintAndLog("Filesystem", "[File System] Reloading File System Abstraction for "+fsh.Name, nil)
 	//Load the start option for this fsh
 	originalStartOption := fsh.StartOptions
 	runtimePersistenceConfig := fsh.RuntimePersistenceConfig
@@ -551,7 +550,7 @@ func (fsh *FileSystemHandler) Close() {
 	//Close the file system object
 	err := fsh.FileSystemAbstraction.Close()
 	if err != nil {
-		log.Println("[File System]  Unable to close File System Abstraction for Handler: " + fsh.UUID + ". Skipping.")
+		filesystemLogger.PrintAndLog("Filesystem", "[File System]  Unable to close File System Abstraction for Handler: "+fsh.UUID+". Skipping.", nil)
 	}
 }
 

--- a/src/mod/filesystem/fspermission/fspermission.go
+++ b/src/mod/filesystem/fspermission/fspermission.go
@@ -3,7 +3,6 @@ package fspermission
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 
@@ -70,7 +69,7 @@ func SetFilePermisson(fsh *filesystem.FileSystemHandler, file string, permission
 		}
 
 		//Convert the value into a file mode
-		log.Println("Updating " + file + " permission to " + strconv.Itoa(finalMode))
+		fspermissionLogger.PrintAndLog("Fspermission", "Updating "+file+" permission to "+strconv.Itoa(finalMode), nil)
 
 		//Magic way to convert dec to oct
 		output, _ := strconv.ParseInt("0"+strconv.Itoa(finalMode), 8, 64)

--- a/src/mod/filesystem/fspermission/zz_logger.go
+++ b/src/mod/filesystem/fspermission/zz_logger.go
@@ -1,0 +1,5 @@
+package fspermission
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var fspermissionLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/metadata/folder.go
+++ b/src/mod/filesystem/metadata/folder.go
@@ -3,11 +3,11 @@ package metadata
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"image"
 	"image/draw"
 	"image/jpeg"
 	"image/png"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,7 +108,7 @@ func generateThumbnailForFolder(fsh *filesystem.FileSystemHandler, cacheFolder s
 		//Fail to decode the image. Try to remove the damaged iamge file
 		image3.Close()
 		fshAbs.Remove(contentCache[0])
-		log.Println("Failed to decode cahce image for: " + contentCache[0] + ". Removing thumbnail cache")
+		metadataLogger.PrintAndLog("Metadata", "Failed to decode cahce image for: "+contentCache[0]+". Removing thumbnail cache", nil)
 		return "", errors.New("failed to decode: " + err.Error())
 	}
 	defer image3.Close()
@@ -119,7 +119,8 @@ func generateThumbnailForFolder(fsh *filesystem.FileSystemHandler, cacheFolder s
 
 	outfile, err := fshAbs.Create(filepath.Join(cacheFolder, filepath.Base(file)+".png"))
 	if err != nil {
-		log.Fatalf("failed to create: %s", err)
+		metadataLogger.PrintAndLog("Metadata", fmt.Sprintf("failed to create: %s", err), nil)
+		os.Exit(1)
 	}
 	png.Encode(outfile, resultThumbnail)
 	outfile.Close()

--- a/src/mod/filesystem/metadata/metadata.go
+++ b/src/mod/filesystem/metadata/metadata.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -219,7 +219,7 @@ func (rh *RenderHandler) generateCache(fsh *filesystem.FileSystemHandler, cacheF
 
 func (rh *RenderHandler) fileIsBusy(path string) bool {
 	if rh == nil {
-		log.Println("RenderHandler is null!")
+		metadataLogger.PrintAndLog("Metadata", "RenderHandler is null!", nil)
 		return true
 	}
 	_, ok := rh.renderingFiles.Load(path)
@@ -266,7 +266,7 @@ func (rh *RenderHandler) HandleLoadCache(w http.ResponseWriter, r *http.Request,
 	upgrader.CheckOrigin = func(r *http.Request) bool { return true }
 	c, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Print("upgrade:", err)
+		metadataLogger.PrintAndLog("Metadata", fmt.Sprint("upgrade:", err), nil)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("500 - Internal Server Error"))
 		return

--- a/src/mod/filesystem/metadata/zz_logger.go
+++ b/src/mod/filesystem/metadata/zz_logger.go
@@ -1,0 +1,5 @@
+package metadata
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var metadataLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/renderer/renderer.go
+++ b/src/mod/filesystem/renderer/renderer.go
@@ -6,7 +6,6 @@ import (
 
 	"errors"
 	"image"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,7 +62,7 @@ func (r *Renderer) RenderModel(filename string) (image.Image, error) {
 		}
 		mesh = m
 	} else {
-		log.Println("Not supported format, given: " + filepath.Ext(filename))
+		rendererLogger.PrintAndLog("Renderer", "Not supported format, given: "+filepath.Ext(filename), nil)
 		return nil, errors.New("Not supported model format")
 	}
 

--- a/src/mod/filesystem/renderer/zz_logger.go
+++ b/src/mod/filesystem/renderer/zz_logger.go
@@ -1,0 +1,5 @@
+package renderer
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var rendererLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/static.go
+++ b/src/mod/filesystem/static.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"mime"
 	"os"
 	"os/exec"
@@ -194,9 +193,9 @@ func MountDevice(mountpt string, mountdev string, filesystem string) error {
 		}
 		//Mount the device
 		if CheckMounted(mountpt) {
-			log.Println(mountpt + " already mounted.")
+			filesystemLogger.PrintAndLog("Filesystem", mountpt+" already mounted.", nil)
 		} else {
-			log.Println("Mounting " + mountdev + "(" + filesystem + ") to " + filepath.Clean(mountpt))
+			filesystemLogger.PrintAndLog("Filesystem", "Mounting "+mountdev+"("+filesystem+") to "+filepath.Clean(mountpt), nil)
 			cmd := exec.Command("mount", "-t", filesystem, mountdev, filepath.Clean(mountpt))
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr

--- a/src/mod/filesystem/zz_logger.go
+++ b/src/mod/filesystem/zz_logger.go
@@ -1,0 +1,5 @@
+package filesystem
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var filesystemLogger, _ = logger.NewTmpLogger()

--- a/src/mod/info/hardwareinfo/hardwareinfo.go
+++ b/src/mod/info/hardwareinfo/hardwareinfo.go
@@ -2,7 +2,7 @@ package hardwareinfo
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -58,12 +58,12 @@ PrintSystemHardwareDebugMessage print system information on Windows.
 Which is lagging but helpful for debugging wmic on Windows
 */
 func PrintSystemHardwareDebugMessage() {
-	log.Println("Windows Version: " + wmicGetinfo("os", "Caption")[0])
-	log.Println("Total Memory: " + wmicGetinfo("ComputerSystem", "TotalPhysicalMemory")[0] + "B")
-	log.Println("Processor: " + wmicGetinfo("cpu", "Name")[0])
-	log.Println("Following disk was detected:")
+	hardwareinfoLogger.PrintAndLog("Hardwareinfo", "Windows Version: "+wmicGetinfo("os", "Caption")[0], nil)
+	hardwareinfoLogger.PrintAndLog("Hardwareinfo", "Total Memory: "+wmicGetinfo("ComputerSystem", "TotalPhysicalMemory")[0]+"B", nil)
+	hardwareinfoLogger.PrintAndLog("Hardwareinfo", "Processor: "+wmicGetinfo("cpu", "Name")[0], nil)
+	hardwareinfoLogger.PrintAndLog("Hardwareinfo", "Following disk was detected:", nil)
 	for _, info := range wmicGetinfo("diskdrive", "Model") {
-		log.Println(info)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(info), nil)
 	}
 }
 
@@ -71,7 +71,7 @@ func (s *Server) GetArOZInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(s.hostInfo)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return
 	}
 

--- a/src/mod/info/hardwareinfo/sysinfo.go
+++ b/src/mod/info/hardwareinfo/sysinfo.go
@@ -5,12 +5,13 @@ package hardwareinfo
 
 import (
 	"encoding/json"
-	"imuslab.com/arozos/mod/utils"
-	"log"
+	"fmt"
 	"net/http"
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"imuslab.com/arozos/mod/utils"
 )
 
 func Ifconfig(w http.ResponseWriter, r *http.Request) {
@@ -32,7 +33,7 @@ func Ifconfig(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -76,7 +77,7 @@ func GetDriveStat(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 
@@ -100,7 +101,7 @@ func GetUSB(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -177,7 +178,7 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(CPUInfo)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -196,7 +197,7 @@ func GetRamInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(ramSizeInt)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }

--- a/src/mod/info/hardwareinfo/sysinfo_darwin.go
+++ b/src/mod/info/hardwareinfo/sysinfo_darwin.go
@@ -5,12 +5,13 @@ package hardwareinfo
 
 import (
 	"encoding/json"
-	"imuslab.com/arozos/mod/utils"
-	"log"
+	"fmt"
 	"net/http"
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"imuslab.com/arozos/mod/utils"
 )
 
 /*
@@ -31,7 +32,7 @@ import (
 	CPUFreq: Refers to the CPU frequency in terms of gigahertz, e.g. 0.8GHz
 */
 
-//usbinfo from https://apple.stackexchange.com/questions/170105/list-usb-devices-on-osx-command-line
+// usbinfo from https://apple.stackexchange.com/questions/170105/list-usb-devices-on-osx-command-line
 const unknown_string = "??? "
 const query_frequency_command = "sysctl machdep.cpu.brand_string | awk '{print $NF}'"
 const query_cpumodel_command = "sysctl machdep.cpu.brand_string | awk '{for(i=1;++i<=NF-3;) printf $i\" \"; print $(NF-2)}'"
@@ -47,7 +48,7 @@ func GetCPUFreq() string {
 	shell := exec.Command("bash", "-c", query_frequency_command) // Run command
 	freqByteArr, err := shell.CombinedOutput()                   // Response from cmdline
 	if err != nil {                                              // If done w/ errors then
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -67,7 +68,7 @@ func GetCPUModel() string {
 	shell := exec.Command("bash", "-c", query_cpumodel_command) // Run command
 	modelStr, err := shell.CombinedOutput()                     // Response from cmdline
 	if err != nil {                                             // If done w/ errors then
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -80,7 +81,7 @@ func GetCPUHardware() string {
 	shell := exec.Command("bash", "-c", query_cpuhardware_command) // Run command
 	hwStr, err := shell.CombinedOutput()                           // Response from cmdline
 	if err != nil {                                                // If done w/ errors then
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -93,7 +94,7 @@ func GetCPUArch() string {
 	shell := exec.Command("bash", "-c", query_cpuarch_command) // Run command
 	archStr, err := shell.CombinedOutput()                     // Response from cmdline
 	if err != nil {                                            // If done w/ errors then
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -113,7 +114,7 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(CPUInfo)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -138,7 +139,7 @@ func Ifconfig(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -183,7 +184,7 @@ func GetDriveStat(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 
@@ -210,7 +211,7 @@ func GetUSB(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -231,7 +232,7 @@ func GetRamInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(ramSizeInt)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }

--- a/src/mod/info/hardwareinfo/sysinfo_freebsd.go
+++ b/src/mod/info/hardwareinfo/sysinfo_freebsd.go
@@ -5,12 +5,13 @@ package hardwareinfo
 
 import (
 	"encoding/json"
-	"imuslab.com/arozos/mod/utils"
-	"log"
+	"fmt"
 	"net/http"
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"imuslab.com/arozos/mod/utils"
 )
 
 /*
@@ -44,7 +45,7 @@ func GetCPUFreq() string {
 	shell := exec.Command("bash", "-c", query_frequency_command) // Run command
 	freqByteArr, err := shell.CombinedOutput()                   // Response from cmdline
 	if err != nil {                                              // If done w/ errors then
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -64,7 +65,7 @@ func GetCPUModel() string {
 	shell := exec.Command("bash", "-c", query_cpumodel_command) // Run command
 	modelStr, err := shell.CombinedOutput()                     // Response from cmdline
 	if err != nil {                                             // If done w/ errors then
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -77,7 +78,7 @@ func GetCPUHardware() string {
 	shell := exec.Command("bash", "-c", query_cpuhardware_command) // Run command
 	hwStr, err := shell.CombinedOutput()                           // Response from cmdline
 	if err != nil {                                                // If done w/ errors then
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -90,7 +91,7 @@ func GetCPUArch() string {
 	shell := exec.Command("bash", "-c", query_cpuarch_command) // Run command
 	archStr, err := shell.CombinedOutput()                     // Response from cmdline
 	if err != nil {                                            // If done w/ errors then
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -110,7 +111,7 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(CPUInfo)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -135,7 +136,7 @@ func Ifconfig(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -180,7 +181,7 @@ func GetDriveStat(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 
@@ -207,7 +208,7 @@ func GetUSB(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -228,7 +229,7 @@ func GetRamInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(ramSizeInt)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }

--- a/src/mod/info/hardwareinfo/sysinfo_window.go
+++ b/src/mod/info/hardwareinfo/sysinfo_window.go
@@ -5,7 +5,7 @@ package hardwareinfo
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -25,7 +25,7 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(CPUInfo)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -39,7 +39,7 @@ func Ifconfig(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -63,7 +63,7 @@ func GetDriveStat(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -77,7 +77,7 @@ func GetUSB(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(arr)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -92,7 +92,7 @@ func GetRamInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(RAMsize)
 	if err != nil {
-		log.Println(err)
+		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }

--- a/src/mod/info/hardwareinfo/zz_logger.go
+++ b/src/mod/info/hardwareinfo/zz_logger.go
@@ -1,0 +1,5 @@
+package hardwareinfo
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var hardwareinfoLogger, _ = logger.NewTmpLogger()

--- a/src/mod/iot/handlerManager.go
+++ b/src/mod/iot/handlerManager.go
@@ -2,7 +2,7 @@ package iot
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 
 	"imuslab.com/arozos/mod/database"
@@ -44,7 +44,7 @@ func (m *Manager) RegisterHandler(h ProtocolHandler) error {
 	err := h.Start()
 	if err != nil {
 		//Handler startup failed
-		log.Println("[IoT] *ERROR* Protocol Handler Startup Failed: ", err.Error())
+		iotLogger.PrintAndLog("Iot", fmt.Sprint("[IoT] *ERROR* Protocol Handler Startup Failed: ", err.Error()), nil)
 		return err
 	}
 
@@ -205,7 +205,7 @@ func (m *Manager) ScanDevices() []*Device {
 		//Scan devices using this handler
 		thisProtcolDeviceList, err := ph.Scan()
 		if err != nil {
-			log.Println("[IoT] *ERROR* Scan Error: " + err.Error())
+			iotLogger.PrintAndLog("Iot", "[IoT] *ERROR* Scan Error: "+err.Error(), nil)
 			continue
 		}
 

--- a/src/mod/iot/hds/hds.go
+++ b/src/mod/iot/hds/hds.go
@@ -2,7 +2,7 @@ package hds
 
 import (
 	"errors"
-	"log"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,19 +24,19 @@ type Handler struct {
 	lastScanTime int64
 }
 
-//Create a new HDS Protocol Handler
+// Create a new HDS Protocol Handler
 func NewProtocolHandler() *Handler {
 	//Create a new MDNS Host
 	return &Handler{}
 }
 
-//Start the HDSv1 scanner, which no startup process is required
+// Start the HDSv1 scanner, which no startup process is required
 func (h *Handler) Start() error {
-	log.Println("[IoT] Home Dynamic System (Legacy) Loaded")
+	hdsLogger.PrintAndLog("Hds", "[IoT] Home Dynamic System (Legacy) Loaded", nil)
 	return nil
 }
 
-//Scan all the HDS devices in LAN using the legacy ip scanner methods
+// Scan all the HDS devices in LAN using the legacy ip scanner methods
 func (h *Handler) Scan() ([]*iot.Device, error) {
 	//Get the current local IP address
 	ip := getLocalIP()
@@ -68,7 +68,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 
 	//Check if the IP range is supported by HDS protocol
 	if !valid {
-		log.Println("[IoT] Home Dynamic Protocol requirement not satisfied. Skipping Scan")
+		hdsLogger.PrintAndLog("Hds", "[IoT] Home Dynamic Protocol requirement not satisfied. Skipping Scan", nil)
 		return nil, nil
 	}
 
@@ -138,7 +138,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 				ControlEndpoints: endpoints,
 			})
 
-			log.Println("*HDS* Found device ", devName, " at ", targetIP, " with UUID ", uuid)
+			hdsLogger.PrintAndLog("Hds", fmt.Sprint("*HDS* Found device ", devName, " at ", targetIP, " with UUID ", uuid), nil)
 		}(&wg)
 	}
 
@@ -147,22 +147,22 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 	return results, nil
 }
 
-//Home Dynamic system's devices no need to established conenction before executing anything
+// Home Dynamic system's devices no need to established conenction before executing anything
 func (h *Handler) Connect(device *iot.Device, authInfo *iot.AuthInfo) error {
 	return nil
 }
 
-//Same rules also apply to disconnect
+// Same rules also apply to disconnect
 func (h *Handler) Disconnect(device *iot.Device) error {
 	return nil
 }
 
-//Get the icon filename of the device, it is always switch for hdsv1
+// Get the icon filename of the device, it is always switch for hdsv1
 func (h *Handler) Icon(device *iot.Device) string {
 	return "switch"
 }
 
-//Get the status of the device
+// Get the status of the device
 func (h *Handler) Execute(device *iot.Device, endpoint *iot.Endpoint, payload interface{}) (interface{}, error) {
 	//GET request the target device endpoint
 	resp, err := tryGet("http://" + device.IPAddr + ":" + strconv.Itoa(device.Port) + "/" + endpoint.RelPath)
@@ -173,7 +173,7 @@ func (h *Handler) Execute(device *iot.Device, endpoint *iot.Endpoint, payload in
 	return resp, nil
 }
 
-//Get the status of the device
+// Get the status of the device
 func (h *Handler) Status(device *iot.Device) (map[string]interface{}, error) {
 	resp, err := tryGet("http://" + device.IPAddr + "/status")
 	if err != nil {
@@ -187,7 +187,7 @@ func (h *Handler) Status(device *iot.Device) (map[string]interface{}, error) {
 	return result, nil
 }
 
-//Return the specification of this protocol handler
+// Return the specification of this protocol handler
 func (h *Handler) Stats() iot.Stats {
 	return iot.Stats{
 		Name:          "Home Dynamic",

--- a/src/mod/iot/hds/utils.go
+++ b/src/mod/iot/hds/utils.go
@@ -3,8 +3,8 @@ package hds
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"strconv"
@@ -46,7 +46,7 @@ func tryGetHDSUUID(ip string) (string, error) {
 		return "", err
 	}
 
-	log.Println(ip, uuid)
+	hdsLogger.PrintAndLog("Hds", fmt.Sprint(ip, uuid), nil)
 	return uuid, nil
 }
 

--- a/src/mod/iot/hds/zz_logger.go
+++ b/src/mod/iot/hds/zz_logger.go
@@ -1,0 +1,5 @@
+package hds
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var hdsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/iot/hdsv2/hdsv2.go
+++ b/src/mod/iot/hdsv2/hdsv2.go
@@ -3,8 +3,8 @@ package hdsv2
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -37,7 +37,7 @@ func NewProtocolHandler(scanner *mdns.MDNSHost) *Handler {
 }
 
 func (h *Handler) Start() error {
-	log.Println("[IoT] Home Dynamic v2 Loaded")
+	hdsv2Logger.PrintAndLog("Hdsv2", "[IoT] Home Dynamic v2 Loaded", nil)
 	return nil
 }
 
@@ -74,7 +74,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 		status, err := getStatusForDevice(&thisDevice)
 		if err != nil {
 			//This might be not a valid HDSv2 device. Skip this
-			log.Println("*HDSv2* Get status failed for device: ", host.HostName, err.Error())
+			hdsv2Logger.PrintAndLog("Hdsv2", fmt.Sprint("*HDSv2* Get status failed for device: ", host.HostName, err.Error()), nil)
 			continue
 		}
 		thisDevice.Status = status
@@ -83,7 +83,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 		eps, err := getEndpoints(&thisDevice)
 		if err != nil {
 			//This might be not a valid HDSv2 device. Skip this
-			log.Println("*HDSv2* Get endpoints failed for device: ", host.HostName, err.Error())
+			hdsv2Logger.PrintAndLog("Hdsv2", fmt.Sprint("*HDSv2* Get endpoints failed for device: ", host.HostName, err.Error()), nil)
 			continue
 		}
 		thisDevice.ControlEndpoints = eps

--- a/src/mod/iot/hdsv2/zz_logger.go
+++ b/src/mod/iot/hdsv2/zz_logger.go
@@ -1,0 +1,5 @@
+package hdsv2
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var hdsv2Logger, _ = logger.NewTmpLogger()

--- a/src/mod/iot/sonoff_s2x/sonoff_s2x.go
+++ b/src/mod/iot/sonoff_s2x/sonoff_s2x.go
@@ -1,7 +1,6 @@
 package sonoff_s2x
 
 import (
-	"log"
 	"regexp"
 	"strings"
 
@@ -35,7 +34,7 @@ func NewProtocolHandler(scanner *mdns.MDNSHost) *Handler {
 }
 
 func (h *Handler) Start() error {
-	log.Println("[IoT] Sonoff Tasmoto S2X 6.4 scanner loaded")
+	sonoff_s2xLogger.PrintAndLog("Sonoff_s2x", "[IoT] Sonoff Tasmoto S2X 6.4 scanner loaded", nil)
 	return nil
 }
 
@@ -52,7 +51,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 			value, err := tryGet("http://" + dev.IPv4[0].String() + "/")
 			if err != nil {
 				//This things is not sonoff smart socket
-				log.Println(dev.HostName + " is not sonoff")
+				sonoff_s2xLogger.PrintAndLog("Sonoff_s2x", dev.HostName+" is not sonoff", nil)
 				continue
 			}
 
@@ -63,7 +62,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 				info, err := tryGet("http://" + dev.IPv4[0].String() + "/in")
 				if err != nil {
 					//This things is not sonoff smart socket
-					log.Println(dev.HostName + " failed to extract its MAC address from /in page")
+					sonoff_s2xLogger.PrintAndLog("Sonoff_s2x", dev.HostName+" failed to extract its MAC address from /in page", nil)
 					continue
 				}
 

--- a/src/mod/iot/sonoff_s2x/zz_logger.go
+++ b/src/mod/iot/sonoff_s2x/zz_logger.go
@@ -1,0 +1,5 @@
+package sonoff_s2x
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var sonoff_s2xLogger, _ = logger.NewTmpLogger()

--- a/src/mod/iot/zz_logger.go
+++ b/src/mod/iot/zz_logger.go
@@ -1,0 +1,5 @@
+package iot
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var iotLogger, _ = logger.NewTmpLogger()

--- a/src/mod/media/transcoder/transcoder.go
+++ b/src/mod/media/transcoder/transcoder.go
@@ -8,8 +8,8 @@ package transcoder
 */
 
 import (
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os/exec"
 	"time"
@@ -64,7 +64,7 @@ func TranscodeAndStream(w http.ResponseWriter, r *http.Request, inputFile string
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		http.Error(w, "Failed to create error pipe", http.StatusInternalServerError)
-		log.Printf("Failed to create error pipe: %v", err)
+		transcoderLogger.PrintAndLog("Transcoder", fmt.Sprintf("Failed to create error pipe: %v", err), nil)
 		return
 	}
 
@@ -99,18 +99,18 @@ func TranscodeAndStream(w http.ResponseWriter, r *http.Request, inputFile string
 	go func() {
 		errOutput, _ := io.ReadAll(stderr)
 		if len(errOutput) > 0 {
-			log.Printf("FFmpeg error output: %s", string(errOutput))
+			transcoderLogger.PrintAndLog("Transcoder", fmt.Sprintf("FFmpeg error output: %s", string(errOutput)), nil)
 		}
 	}()
 
 	go func() {
 		if err := cmd.Wait(); err != nil {
-			log.Printf("FFmpeg process exited: %v", err)
+			transcoderLogger.PrintAndLog("Transcoder", fmt.Sprintf("FFmpeg process exited: %v", err), nil)
 			return
 		}
 	}()
 
 	// Wait for the command to finish or client disconnect
 	<-done
-	log.Println("[Media Server] Transcode client disconnected")
+	transcoderLogger.PrintAndLog("Transcoder", "[Media Server] Transcode client disconnected", nil)
 }

--- a/src/mod/media/transcoder/zz_logger.go
+++ b/src/mod/media/transcoder/zz_logger.go
@@ -1,0 +1,5 @@
+package transcoder
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var transcoderLogger, _ = logger.NewTmpLogger()

--- a/src/mod/modules/installer.go
+++ b/src/mod/modules/installer.go
@@ -3,8 +3,8 @@ package modules
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -63,7 +63,7 @@ func (m *ModuleHandler) InstallViaZip(realpath string, gateway *agi.Gateway) err
 			os.RemoveAll(destPath)
 		}
 		if err := os.Rename(folder, destPath); err != nil {
-			log.Println("*Module Installer* Failed to move module:", err)
+			modulesLogger.PrintAndLog("Modules", fmt.Sprint("*Module Installer* Failed to move module:", err), nil)
 			return errors.New("Failed to install " + filepath.Base(folder) + ": " + err.Error())
 		}
 		installedFolders = append(installedFolders, destPath)
@@ -98,7 +98,7 @@ func (m *ModuleHandler) ReloadAllModules(gateway *agi.Gateway) error {
 // Install a module via git clone
 func (m *ModuleHandler) InstallModuleViaGit(gitURL string, gateway *agi.Gateway) error {
 	//Download the module from the gitURL
-	log.Println("Starting module installation by Git cloning ", gitURL)
+	modulesLogger.PrintAndLog("Modules", fmt.Sprint("Starting module installation by Git cloning ", gitURL), nil)
 	newDownloadUUID := uuid.NewV4().String()
 	downloadFolder := filepath.Join(m.tmpDirectory, "download", newDownloadUUID)
 	os.MkdirAll(downloadFolder, 0777)
@@ -131,7 +131,7 @@ func (m *ModuleHandler) InstallModuleViaGit(gitURL string, gateway *agi.Gateway)
 	/*
 		for _, src := range copyPendingList {
 			fs.FileCopy(src, "./web/", "skip", func(progress int, filename string) {
-				log.Println("Copying ", filename)
+				modulesLogger.PrintAndLog("Modules", fmt.Sprint("Copying ", filename), nil)
 			})
 		}
 	*/
@@ -159,15 +159,15 @@ func (m *ModuleHandler) ActivateModuleByRoot(moduleFolder string, gateway *agi.G
 			//Load this as an module
 			startDef, err := os.ReadFile(filepath.Join(thisModuleEstimataedRoot, "init.agi"))
 			if err != nil {
-				log.Println("*Module Activator* Failed to read init.agi from " + filepath.Base(moduleFolder))
+				modulesLogger.PrintAndLog("Modules", "*Module Activator* Failed to read init.agi from "+filepath.Base(moduleFolder), nil)
 				return errors.New("Failed to read init.agi from " + filepath.Base(moduleFolder))
 			}
 
 			//Execute the init script using AGI
-			log.Println("Starting module: ", filepath.Base(moduleFolder))
+			modulesLogger.PrintAndLog("Modules", fmt.Sprint("Starting module: ", filepath.Base(moduleFolder)), nil)
 			err = gateway.RunScript(string(startDef))
 			if err != nil {
-				log.Println("*Module Activator* " + filepath.Base(moduleFolder) + " Starting failed" + err.Error())
+				modulesLogger.PrintAndLog("Modules", "*Module Activator* "+filepath.Base(moduleFolder)+" Starting failed"+err.Error(), nil)
 				return errors.New(filepath.Base(moduleFolder) + " Starting failed: " + err.Error())
 
 			}
@@ -208,7 +208,7 @@ func (m *ModuleHandler) HandleModuleInstallationListing(w http.ResponseWriter, r
 		// Folder mod time (kept for backward compat)
 		mtime, err := fs.GetModTime(dirPath)
 		if err != nil {
-			log.Println(err)
+			modulesLogger.PrintAndLog("Modules", fmt.Sprint(err), nil)
 		}
 		t := time.Unix(mtime, 0)
 
@@ -263,7 +263,7 @@ func (m *ModuleHandler) UninstallModule(moduleName string) error {
 	//Check if the module exists
 	if utils.FileExists(filepath.Join("./web", moduleName)) {
 		//Remove the module
-		log.Println("Removing Module: ", moduleName)
+		modulesLogger.PrintAndLog("Modules", fmt.Sprint("Removing Module: ", moduleName), nil)
 		os.RemoveAll(filepath.Join("./web", moduleName))
 
 		//Unregister the module from loaded list

--- a/src/mod/modules/zz_logger.go
+++ b/src/mod/modules/zz_logger.go
@@ -1,0 +1,5 @@
+package modules
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var modulesLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/dynamicproxy/dpcore/dpcore.go
+++ b/src/mod/network/dynamicproxy/dpcore/dpcore.go
@@ -188,7 +188,7 @@ func (p *ReverseProxy) logf(format string, args ...interface{}) {
 	if p.ErrorLog != nil {
 		p.ErrorLog.Printf(format, args...)
 	} else {
-		log.Printf(format, args...)
+		dpcoreLogger.PrintAndLog("Dpcore", fmt.Sprintf(format, args...), nil)
 	}
 }
 

--- a/src/mod/network/dynamicproxy/dpcore/zz_logger.go
+++ b/src/mod/network/dynamicproxy/dpcore/zz_logger.go
@@ -1,0 +1,5 @@
+package dpcore
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var dpcoreLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/dynamicproxy/dynamicproxy.go
+++ b/src/mod/network/dynamicproxy/dynamicproxy.go
@@ -3,7 +3,7 @@ package dynamicproxy
 import (
 	"context"
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,8 +16,7 @@ import (
 )
 
 /*
-	Allow users to setup manual proxying for specific path
-
+Allow users to setup manual proxying for specific path
 */
 type Router struct {
 	ListenPort        int
@@ -71,7 +70,7 @@ func NewDynamicProxy(port int) (*Router, error) {
 	return &thisRouter, nil
 }
 
-//Start the dynamic routing
+// Start the dynamic routing
 func (router *Router) StartProxyService() error {
 	//Create a new server object
 	if router.server != nil {
@@ -86,7 +85,7 @@ func (router *Router) StartProxyService() error {
 	router.Running = true
 	go func() {
 		err := router.server.ListenAndServe()
-		log.Println("[DynamicProxy] " + err.Error())
+		dynamicproxyLogger.PrintAndLog("Dynamicproxy", "[DynamicProxy] "+err.Error(), nil)
 	}()
 
 	return nil
@@ -110,7 +109,7 @@ func (router *Router) StopProxyService() error {
 }
 
 /*
-	Add an URL into a custom proxy services
+Add an URL into a custom proxy services
 */
 func (router *Router) AddProxyService(rootname string, domain string, requireTLS bool) error {
 	if domain[len(domain)-1:] == "/" {
@@ -138,12 +137,12 @@ func (router *Router) AddProxyService(rootname string, domain string, requireTLS
 		Proxy:      proxy,
 	})
 
-	log.Println("Adding Proxy Rule: ", rootname+" to "+domain)
+	dynamicproxyLogger.PrintAndLog("Dynamicproxy", fmt.Sprint("Adding Proxy Rule: ", rootname+" to "+domain), nil)
 	return nil
 }
 
 /*
-	Add an default router for the proxy server
+Add an default router for the proxy server
 */
 func (router *Router) SetRootProxy(proxyLocation string, requireTLS bool) error {
 	if proxyLocation[len(proxyLocation)-1:] == "/" {
@@ -175,7 +174,7 @@ func (router *Router) SetRootProxy(proxyLocation string, requireTLS bool) error 
 	return nil
 }
 
-//Do all the main routing in here
+// Do all the main routing in here
 func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(r.Host, ".") {
 		//This might be a subdomain. See if there are any subdomain proxy router for this

--- a/src/mod/network/dynamicproxy/proxyRequestHandler.go
+++ b/src/mod/network/dynamicproxy/proxyRequestHandler.go
@@ -1,7 +1,6 @@
 package dynamicproxy
 
 import (
-	"log"
 	"net/http"
 	"net/url"
 
@@ -66,7 +65,7 @@ func (h *ProxyHandler) subdomainRequest(w http.ResponseWriter, r *http.Request, 
 	r.Host = r.URL.Host
 	err := target.Proxy.ServeHTTP(w, r)
 	if err != nil {
-		log.Println(err.Error())
+		dynamicproxyLogger.PrintAndLog("Dynamicproxy", err.Error(), nil)
 	}
 
 }
@@ -94,6 +93,6 @@ func (h *ProxyHandler) proxyRequest(w http.ResponseWriter, r *http.Request, targ
 	r.Host = r.URL.Host
 	err := target.Proxy.ServeHTTP(w, r)
 	if err != nil {
-		log.Println(err.Error())
+		dynamicproxyLogger.PrintAndLog("Dynamicproxy", err.Error(), nil)
 	}
 }

--- a/src/mod/network/dynamicproxy/subdomain.go
+++ b/src/mod/network/dynamicproxy/subdomain.go
@@ -1,7 +1,7 @@
 package dynamicproxy
 
 import (
-	"log"
+	"fmt"
 	"net/url"
 
 	"imuslab.com/arozos/mod/network/reverseproxy"
@@ -39,6 +39,6 @@ func (router *Router) AddSubdomainRoutingService(hostnameWithSubdomain string, d
 		Proxy:          proxy,
 	})
 
-	log.Println("Adding Subdomain Rule: ", hostnameWithSubdomain+" to "+domain)
+	dynamicproxyLogger.PrintAndLog("Dynamicproxy", fmt.Sprint("Adding Subdomain Rule: ", hostnameWithSubdomain+" to "+domain), nil)
 	return nil
 }

--- a/src/mod/network/dynamicproxy/zz_logger.go
+++ b/src/mod/network/dynamicproxy/zz_logger.go
@@ -1,0 +1,5 @@
+package dynamicproxy
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var dynamicproxyLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/mdns/mdns.go
+++ b/src/mod/network/mdns/mdns.go
@@ -2,8 +2,9 @@ package mdns
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -42,13 +43,13 @@ func NewMDNS(config NetworkHost, MacOverride string) (*MDNSHost, error) {
 	if err == nil {
 		macAddressBoardcast = strings.Join(macAddress, ",")
 	} else {
-		log.Println("[mDNS] Unable to get MAC Address: ", err.Error())
+		mdnsLogger.PrintAndLog("Mdns", fmt.Sprint("[mDNS] Unable to get MAC Address: ", err.Error()), nil)
 	}
 
 	//Register the mds services
 	server, err := zeroconf.Register(config.HostName, "_http._tcp", "local.", config.Port, []string{"version_build=" + config.BuildVersion, "version_minor=" + config.MinorVersion, "vendor=" + config.Vendor, "model=" + config.Model, "uuid=" + config.UUID, "domain=" + config.Domain, "mac_addr=" + macAddressBoardcast}, nil)
 	if err != nil {
-		log.Println("[mDNS] Error when registering zeroconf broadcast message", err.Error())
+		mdnsLogger.PrintAndLog("Mdns", fmt.Sprint("[mDNS] Error when registering zeroconf broadcast message", err.Error()), nil)
 		return &MDNSHost{}, err
 	}
 
@@ -58,7 +59,7 @@ func NewMDNS(config NetworkHost, MacOverride string) (*MDNSHost, error) {
 		ifaceIp := ""
 		ifaces, err := net.Interfaces()
 		if err != nil {
-			log.Println("[mDNS] Unable to override iface MAC: " + err.Error() + ". Resuming with default iface")
+			mdnsLogger.PrintAndLog("Mdns", "[mDNS] Unable to override iface MAC: "+err.Error()+". Resuming with default iface", nil)
 		}
 
 		foundMatching := false
@@ -95,9 +96,9 @@ func NewMDNS(config NetworkHost, MacOverride string) (*MDNSHost, error) {
 		}
 
 		if !foundMatching {
-			log.Println("[mDNS] Unable to find the target iface with MAC address: " + MacOverride + ". Resuming with default iface")
+			mdnsLogger.PrintAndLog("Mdns", "[mDNS] Unable to find the target iface with MAC address: "+MacOverride+". Resuming with default iface", nil)
 		} else {
-			log.Println("[mDNS] Entering force MAC address mode, listening on: " + MacOverride + "(IP address: " + ifaceIp + ")")
+			mdnsLogger.PrintAndLog("Mdns", "[mDNS] Entering force MAC address mode, listening on: "+MacOverride+"(IP address: "+ifaceIp+")", nil)
 		}
 	}
 
@@ -126,7 +127,8 @@ func (m *MDNSHost) Scan(timeout int, domainFilter string) []*NetworkHost {
 
 	resolver, err := zeroconf.NewResolver(zcoption)
 	if err != nil {
-		log.Fatalln("Failed to initialize resolver:", err.Error())
+		mdnsLogger.PrintAndLog("Mdns", fmt.Sprint("Failed to initialize resolver:", err.Error()), nil)
+		os.Exit(1)
 	}
 
 	entries := make(chan *zeroconf.ServiceEntry)
@@ -220,7 +222,8 @@ func (m *MDNSHost) Scan(timeout int, domainFilter string) []*NetworkHost {
 	defer cancel()
 	err = resolver.Browse(ctx, "_http._tcp", "local.", entries)
 	if err != nil {
-		log.Fatalln("Failed to browse:", err.Error())
+		mdnsLogger.PrintAndLog("Mdns", fmt.Sprint("Failed to browse:", err.Error()), nil)
+		os.Exit(1)
 	}
 
 	//Update the master scan record

--- a/src/mod/network/mdns/zz_logger.go
+++ b/src/mod/network/mdns/zz_logger.go
@@ -1,0 +1,5 @@
+package mdns
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var mdnsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/neighbour/neighbour.go
+++ b/src/mod/network/neighbour/neighbour.go
@@ -2,7 +2,7 @@ package neighbour
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"time"
 
 	"imuslab.com/arozos/mod/cluster/wakeonlan"
@@ -64,7 +64,7 @@ func (d *Discoverer) GetNearbyHosts() []*mdns.NetworkHost {
 
 // Start Scanning, interval and scan Duration in seconds
 func (d *Discoverer) StartScanning(interval int, scanDuration int) {
-	log.Println("ArozOS Neighbour Scanning Started")
+	neighbourLogger.PrintAndLog("Neighbour", "ArozOS Neighbour Scanning Started", nil)
 	if d.ScannerRunning() {
 		//Another scanner already running. Terminate it
 		d.StopScanning()
@@ -89,7 +89,7 @@ func (d *Discoverer) StartScanning(interval int, scanDuration int) {
 	go func() {
 		//Run initial scanning
 		d.UpdateScan(scanDuration)
-		log.Println("ArozOS Neighbour Scanning Completed, ", len(d.NearbyHosts), " neighbours found!")
+		neighbourLogger.PrintAndLog("Neighbour", fmt.Sprint("ArozOS Neighbour Scanning Completed, ", len(d.NearbyHosts), " neighbours found!"), nil)
 	}()
 
 	//Update the Discoverer settings
@@ -135,7 +135,7 @@ func (d *Discoverer) GetOfflineHosts() ([]*HostRecord, error) {
 
 		if time.Now().Unix()-thisHostRecord.LastOnline > AutoDeleteRecordTime {
 			//Remove this record
-			log.Println("[Neighbour] Removing network host record due to long period offline: " + thisHostUUID + " (" + thisHostRecord.Name + ")")
+			neighbourLogger.PrintAndLog("Neighbour", "[Neighbour] Removing network host record due to long period offline: "+thisHostUUID+" ("+thisHostRecord.Name+")", nil)
 			d.Database.Delete("neighbour", thisHostUUID)
 			continue
 		}
@@ -181,5 +181,5 @@ func (d *Discoverer) StopScanning() {
 		d.d = nil
 		d.t = nil
 	}
-	log.Println("ArozOS Neighbour Scanning Stopped")
+	neighbourLogger.PrintAndLog("Neighbour", "ArozOS Neighbour Scanning Stopped", nil)
 }

--- a/src/mod/network/neighbour/zz_logger.go
+++ b/src/mod/network/neighbour/zz_logger.go
@@ -1,0 +1,5 @@
+package neighbour
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var neighbourLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/network.go
+++ b/src/mod/network/network.go
@@ -3,8 +3,8 @@ package network
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -178,7 +178,7 @@ func GetNICInfo(w http.ResponseWriter, r *http.Request) {
 
 	jsonData, err := json.Marshal(NICList)
 	if err != nil {
-		log.Println(err)
+		networkLogger.PrintAndLog("Network", fmt.Sprint(err), nil)
 		utils.SendErrorResponse(w, "Failed to encode NIC data")
 		return
 	}

--- a/src/mod/network/reverseproxy/reverse.go
+++ b/src/mod/network/reverseproxy/reverse.go
@@ -2,6 +2,7 @@ package reverseproxy
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -188,7 +189,7 @@ func (p *ReverseProxy) logf(format string, args ...interface{}) {
 	if p.ErrorLog != nil {
 		p.ErrorLog.Printf(format, args...)
 	} else {
-		log.Printf(format, args...)
+		reverseproxyLogger.PrintAndLog("Reverseproxy", fmt.Sprintf(format, args...), nil)
 	}
 }
 

--- a/src/mod/network/reverseproxy/zz_logger.go
+++ b/src/mod/network/reverseproxy/zz_logger.go
@@ -1,0 +1,5 @@
+package reverseproxy
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var reverseproxyLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/ssdp/ssdp.go
+++ b/src/mod/network/ssdp/ssdp.go
@@ -2,7 +2,6 @@ package ssdp
 
 import (
 	"errors"
-	"log"
 	"net"
 	"net/http"
 	"os/exec"
@@ -40,11 +39,11 @@ func NewSSDPHost(outboundIP string, port int, templateFile string, option SSDPOp
 		interfaceName, err := getFirstNetworkInterfaceName()
 		if err != nil {
 			//Ignore the interface binding
-			log.Println("[WARN] No connected network interface. Starting SSDP anyway.")
+			ssdpLogger.PrintAndLog("Ssdp", "[WARN] No connected network interface. Starting SSDP anyway.", nil)
 		} else {
 			mainNIC, err := net.InterfaceByName(interfaceName)
 			if err != nil {
-				log.Println("[WARN] Unable to get interface by name: " + interfaceName + ". Starting SSDP on all IPv4 interfaces.")
+				ssdpLogger.PrintAndLog("Ssdp", "[WARN] Unable to get interface by name: "+interfaceName+". Starting SSDP on all IPv4 interfaces.", nil)
 			} else {
 				ssdp.Interfaces = []net.Interface{*mainNIC}
 			}
@@ -73,7 +72,7 @@ func NewSSDPHost(outboundIP string, port int, templateFile string, option SSDPOp
 func (a *SSDPHost) Start() {
 	//Advertise ssdp
 	http.HandleFunc("/ssdp.xml", a.handleSSDP)
-	log.Println("Starting SSDP Discovery Service: " + a.Option.URLBase)
+	ssdpLogger.PrintAndLog("Ssdp", "Starting SSDP Discovery Service: "+a.Option.URLBase, nil)
 	var aliveTick <-chan time.Time
 	aliveTick = time.Tick(time.Duration(5) * time.Second)
 

--- a/src/mod/network/ssdp/zz_logger.go
+++ b/src/mod/network/ssdp/zz_logger.go
@@ -1,0 +1,5 @@
+package ssdp
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var ssdpLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/upnp/upnp.go
+++ b/src/mod/network/upnp/upnp.go
@@ -2,7 +2,7 @@ package upnp
 
 import (
 	"errors"
-	"log"
+	"fmt"
 	"sync"
 	"time"
 
@@ -25,7 +25,7 @@ type UPnPClient struct {
 
 func NewUPNPClient(basePort int, hostname string) (*UPnPClient, error) {
 	//Create uPNP forwarding in the NAT router
-	log.Println("Discovering UPnP router in Local Area Network...")
+	upnpLogger.PrintAndLog("Upnp", "Discovering UPnP router in Local Area Network...", nil)
 	d, err := upnp.Discover()
 	if err != nil {
 		return &UPnPClient{}, err
@@ -54,7 +54,7 @@ func NewUPNPClient(basePort int, hostname string) (*UPnPClient, error) {
 }
 
 func (u *UPnPClient) ForwardPort(portNumber int, ruleName string) error {
-	log.Println("UPnP forwarding new port: ", portNumber, "for "+ruleName+" service")
+	upnpLogger.PrintAndLog("Upnp", fmt.Sprint("UPnP forwarding new port: ", portNumber, "for "+ruleName+" service"), nil)
 
 	//Check if port already forwarded
 	_, ok := u.PolicyNames.Load(portNumber)
@@ -91,21 +91,21 @@ func (u *UPnPClient) ClosePort(portNumber int) error {
 		u.RequiredPorts = newRequiredPort
 
 		// Close the port
-		log.Println("Closing UPnP Port Forward: ", portNumber)
+		upnpLogger.PrintAndLog("Upnp", fmt.Sprint("Closing UPnP Port Forward: ", portNumber), nil)
 		err := u.Connection.Clear(uint16(portNumber))
 
 		//Delete the name registry
 		u.PolicyNames.Delete(portNumber)
 
 		if err != nil {
-			log.Println(err)
+			upnpLogger.PrintAndLog("Upnp", fmt.Sprint(err), nil)
 			return err
 		}
 	}
 	return nil
 }
 
-//Renew forward rules, prevent router lease time from flushing the Upnp config
+// Renew forward rules, prevent router lease time from flushing the Upnp config
 func (u *UPnPClient) RenewForwardRules() {
 	portsToRenew := u.RequiredPorts
 	for _, thisPort := range portsToRenew {
@@ -117,7 +117,7 @@ func (u *UPnPClient) RenewForwardRules() {
 		time.Sleep(100 * time.Millisecond)
 		u.ForwardPort(thisPort, ruleName.(string))
 	}
-	log.Println("UPnP Port Forward rule renew completed")
+	upnpLogger.PrintAndLog("Upnp", "UPnP Port Forward rule renew completed", nil)
 }
 
 func (u *UPnPClient) Close() {
@@ -126,7 +126,7 @@ func (u *UPnPClient) Close() {
 		for _, portNumber := range u.RequiredPorts {
 			err := u.Connection.Clear(uint16(portNumber))
 			if err != nil {
-				log.Println(err)
+				upnpLogger.PrintAndLog("Upnp", fmt.Sprint(err), nil)
 			}
 		}
 	}

--- a/src/mod/network/upnp/zz_logger.go
+++ b/src/mod/network/upnp/zz_logger.go
@@ -1,0 +1,5 @@
+package upnp
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var upnpLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/webdav/litmus_test_server.go
+++ b/src/mod/network/webdav/litmus_test_server.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 /*
@@ -23,6 +24,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 
 	"golang.org/x/net/webdav"
 )
@@ -48,9 +50,9 @@ func main() {
 					dst = u.Path
 				}
 				o := r.Header.Get("Overwrite")
-				log.Printf("%-20s%-10s%-30s%-30so=%-2s%v", litmus, r.Method, r.URL.Path, dst, o, err)
+				systemWideLogger.PrintAndLog("System", fmt.Sprintf("%-20s%-10s%-30s%-30so=%-2s%v", litmus, r.Method, r.URL.Path, dst, o, err), nil)
 			default:
-				log.Printf("%-20s%-10s%-30s%v", litmus, r.Method, r.URL.Path, err)
+				systemWideLogger.PrintAndLog("System", fmt.Sprintf("%-20s%-10s%-30s%v", litmus, r.Method, r.URL.Path, err), nil)
 			}
 		},
 	}
@@ -89,6 +91,7 @@ func main() {
 	}))
 
 	addr := fmt.Sprintf(":%d", *port)
-	log.Printf("Serving %v", addr)
-	log.Fatal(http.ListenAndServe(addr, nil))
+	systemWideLogger.PrintAndLog("System", fmt.Sprintf("Serving %v", addr), nil)
+	systemWideLogger.PrintAndLog("System", fmt.Sprint(http.ListenAndServe(addr), nil), nil)
+	os.Exit(1)
 }

--- a/src/mod/network/websocketproxy/websocketproxy.go
+++ b/src/mod/network/websocketproxy/websocketproxy.go
@@ -4,7 +4,6 @@ package websocketproxy
 import (
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -68,14 +67,14 @@ func NewProxy(target *url.URL) *WebsocketProxy {
 // ServeHTTP implements the http.Handler that proxies WebSocket connections.
 func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if w.Backend == nil {
-		log.Println("websocketproxy: backend function is not defined")
+		websocketproxyLogger.PrintAndLog("Websocketproxy", "websocketproxy: backend function is not defined", nil)
 		http.Error(rw, "internal server error (code: 1)", http.StatusInternalServerError)
 		return
 	}
 
 	backendURL := w.Backend(req)
 	if backendURL == nil {
-		log.Println("websocketproxy: backend URL is nil")
+		websocketproxyLogger.PrintAndLog("Websocketproxy", "websocketproxy: backend URL is nil", nil)
 		http.Error(rw, "internal server error (code: 2)", http.StatusInternalServerError)
 		return
 	}
@@ -137,13 +136,13 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// http://tools.ietf.org/html/draft-ietf-hybi-websocket-multiplexing-01
 	connBackend, resp, err := dialer.Dial(backendURL.String(), requestHeader)
 	if err != nil {
-		log.Printf("websocketproxy: couldn't dial to remote backend url %s", err)
+		websocketproxyLogger.PrintAndLog("Websocketproxy", fmt.Sprintf("websocketproxy: couldn't dial to remote backend url %s", err), nil)
 		if resp != nil {
 			// If the WebSocket handshake fails, ErrBadHandshake is returned
 			// along with a non-nil *http.Response so that callers can handle
 			// redirects, authentication, etcetera.
 			if err := copyResponse(rw, resp); err != nil {
-				log.Printf("websocketproxy: couldn't write response after failed remote backend handshake: %s", err)
+				websocketproxyLogger.PrintAndLog("Websocketproxy", fmt.Sprintf("websocketproxy: couldn't write response after failed remote backend handshake: %s", err), nil)
 			}
 		} else {
 			http.Error(rw, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
@@ -171,7 +170,7 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	upgrader.CheckOrigin = func(r *http.Request) bool { return true }
 	connPub, err := upgrader.Upgrade(rw, req, upgradeHeader)
 	if err != nil {
-		log.Printf("websocketproxy: couldn't upgrade %s", err)
+		websocketproxyLogger.PrintAndLog("Websocketproxy", fmt.Sprintf("websocketproxy: couldn't upgrade %s", err), nil)
 		return
 	}
 	defer connPub.Close()
@@ -212,7 +211,7 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	}
 	if e, ok := err.(*websocket.CloseError); !ok || e.Code == websocket.CloseAbnormalClosure {
-		log.Printf(message, err)
+		websocketproxyLogger.PrintAndLog("Websocketproxy", fmt.Sprintf(message, err), nil)
 	}
 }
 

--- a/src/mod/network/websocketproxy/zz_logger.go
+++ b/src/mod/network/websocketproxy/zz_logger.go
@@ -1,0 +1,5 @@
+package websocketproxy
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var websocketproxyLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/wifi/wifi_linux.go
+++ b/src/mod/network/wifi/wifi_linux.go
@@ -5,7 +5,7 @@ package wifi
 
 import (
 	"errors"
-	"log"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,7 +26,7 @@ func (w *WiFiManager) SetInterfacePower(wlanInterface string, on bool) error {
 	cmd := exec.Command("ifconfig", wlanInterface, status)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Println("*WiFi* WiFi toggle failed: ", string(out))
+		wifiLogger.PrintAndLog("Wifi", fmt.Sprint("*WiFi* WiFi toggle failed: ", string(out)), nil)
 		return err
 	}
 
@@ -85,7 +85,7 @@ func (w *WiFiManager) ScanNearbyWiFi(interfaceName string) ([]WiFiInfo, error) {
 		if strings.Contains(string(out), "Interface doesn't support scanning") {
 			//Try nmcli instead if exists
 			if pkg_exists("nmcli") {
-				log.Println("*WiFi* Running WiFi scan in nmcli compatibility mode")
+				wifiLogger.PrintAndLog("Wifi", "*WiFi* Running WiFi scan in nmcli compatibility mode", nil)
 				cmd := exec.Command("bash", "-c", "nmcli d wifi list")
 				out, err := cmd.CombinedOutput()
 				if err != nil {
@@ -151,7 +151,7 @@ func (w *WiFiManager) ScanNearbyWiFi(interfaceName string) ([]WiFiInfo, error) {
 
 				return results, nil
 			} else {
-				log.Println("*WiFi* Scan Failed: ", err.Error())
+				wifiLogger.PrintAndLog("Wifi", fmt.Sprint("*WiFi* Scan Failed: ", err.Error()), nil)
 				return []WiFiInfo{}, errors.New("Interface doesn't support scanning")
 			}
 		}
@@ -303,8 +303,8 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 			cmd := exec.Command("nmcli", "con", "down", oldSSID)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				log.Println("*WiFi* Connecting previous SSID failed: " + string(out))
-				log.Println("*WiFi* Trying to connect new AP anyway")
+				wifiLogger.PrintAndLog("Wifi", "*WiFi* Connecting previous SSID failed: "+string(out), nil)
+				wifiLogger.PrintAndLog("Wifi", "*WiFi* Trying to connect new AP anyway", nil)
 			}
 		}
 
@@ -317,7 +317,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		cmd := exec.Command("nmcli", "device", "wifi", "connect", ssid, "password", password)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Println("*WiFi* Connecting to SSID " + ssid + " failed: " + string(out))
+			wifiLogger.PrintAndLog("Wifi", "*WiFi* Connecting to SSID "+ssid+" failed: "+string(out), nil)
 			return &WiFiConnectionResult{Success: false}, errors.New(string(out))
 		}
 
@@ -326,7 +326,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 			w.database.Write("wifi", ssid, password)
 		}
 
-		log.Println(string(out))
+		wifiLogger.PrintAndLog("Wifi", string(out), nil)
 		//Check and return the current connection ssid
 		//Wait until the WiFi is conencted
 		rescanCount := 0
@@ -334,9 +334,9 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		//Wait for 30 seconds
 		for rescanCount < 10 && connectedSSID == "" {
 			connectedSSID, _, _ = w.GetConnectedWiFi()
-			log.Println(connectedSSID)
+			wifiLogger.PrintAndLog("Wifi", fmt.Sprint(connectedSSID), nil)
 			rescanCount = rescanCount + 1
-			log.Println("*WiFi* Waiting WiFi Connection (Retry " + strconv.Itoa(rescanCount) + "/10)")
+			wifiLogger.PrintAndLog("Wifi", "*WiFi* Waiting WiFi Connection (Retry "+strconv.Itoa(rescanCount)+"/10)", nil)
 			time.Sleep(3 * time.Second)
 		}
 
@@ -378,7 +378,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		//Special case, for handling WiFi Switching without retyping the password
 		writeToConfig = false
 	} else {
-		log.Println("*WiFi* Unsupported connection type")
+		wifiLogger.PrintAndLog("Wifi", "*WiFi* Unsupported connection type", nil)
 		return &WiFiConnectionResult{Success: false}, errors.New("Unsupported Connection Type")
 	}
 
@@ -388,15 +388,15 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	}
 
 	if writeToConfig == true {
-		log.Println("*WiFi* WiFi Config Generated. Writing to file...")
+		wifiLogger.PrintAndLog("Wifi", "*WiFi* WiFi Config Generated. Writing to file...", nil)
 		//Write config file to disk
 		err := os.WriteFile("./system/network/wifi/ap/"+ssid+".config", []byte(networkConfigFile), 0755)
 		if err != nil {
-			log.Println(err.Error())
+			wifiLogger.PrintAndLog("Wifi", err.Error(), nil)
 			return &WiFiConnectionResult{Success: false}, err
 		}
 	} else {
-		log.Println("*WiFi* Switching WiFi AP...")
+		wifiLogger.PrintAndLog("Wifi", "*WiFi* Switching WiFi AP...", nil)
 	}
 
 	//Start creating the new wpa_supplicant file
@@ -404,7 +404,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	configHeader, err := os.ReadFile("./system/network/wifi/wpa_supplicant.conf_template.config")
 	if err != nil {
 		//Template header not found. Use default one from Raspberry Pi
-		log.Println("*WiFi* Warning! wpa_supplicant template file not found. Using default template.")
+		wifiLogger.PrintAndLog("Wifi", "*WiFi* Warning! wpa_supplicant template file not found. Using default template.", nil)
 		configHeader = []byte(`ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 		update_config=1
 		{{networks}}
@@ -414,7 +414,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	//Build network informations
 	networksConfigs, err := filepath.Glob("./system/network/wifi/ap/*.config")
 	if err != nil {
-		log.Println(err.Error())
+		wifiLogger.PrintAndLog("Wifi", err.Error(), nil)
 		return &WiFiConnectionResult{Success: false}, err
 	}
 
@@ -424,7 +424,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	for _, configFile := range networksConfigs {
 		thisNetworkConfig, err := os.ReadFile(configFile)
 		if err != nil {
-			log.Println("*WiFi* Failed to read Network Config File: " + configFile)
+			wifiLogger.PrintAndLog("Wifi", "*WiFi* Failed to read Network Config File: "+configFile, nil)
 			continue
 		}
 
@@ -451,11 +451,11 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	//Try to write the new config to wpa_supplicant
 	err = os.WriteFile(w.wpa_supplicant_path, []byte(newconfig), 0777)
 	if err != nil {
-		log.Println("*WiFi* Failed to update wpa_supplicant config, are you sure you have access permission to that file?")
+		wifiLogger.PrintAndLog("Wifi", "*WiFi* Failed to update wpa_supplicant config, are you sure you have access permission to that file?", nil)
 		return &WiFiConnectionResult{Success: false}, err
 	}
 
-	log.Println("*WiFi* WiFi Config Updated. Restarting Wireless Interfaces...")
+	wifiLogger.PrintAndLog("Wifi", "*WiFi* WiFi Config Updated. Restarting Wireless Interfaces...", nil)
 
 	//Restart network services
 	cmd := exec.Command("wpa_cli", "-i", w.wan_interface_name, "reconfigure")
@@ -464,7 +464,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		//Maybe the user forgot to set the flag. Try auto detect.
 		autoDetectedWIface, err := w.GetWirelessInterfaces()
 		if err != nil || len(autoDetectedWIface) == 0 {
-			log.Println("failed to restart network: " + string(out))
+			wifiLogger.PrintAndLog("Wifi", "failed to restart network: "+string(out), nil)
 			return &WiFiConnectionResult{Success: false}, err
 		}
 
@@ -473,22 +473,22 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			//Really failed.
-			log.Println("failed to restart network: " + string(out))
+			wifiLogger.PrintAndLog("Wifi", "failed to restart network: "+string(out), nil)
 			return &WiFiConnectionResult{Success: false}, err
 		}
 
 	}
 
-	log.Println("*WiFi* Trying to connect new AP")
+	wifiLogger.PrintAndLog("Wifi", "*WiFi* Trying to connect new AP", nil)
 	//Wait until the WiFi is conencted
 	rescanCount := 0
 	connectedSSID, _, _ := w.GetConnectedWiFi()
 	//Wait for 30 seconds
 	for rescanCount < 10 && connectedSSID == "" {
 		connectedSSID, _, _ = w.GetConnectedWiFi()
-		log.Println(connectedSSID)
+		wifiLogger.PrintAndLog("Wifi", fmt.Sprint(connectedSSID), nil)
 		rescanCount = rescanCount + 1
-		log.Println("*WiFi* Waiting WiFi Connection (Retry " + strconv.Itoa(rescanCount) + "/10)")
+		wifiLogger.PrintAndLog("Wifi", "*WiFi* Waiting WiFi Connection (Retry "+strconv.Itoa(rescanCount)+"/10)", nil)
 		time.Sleep(3 * time.Second)
 	}
 

--- a/src/mod/network/wifi/wifi_windows.go
+++ b/src/mod/network/wifi/wifi_windows.go
@@ -11,13 +11,12 @@ package wifi
 
 import (
 	"errors"
-	"log"
 	"os/exec"
 	"strconv"
 	"strings"
 )
 
-//Toggle WiFi On Off. Only allow on sudo mode
+// Toggle WiFi On Off. Only allow on sudo mode
 func (w *WiFiManager) SetInterfacePower(wlanInterface string, on bool) error {
 	return errors.New("Windows WiFi function is currently readonly")
 }
@@ -31,7 +30,7 @@ func (w *WiFiManager) ScanNearbyWiFi(interfaceName string) ([]WiFiInfo, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		//No interface found on the system
-		log.Println(string(out))
+		wifiLogger.PrintAndLog("Wifi", string(out), nil)
 		return []WiFiInfo{}, errors.New(string(out))
 	}
 
@@ -132,7 +131,7 @@ func (w *WiFiManager) GetWirelessInterfaces() ([]string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		//No interface found on the system
-		log.Println(string(out))
+		wifiLogger.PrintAndLog("Wifi", string(out), nil)
 		return []string{}, err
 	}
 	output := string(out)
@@ -158,13 +157,13 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	return &WiFiConnectionResult{}, errors.New("Windows WiFi function is currently readonly")
 }
 
-//Get connected wifi ssid, interface name and error if any
+// Get connected wifi ssid, interface name and error if any
 func (w *WiFiManager) GetConnectedWiFi() (string, string, error) {
 	cmd := exec.Command("cmd", "/c", "chcp 65001 && netsh WLAN show interface")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		//No interface found on the system
-		log.Println(string(out))
+		wifiLogger.PrintAndLog("Wifi", string(out), nil)
 		return "", "", nil
 	}
 	output := string(out)

--- a/src/mod/network/wifi/zz_logger.go
+++ b/src/mod/network/wifi/zz_logger.go
@@ -1,0 +1,5 @@
+package wifi
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var wifiLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/zz_logger.go
+++ b/src/mod/network/zz_logger.go
@@ -1,0 +1,5 @@
+package network
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var networkLogger, _ = logger.NewTmpLogger()

--- a/src/mod/notification/agents/smtpn/smtpn.go
+++ b/src/mod/notification/agents/smtpn/smtpn.go
@@ -11,7 +11,7 @@ package smtpn
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"net/smtp"
 	"os"
 	"strconv"
@@ -94,7 +94,7 @@ func (a Agent) ConsumerNotification(incomingNotification *notification.Notificat
 		if err == nil {
 			userEmails = append(userEmails, []string{username, userEmail})
 		} else {
-			log.Println("[SMTP Notification] Unable to notify " + username + ": Email not set")
+			smtpnLogger.PrintAndLog("Smtpn", "[SMTP Notification] Unable to notify "+username+": Email not set", nil)
 		}
 	}
 
@@ -112,7 +112,7 @@ func (a Agent) ConsumerNotification(incomingNotification *notification.Notificat
 			"timestamp": time.Now().Format("2006-01-02 3:4:5 PM"),
 		})
 		if err != nil {
-			log.Println("[SMTP] Template load failed: " + err.Error())
+			smtpnLogger.PrintAndLog("Smtpn", "[SMTP] Template load failed: "+err.Error(), nil)
 		}
 
 		msg := []byte("To: " + thisEmail + "\n" +
@@ -125,7 +125,7 @@ func (a Agent) ConsumerNotification(incomingNotification *notification.Notificat
 		auth := smtp.PlainAuth("", a.SMTPSender, a.SMTPPassword, a.SMTPDomain)
 		err = smtp.SendMail(a.SMTPDomain+":"+strconv.Itoa(a.SMTPPort), auth, a.SMTPSender, []string{thisEmail}, msg)
 		if err != nil {
-			log.Println("[SMTPN] Email sent failed: ", err.Error())
+			smtpnLogger.PrintAndLog("Smtpn", fmt.Sprint("[SMTPN] Email sent failed: ", err.Error()), nil)
 			return err
 		}
 	}

--- a/src/mod/notification/agents/smtpn/zz_logger.go
+++ b/src/mod/notification/agents/smtpn/zz_logger.go
@@ -1,0 +1,5 @@
+package smtpn
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var smtpnLogger, _ = logger.NewTmpLogger()

--- a/src/mod/notification/notification.go
+++ b/src/mod/notification/notification.go
@@ -2,7 +2,6 @@ package notification
 
 import (
 	"container/list"
-	"log"
 )
 
 /*
@@ -47,7 +46,7 @@ func NewNotificationQueue() *NotificationQueue {
 	}
 }
 
-//Add a notification agent to the queue
+// Add a notification agent to the queue
 func (q *NotificationQueue) RegisterNotificationAgent(agent Agent) {
 	q.Agents = append(q.Agents, &agent)
 }
@@ -73,11 +72,11 @@ func (q *NotificationQueue) BroadcastNotification(message *NotificationPayload) 
 		//Send this notification via this agent
 		err := thisAgent.ConsumerNotification(message)
 		if err != nil {
-			log.Println("[Notification] Unable to send message via notification agent: " + thisAgent.Name())
+			notificationLogger.PrintAndLog("Notification", "[Notification] Unable to send message via notification agent: "+thisAgent.Name(), nil)
 		}
 
 	}
 
-	log.Println("[Notification] Message titled: " + message.Title + " (ID: " + message.ID + ") broadcasted")
+	notificationLogger.PrintAndLog("Notification", "[Notification] Message titled: "+message.Title+" (ID: "+message.ID+") broadcasted", nil)
 	return nil
 }

--- a/src/mod/notification/zz_logger.go
+++ b/src/mod/notification/zz_logger.go
@@ -1,0 +1,5 @@
+package notification
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var notificationLogger, _ = logger.NewTmpLogger()

--- a/src/mod/permission/permission.go
+++ b/src/mod/permission/permission.go
@@ -3,7 +3,7 @@ package permission
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"strings"
 
 	db "imuslab.com/arozos/mod/database"
@@ -72,7 +72,7 @@ func (h *PermissionHandler) LoadPermissionGroupsFromDatabase() error {
 			json.Unmarshal(keypairs[1], &originalJSONString)
 			err := json.Unmarshal([]byte(originalJSONString), &groupPermission)
 			if err != nil {
-				log.Println(err)
+				permissionLogger.PrintAndLog("Permission", fmt.Sprint(err), nil)
 			}
 			//IsAdmin
 			isAdmin := "false"
@@ -111,7 +111,7 @@ func (h *PermissionHandler) LoadPermissionGroupsFromDatabase() error {
 	return nil
 }
 
-//Get the user permission groups
+// Get the user permission groups
 func (h *PermissionHandler) GetUsersPermissionGroup(username string) ([]*PermissionGroup, error) {
 	//Get user permission group name from database
 	targetUserGroup := []string{}

--- a/src/mod/permission/request.go
+++ b/src/mod/permission/request.go
@@ -12,14 +12,14 @@ package permission
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 	"strconv"
 
 	"imuslab.com/arozos/mod/utils"
 )
 
-//Handle group editing operations
+// Handle group editing operations
 func (h *PermissionHandler) HandleListGroup(w http.ResponseWriter, r *http.Request) {
 	listPermission, _ := utils.GetPara(r, "showper")
 	if listPermission == "" {
@@ -45,7 +45,7 @@ func (h *PermissionHandler) HandleListGroup(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-//Listing a group's detail for editing or updating the group content
+// Listing a group's detail for editing or updating the group content
 func (h *PermissionHandler) HandleGroupEdit(w http.ResponseWriter, r *http.Request) {
 	groupname, err := utils.PostPara(r, "groupname")
 	if err != nil {
@@ -185,7 +185,7 @@ func (h *PermissionHandler) HandleGroupCreate(w http.ResponseWriter, r *http.Req
 	h.NewPermissionGroup(groupname, isAdmin == "true", int64(quotaInt), permissionSlice, interfaceModule)
 
 	utils.SendOK(w)
-	log.Println("Creating New Permission Group:", groupname, permission, isAdmin, quota)
+	permissionLogger.PrintAndLog("Permission", fmt.Sprint("Creating New Permission Group:", groupname, permission, isAdmin, quota), nil)
 }
 
 func (h *PermissionHandler) HandleGroupRemove(w http.ResponseWriter, r *http.Request) {

--- a/src/mod/permission/zz_logger.go
+++ b/src/mod/permission/zz_logger.go
@@ -1,0 +1,5 @@
+package permission
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var permissionLogger, _ = logger.NewTmpLogger()

--- a/src/mod/prouter/prouter.go
+++ b/src/mod/prouter/prouter.go
@@ -12,7 +12,6 @@ package prouter
 */
 import (
 	"errors"
-	"log"
 	"net/http"
 
 	"imuslab.com/arozos/mod/security/csrf"
@@ -52,7 +51,7 @@ func NewModuleRouter(option RouterOption) *RouterDef {
 func (router *RouterDef) HandleFunc(endpoint string, handler func(http.ResponseWriter, *http.Request)) error {
 	//Check if the endpoint already registered
 	if _, exist := router.endpoints[endpoint]; exist {
-		log.Println("WARNING! Duplicated registering of web endpoint: " + endpoint)
+		prouterLogger.PrintAndLog("Prouter", "WARNING! Duplicated registering of web endpoint: "+endpoint, nil)
 		return errors.New("Endpoint register duplicated")
 	}
 

--- a/src/mod/prouter/zz_logger.go
+++ b/src/mod/prouter/zz_logger.go
@@ -1,0 +1,5 @@
+package prouter
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var prouterLogger, _ = logger.NewTmpLogger()

--- a/src/mod/share/share.go
+++ b/src/mod/share/share.go
@@ -18,7 +18,6 @@ import (
 	"image/jpeg"
 	"io"
 	"io/fs"
-	"log"
 	"math"
 	"mime"
 	"net/http"
@@ -606,17 +605,17 @@ func (s *Manager) HandleShareAccess(w http.ResponseWriter, r *http.Request) {
 							} else {
 								f, err := targetFshAbs.ReadStream(path)
 								if err != nil {
-									log.Println("[Share] Buffer and zip download operation failed: ", err)
+									shareLogger.PrintAndLog("Share", fmt.Sprint("[Share] Buffer and zip download operation failed: ", err), nil)
 								}
 								defer f.Close()
 								dest, err := os.OpenFile(localPath, os.O_CREATE|os.O_WRONLY, 0775)
 								if err != nil {
-									log.Println("[Share] Buffer and zip download operation failed: ", err)
+									shareLogger.PrintAndLog("Share", fmt.Sprint("[Share] Buffer and zip download operation failed: ", err), nil)
 								}
 								defer dest.Close()
 								_, err = io.Copy(dest, f)
 								if err != nil {
-									log.Println("[Share] Buffer and zip download operation failed: ", err)
+									shareLogger.PrintAndLog("Share", fmt.Sprint("[Share] Buffer and zip download operation failed: ", err), nil)
 								}
 
 							}
@@ -633,7 +632,7 @@ func (s *Manager) HandleShareAccess(w http.ResponseWriter, r *http.Request) {
 						//Failed to create zip file
 						w.WriteHeader(http.StatusInternalServerError)
 						w.Write([]byte("500 - Internal Server Error: Zip file creation failed"))
-						log.Println("Failed to create zip file for share download: " + err.Error())
+						shareLogger.PrintAndLog("Share", "Failed to create zip file for share download: "+err.Error(), nil)
 						return
 					}
 
@@ -1322,9 +1321,9 @@ func (s *Manager) ValidateAndClearShares() {
 			//This share source file don't exists anymore. Remove it
 			err = s.options.ShareEntryTable.RemoveShareByPathHash(pathHash)
 			if err != nil {
-				log.Println("[Share] Failed to remove share", err)
+				shareLogger.PrintAndLog("Share", fmt.Sprint("[Share] Failed to remove share", err), nil)
 			}
-			log.Println("[Share] Removing share to file: " + thisShareOption.FileRealPath + " as it no longer exists")
+			shareLogger.PrintAndLog("Share", "[Share] Removing share to file: "+thisShareOption.FileRealPath+" as it no longer exists", nil)
 		}
 		return true
 	})

--- a/src/mod/share/zz_logger.go
+++ b/src/mod/share/zz_logger.go
@@ -1,0 +1,5 @@
+package share
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var shareLogger, _ = logger.NewTmpLogger()

--- a/src/mod/storage/ftp/drivers.go
+++ b/src/mod/storage/ftp/drivers.go
@@ -3,7 +3,7 @@ package ftp
 import (
 	"crypto/tls"
 	"errors"
-	"log"
+	"fmt"
 	"os"
 	"time"
 
@@ -32,7 +32,7 @@ func (m mainDriver) ClientDisconnected(cc ftp.ClientContext) {
 				if err == nil {
 					//Update the user storage quota
 					userinfo.StorageQuota.CalculateQuotaUsage()
-					log.Println("FTP storage quota updated: ", val.(string))
+					ftpLogger.PrintAndLog("Ftp", fmt.Sprint("FTP storage quota updated: ", val.(string)), nil)
 				}
 			} else {
 				//This user is being delete during his connection to FTP???
@@ -44,7 +44,7 @@ func (m mainDriver) ClientDisconnected(cc ftp.ClientContext) {
 
 }
 
-//Authenicate user using arozos authAgent
+// Authenicate user using arozos authAgent
 func (m mainDriver) AuthUser(cc ftp.ClientContext, user string, pass string) (ftp.ClientDriver, error) {
 	authAgent := m.userHandler.GetAuthAgent()
 	if authAgent.ValidateUsernameAndPassword(user, pass) {
@@ -71,7 +71,7 @@ func (m mainDriver) AuthUser(cc ftp.ClientContext, user string, pass string) (ft
 			//log the signin request
 			m.userHandler.GetAuthAgent().Logger.LogAuthByRequestInfo(user, cc.RemoteAddr().String(), time.Now().Unix(), false, "ftp")
 			//Disconnect this user as he is not in the group that is allowed to access ftp
-			log.Println(userinfo.Username + " tries to access FTP endpoint with invalid permission settings.")
+			ftpLogger.PrintAndLog("Ftp", userinfo.Username+" tries to access FTP endpoint with invalid permission settings.", nil)
 			return nil, errors.New("User " + userinfo.Username + " has no permission to access FTP endpoint")
 		}
 

--- a/src/mod/storage/ftp/ftp.go
+++ b/src/mod/storage/ftp/ftp.go
@@ -2,7 +2,6 @@ package ftp
 
 import (
 	"errors"
-	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -12,7 +11,7 @@ import (
 	"imuslab.com/arozos/mod/user"
 )
 
-//Handler is the handler for the FTP server defined in arozos
+// Handler is the handler for the FTP server defined in arozos
 type Handler struct {
 	ServerName    string
 	Port          int
@@ -29,7 +28,7 @@ type mainDriver struct {
 	connectedUserList *sync.Map
 }
 
-//NewFTPHandler creates a new handler for FTP Server as a wrapper to the ftpserverlib
+// NewFTPHandler creates a new handler for FTP Server as a wrapper to the ftpserverlib
 func NewFTPHandler(userHandler *user.UserHandler, ServerName string, Port int, tmpFolder string, PassiveModeIP string) (*Handler, error) {
 	//Create table for ftp if it doesn't exists
 	db := userHandler.GetDatabase()
@@ -59,19 +58,19 @@ func NewFTPHandler(userHandler *user.UserHandler, ServerName string, Port int, t
 	}, nil
 }
 
-//Update which usergroups can access the file system via ftp server
+// Update which usergroups can access the file system via ftp server
 func UpdateAccessableGroups(database *database.Database, groups []string) {
 	database.Write("ftp", "groups", groups)
 	if len(groups) == 0 {
-		log.Println("Setting no group access to ftp server!")
+		ftpLogger.PrintAndLog("Ftp", "Setting no group access to ftp server!", nil)
 	}
 }
 
-//ListenAndServe Start Listen and Serve
+// ListenAndServe Start Listen and Serve
 func (f *Handler) Start() error {
 	if f.server != nil {
 		go func(f *Handler) {
-			log.Println("FTP Server Started, listening at: " + strconv.Itoa(f.Port))
+			ftpLogger.PrintAndLog("Ftp", "FTP Server Started, listening at: "+strconv.Itoa(f.Port), nil)
 			f.server.ListenAndServe()
 		}(f)
 		f.ServerRunning = true
@@ -81,7 +80,7 @@ func (f *Handler) Start() error {
 	}
 }
 
-//Close the FTP Server
+// Close the FTP Server
 func (f *Handler) Close() {
 	if f.server != nil {
 		f.server.Stop()

--- a/src/mod/storage/ftp/zz_logger.go
+++ b/src/mod/storage/ftp/zz_logger.go
@@ -1,0 +1,5 @@
+package ftp
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var ftpLogger, _ = logger.NewTmpLogger()

--- a/src/mod/storage/sftpserver/sftpserver.go
+++ b/src/mod/storage/sftpserver/sftpserver.go
@@ -2,8 +2,8 @@ package sftpserver
 
 import (
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"sync"
@@ -62,7 +62,7 @@ func NewSFTPServer(sftpConfig *SFTPConfig) (*Instance, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("[SFTP] Listening on %v\n", listener.Addr())
+	sftpserverLogger.PrintAndLog("Sftpserver", fmt.Sprintf("[SFTP] Listening on %v\n", listener.Addr()), nil)
 
 	//Setup a closer handler for this instance
 	closeChan := make(chan bool)
@@ -99,7 +99,7 @@ func NewSFTPServer(sftpConfig *SFTPConfig) (*Instance, error) {
 				if err != nil {
 					return err
 				}
-				log.Println("[SFTP] User Connected: ", cx.User())
+				sftpserverLogger.PrintAndLog("Sftpserver", fmt.Sprint("[SFTP] User Connected: ", cx.User()), nil)
 
 				userinfo, err := sftpConfig.UserManager.GetUserInfoFromUsername(cx.User())
 				if err != nil {
@@ -167,10 +167,10 @@ func NewSFTPServer(sftpConfig *SFTPConfig) (*Instance, error) {
 					if err := server.Serve(); err == io.EOF {
 						kickChan <- true
 						//server.Close()
-						log.Print("sftp client exited session.")
+						sftpserverLogger.PrintAndLog("Sftpserver", "sftp client exited session.", nil)
 					} else if err != nil {
 						kickChan <- false
-						log.Println("sftp server completed with error:", err)
+						sftpserverLogger.PrintAndLog("Sftpserver", fmt.Sprint("sftp server completed with error:", err), nil)
 					}
 
 				}
@@ -186,5 +186,5 @@ func NewSFTPServer(sftpConfig *SFTPConfig) (*Instance, error) {
 func (i *Instance) Close() {
 	i.closer <- true
 	i.Closed = true
-	log.Println("[SFTP] SFTP Server Closed")
+	sftpserverLogger.PrintAndLog("Sftpserver", "[SFTP] SFTP Server Closed", nil)
 }

--- a/src/mod/storage/sftpserver/zz_logger.go
+++ b/src/mod/storage/sftpserver/zz_logger.go
@@ -1,0 +1,5 @@
+package sftpserver
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var sftpserverLogger, _ = logger.NewTmpLogger()

--- a/src/mod/storage/tftp/tftp.go
+++ b/src/mod/storage/tftp/tftp.go
@@ -2,8 +2,8 @@ package tftp
 
 import (
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"strconv"
 	"sync"
 	"time"
@@ -65,12 +65,12 @@ func NewTFTPHandler(userHandler *user.UserHandler, ServerName string, Port int, 
 func (h *Handler) Start() error {
 	if h.server != nil {
 		addr := ":" + strconv.Itoa(h.Port)
-		log.Println("[TFTP] Server Started, listening at: " + strconv.Itoa(h.Port))
+		tftpLogger.PrintAndLog("Tftp", "[TFTP] Server Started, listening at: "+strconv.Itoa(h.Port), nil)
 
 		go func() {
 			err := h.server.ListenAndServe(addr)
 			if err != nil {
-				log.Println("[TFTP] Server error:", err)
+				tftpLogger.PrintAndLog("Tftp", fmt.Sprint("[TFTP] Server error:", err), nil)
 			}
 		}()
 
@@ -117,7 +117,7 @@ func (d *tftpDriver) readHandler(filename string, rf io.ReaderFrom) error {
 	// Open file for reading
 	file, err := afs.Open(filename)
 	if err != nil {
-		log.Printf("[TFTP] READ: Failed to open %s: %v", filename, err)
+		tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] READ: Failed to open %s: %v", filename, err), nil)
 		return err
 	}
 	defer file.Close()
@@ -136,11 +136,11 @@ func (d *tftpDriver) readHandler(filename string, rf io.ReaderFrom) error {
 
 	n, err := rf.ReadFrom(file)
 	if err != nil {
-		log.Printf("[TFTP] READ: Transfer error for %s: %v", filename, err)
+		tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] READ: Transfer error for %s: %v", filename, err), nil)
 		return err
 	}
 
-	log.Printf("[TFTP] READ: Sent %s (%d bytes)", filename, n)
+	tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] READ: Sent %s (%d bytes)", filename, n), nil)
 	return nil
 }
 
@@ -171,17 +171,17 @@ func (d *tftpDriver) writeHandler(filename string, wt io.WriterTo) error {
 	// Check if user can write
 	file, err := afs.Create(filename)
 	if err != nil {
-		log.Printf("[TFTP] WRITE: Failed to create %s: %v", filename, err)
+		tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] WRITE: Failed to create %s: %v", filename, err), nil)
 		return err
 	}
 	defer file.Close()
 
 	n, err := wt.WriteTo(file)
 	if err != nil {
-		log.Printf("[TFTP] WRITE: Transfer error for %s: %v", filename, err)
+		tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] WRITE: Transfer error for %s: %v", filename, err), nil)
 		return err
 	}
 
-	log.Printf("[TFTP] WRITE: Received %s (%d bytes)", filename, n)
+	tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] WRITE: Received %s (%d bytes)", filename, n), nil)
 	return nil
 }

--- a/src/mod/storage/tftp/zz_logger.go
+++ b/src/mod/storage/tftp/zz_logger.go
@@ -1,0 +1,5 @@
+package tftp
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var tftpLogger, _ = logger.NewTmpLogger()

--- a/src/mod/storage/webdav/common.go
+++ b/src/mod/storage/webdav/common.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"time"
@@ -107,7 +107,8 @@ func isDir(path string) bool {
 	}
 	fi, err := os.Stat(path)
 	if err != nil {
-		log.Fatal(err)
+		webdavLogger.PrintAndLog("Webdav", fmt.Sprint(err), nil)
+		os.Exit(1)
 		return false
 	}
 	switch mode := fi.Mode(); {

--- a/src/mod/storage/webdav/fshAdapter.go
+++ b/src/mod/storage/webdav/fshAdapter.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
-	"log"
 	"os"
 
 	"imuslab.com/arozos/mod/filesystem"
@@ -145,7 +145,7 @@ func (a *FshWebDAVAdapter) OpenFile(ctx context.Context, name string, flag int, 
 	//Merge it into a proper vpath and perform abstraction path translation
 	realRequestPath, err := a.requestPathToRealPath(name)
 	if err != nil {
-		log.Println(err)
+		webdavLogger.PrintAndLog("Webdav", fmt.Sprint(err), nil)
 		return nil, err
 	}
 

--- a/src/mod/storage/webdav/webdav.go
+++ b/src/mod/storage/webdav/webdav.go
@@ -10,7 +10,7 @@ package webdav
 */
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -224,7 +224,7 @@ func (s *Server) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	//Windows File Explorer. Handle with special case
 	/*
 		if r.Header["User-Agent"] != nil && strings.Contains(r.Header["User-Agent"][0], "Microsoft-WebDAV-MiniRedir") && r.TLS == nil {
-			log.Println("Windows File Explorer Connection. Routing using alternative handler")
+			webdavLogger.PrintAndLog("Webdav", "Windows File Explorer Connection. Routing using alternative handler", nil)
 			s.HandleWindowClientAccess(w, r, reqRoot)
 			return
 		}
@@ -245,14 +245,14 @@ func (s *Server) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	//Validate request origin
 	allowAccess, err := authAgent.ValidateLoginRequest(w, r)
 	if !allowAccess {
-		log.Println("Someone from " + r.RemoteAddr + " try to log into " + username + " WebDAV endpoint but got rejected: " + err.Error())
+		webdavLogger.PrintAndLog("Webdav", "Someone from "+r.RemoteAddr+" try to log into "+username+" WebDAV endpoint but got rejected: "+err.Error(), nil)
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
 	passwordValid, rejectionReason := authAgent.ValidateUsernameAndPasswordWithReason(username, password)
 	if !passwordValid {
 		authAgent.Logger.LogAuthByRequestInfo(username, r.RemoteAddr, time.Now().Unix(), false, "webdav")
-		log.Println("Someone from " + r.RemoteAddr + " try to log into " + username + " WebDAV endpoint but got rejected: " + rejectionReason)
+		webdavLogger.PrintAndLog("Webdav", "Someone from "+r.RemoteAddr+" try to log into "+username+" WebDAV endpoint but got rejected: "+rejectionReason, nil)
 		http.Error(w, rejectionReason, http.StatusUnauthorized)
 		return
 	}
@@ -260,14 +260,14 @@ func (s *Server) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	//Resolve the vroot to realpath
 	userinfo, err := s.userHandler.GetUserInfoFromUsername(username)
 	if err != nil {
-		log.Println(err.Error())
+		webdavLogger.PrintAndLog("Webdav", err.Error(), nil)
 		http.Error(w, "Invalid username or password", http.StatusUnauthorized)
 		return
 	}
 
 	fsh, err := userinfo.GetFileSystemHandlerFromVirtualPath(reqRoot + ":/")
 	if err != nil {
-		log.Println("[WebDAV] Failed to load File System Handler from request root: ", reqRoot+":/", err.Error())
+		webdavLogger.PrintAndLog("Webdav", fmt.Sprint("[WebDAV] Failed to load File System Handler from request root: ", reqRoot+":/", err.Error()), nil)
 		http.Error(w, "Invalid ", http.StatusInternalServerError)
 		return
 	}
@@ -276,7 +276,7 @@ func (s *Server) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	/*
 		realRoot, err := userinfo.VirtualPathToRealPath(reqRoot + ":/")
 		if err != nil {
-			log.Println(err.Error())
+			webdavLogger.PrintAndLog("Webdav", err.Error(), nil)
 			http.Error(w, "Invalid ", http.StatusUnauthorized)
 			return
 		}

--- a/src/mod/storage/webdav/webdavWindowHandler.go
+++ b/src/mod/storage/webdav/webdavWindowHandler.go
@@ -9,7 +9,6 @@ package webdav
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -19,7 +18,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-//Handle request from Windows File Explorer
+// Handle request from Windows File Explorer
 func (s *Server) HandleWindowClientAccess(w http.ResponseWriter, r *http.Request, vroot string) {
 	coookieName := "arozosWebdavToken"
 	cookie, err := r.Cookie(coookieName)
@@ -44,7 +43,7 @@ func (s *Server) HandleWindowClientAccess(w http.ResponseWriter, r *http.Request
 			ip = "localhost"
 		}
 
-		log.Println("New Window WebDAV Client Connected! Assinging UUID:", thisWebDAVClientID)
+		webdavLogger.PrintAndLog("Webdav", fmt.Sprint("New Window WebDAV Client Connected! Assinging UUID:", thisWebDAVClientID), nil)
 		//Store this UUID with the connection
 		s.windowsClientNotLoggedIn.Store(thisWebDAVClientID, &WindowClientInfo{
 			Agent:                   r.Header["User-Agent"][0],
@@ -123,7 +122,7 @@ func (s *Server) HandleWindowClientAccess(w http.ResponseWriter, r *http.Request
 
 			fsh, err := userinfo.GetFileSystemHandlerFromVirtualPath(vroot + ":/")
 			if err != nil {
-				log.Println("[WebDAV] Failed to load File System Handler from request root: ", err.Error())
+				webdavLogger.PrintAndLog("Webdav", fmt.Sprint("[WebDAV] Failed to load File System Handler from request root: ", err.Error()), nil)
 				http.Error(w, "Invalid ", http.StatusUnauthorized)
 				return
 			}

--- a/src/mod/storage/webdav/zz_logger.go
+++ b/src/mod/storage/webdav/zz_logger.go
@@ -1,0 +1,5 @@
+package webdav
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var webdavLogger, _ = logger.NewTmpLogger()

--- a/src/mod/subservice/common.go
+++ b/src/mod/subservice/common.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -108,7 +108,8 @@ func isDir(path string) bool {
 	}
 	fi, err := os.Stat(path)
 	if err != nil {
-		log.Fatal(err)
+		subserviceLogger.PrintAndLog("Subservice", fmt.Sprint(err), nil)
+		os.Exit(1)
 		return false
 	}
 	switch mode := fi.Mode(); {

--- a/src/mod/subservice/subservice.go
+++ b/src/mod/subservice/subservice.go
@@ -3,7 +3,7 @@ package subservice
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -155,7 +155,8 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 		launchConfig, err := os.ReadFile(servicePath + "/moduleInfo.json")
 		if err != nil {
 			if startupMode {
-				log.Fatal("Failed to read moduleInfo.json: "+binaryname, err)
+				subserviceLogger.PrintAndLog("Subservice", fmt.Sprint("Failed to read moduleInfo.json: "+binaryname, err), nil)
+				os.Exit(1)
 			} else {
 				return errors.New("Failed to read moduleInfo.json: " + binaryname)
 			}
@@ -168,7 +169,8 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 		if err != nil {
 			sr.logger.PrintAndLog("Subservice", "Missing module startup info for "+servicePath, errors.New("Startup flag -info return no JSON string and moduleInfo.json does not exists for "+servicePath))
 			if startupMode {
-				log.Fatal("Unable to start service: "+binaryname, err)
+				subserviceLogger.PrintAndLog("Subservice", fmt.Sprint("Unable to start service: "+binaryname, err), nil)
+				os.Exit(1)
 			} else {
 				return errors.New("Unable to start service: " + binaryname)
 			}
@@ -184,7 +186,8 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 	err := json.Unmarshal([]byte(serviceLaunchInfo), &thisModuleInfo)
 	if err != nil {
 		if startupMode {
-			log.Fatal("Failed to load subservice: "+serviceRoot+"\n", err.Error())
+			subserviceLogger.PrintAndLog("Subservice", fmt.Sprint("Failed to load subservice: "+serviceRoot+"\n", err.Error()), nil)
+			os.Exit(1)
 
 		} else {
 			return errors.New("Failed to load subservice: " + serviceRoot)
@@ -204,7 +207,8 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 
 			if !fileExists(initPath) {
 				if startupMode {
-					log.Fatal("start.sh not found. Unable to startup service " + serviceRoot)
+					subserviceLogger.PrintAndLog("Subservice", "start.sh not found. Unable to startup service "+serviceRoot, nil)
+					os.Exit(1)
 				} else {
 					return errors.New("start.sh not found. Unable to startup service " + serviceRoot)
 				}
@@ -239,7 +243,8 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 		//Check if this path is reversed
 		if stringInSlice(rProxyEndpoint, sr.ReservePaths) || rProxyEndpoint == "" {
 			if startupMode {
-				log.Fatal(serviceRoot + " service try to request system reserve path as Reverse Proxy endpoint.")
+				subserviceLogger.PrintAndLog("Subservice", serviceRoot+" service try to request system reserve path as Reverse Proxy endpoint.", nil)
+				os.Exit(1)
 			} else {
 				return errors.New(serviceRoot + " service try to request system reserve path as Reverse Proxy endpoint.")
 			}
@@ -259,7 +264,8 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 
 			if !fileExists(initPath) {
 				if startupMode {
-					log.Fatal("start.sh not found. Unable to startup service " + serviceRoot)
+					subserviceLogger.PrintAndLog("Subservice", "start.sh not found. Unable to startup service "+serviceRoot, nil)
+					os.Exit(1)
 				} else {
 					return errors.New(serviceRoot + "start.sh not found. Unable to startup service " + serviceRoot)
 				}

--- a/src/mod/subservice/zz_logger.go
+++ b/src/mod/subservice/zz_logger.go
@@ -1,0 +1,5 @@
+package subservice
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var subserviceLogger, _ = logger.NewTmpLogger()

--- a/src/mod/time/scheduler/helper.go
+++ b/src/mod/time/scheduler/helper.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 )
 
@@ -33,7 +34,7 @@ func (a *Scheduler) saveJobsToCronFile() error {
 }
 
 func (a *Scheduler) cronlog(message string) {
-	a.options.Logger.PrintAndLog("Scheduler", message, nil)
+	a.options.Logger.PrintAndLog("Scheduler", fmt.Sprint(message), nil)
 }
 
 func (a *Scheduler) cronlogError(message string, err error) {

--- a/src/mod/time/scheduler/scheduler.go
+++ b/src/mod/time/scheduler/scheduler.go
@@ -3,7 +3,6 @@ package scheduler
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -106,7 +105,7 @@ func (a *Scheduler) createTicker(duration time.Duration) chan bool {
 	stop := make(chan bool, 1)
 
 	go func() {
-		defer log.Println("Scheduler Stopped")
+		defer schedulerLogger.PrintAndLog("Scheduler", "Scheduler Stopped", nil)
 		for {
 			select {
 			case <-ticker.C:
@@ -393,11 +392,11 @@ func cronlog(message string) {
 	f, err := os.OpenFile(currentLogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		//Unable to write to file. Log to STDOUT instead
-		log.Println(message)
+		schedulerLogger.PrintAndLog("Scheduler", fmt.Sprint(message), nil)
 		return
 	}
 	if _, err := f.WriteString(message + "\n"); err != nil {
-		log.Println(message)
+		schedulerLogger.PrintAndLog("Scheduler", fmt.Sprint(message), nil)
 		return
 	}
 	defer f.Close()

--- a/src/mod/time/scheduler/zz_logger.go
+++ b/src/mod/time/scheduler/zz_logger.go
@@ -1,0 +1,5 @@
+package scheduler
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var schedulerLogger, _ = logger.NewTmpLogger()

--- a/src/mod/updates/handler.go
+++ b/src/mod/updates/handler.go
@@ -3,7 +3,6 @@ package updates
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"runtime"
@@ -156,7 +155,7 @@ func HandleGetUpdatePlatformInfo(w http.ResponseWriter, r *http.Request) {
 	vendorUpdateConfig := UpdateConfig{}
 	err = json.Unmarshal(updateFileContent, &vendorUpdateConfig)
 	if err != nil {
-		log.Println("[Updates] Failed to parse update config file: ", err.Error())
+		updatesLogger.PrintAndLog("Updates", fmt.Sprint("[Updates] Failed to parse update config file: ", err.Error()), nil)
 		utils.SendErrorResponse(w, "Invalid or corrupted update config")
 		return
 	}

--- a/src/mod/updates/zz_logger.go
+++ b/src/mod/updates/zz_logger.go
@@ -1,0 +1,5 @@
+package updates
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var updatesLogger, _ = logger.NewTmpLogger()

--- a/src/mod/user/user.go
+++ b/src/mod/user/user.go
@@ -2,7 +2,6 @@ package user
 
 import (
 	"errors"
-	"log"
 	"net/http"
 	"os"
 
@@ -41,7 +40,7 @@ type UserHandler struct {
 	shareEntryTable **shareEntry.ShareEntryTable
 }
 
-//Initiate a new user handler
+// Initiate a new user handler
 func NewUserHandler(systemdb *db.Database, authAgent *auth.AuthAgent, permissionHandler *permission.PermissionHandler, baseStoragePool *storage.StoragePool, shareEntryTable **shareEntry.ShareEntryTable) (*UserHandler, error) {
 	return &UserHandler{
 		authAgent:       authAgent,
@@ -52,7 +51,7 @@ func NewUserHandler(systemdb *db.Database, authAgent *auth.AuthAgent, permission
 	}, nil
 }
 
-//Return the user handler's auth agent
+// Return the user handler's auth agent
 func (u *UserHandler) GetAuthAgent() *auth.AuthAgent {
 	return u.authAgent
 }
@@ -61,7 +60,7 @@ func (u *UserHandler) GetPermissionHandler() *permission.PermissionHandler {
 	return u.phandler
 }
 
-//Get the user's base storage pool, in most case it is the system pool
+// Get the user's base storage pool, in most case it is the system pool
 func (u *UserHandler) GetStoragePool() *storage.StoragePool {
 	return u.basePool
 }
@@ -74,7 +73,7 @@ func (u *UserHandler) UpdateStoragePool(newpool *storage.StoragePool) {
 	u.basePool = newpool
 }
 
-//Get User object from username
+// Get User object from username
 func (u *UserHandler) GetUserInfoFromUsername(username string) (*User, error) {
 	//Check if user exists
 	if !u.authAgent.UserExists(username) {
@@ -90,7 +89,7 @@ func (u *UserHandler) GetUserInfoFromUsername(username string) (*User, error) {
 	//Create user directories in the Home Directories
 	if u.basePool.Storages == nil {
 		//This userhandler do not have a basepool?
-		log.Println("USER HANDLER DO NOT HAVE BASEPOOL")
+		userLogger.PrintAndLog("User", "USER HANDLER DO NOT HAVE BASEPOOL", nil)
 	} else {
 		for _, store := range u.basePool.Storages {
 			if store.Hierarchy == "user" {
@@ -145,7 +144,7 @@ func (u *UserHandler) GetUserInfoFromUsername(username string) (*User, error) {
 	return &thisUser, nil
 }
 
-//Get user obejct from session
+// Get user obejct from session
 func (u *UserHandler) GetUserInfoFromRequest(w http.ResponseWriter, r *http.Request) (*User, error) {
 	username, err := u.authAgent.GetUserName(w, r)
 	if err != nil {
@@ -159,7 +158,7 @@ func (u *UserHandler) GetUserInfoFromRequest(w http.ResponseWriter, r *http.Requ
 	return userObject, nil
 }
 
-//Get all the users given the permission group name, super IO heavy operation
+// Get all the users given the permission group name, super IO heavy operation
 func (u *UserHandler) GetUsersInPermissionGroup(permissionGroupName string) ([]*User, error) {
 	results := []*User{}
 	//Check if the given group exists

--- a/src/mod/user/useropr.go
+++ b/src/mod/user/useropr.go
@@ -1,30 +1,30 @@
 package user
 
-import "log"
+import "fmt"
 
-//Get the user's handler
+// Get the user's handler
 func (u *User) Parent() *UserHandler {
 	return u.parent
 }
 
-//Remove the current user
+// Remove the current user
 func (u *User) RemoveUser() {
 	//Remove the user storage quota settings
-	log.Println("Removing User Quota: ", u.Username)
+	userLogger.PrintAndLog("User", fmt.Sprint("Removing User Quota: ", u.Username), nil)
 	u.StorageQuota.RemoveUserQuota()
 
 	//Remove the user authentication register
 	u.parent.authAgent.UnregisterUser(u.Username)
 }
 
-//Get the target user icon
+// Get the target user icon
 func (u *User) GetUserIcon() string {
 	var userIconpath []byte
 	u.parent.database.Read("auth", "profilepic/"+u.Username, &userIconpath)
 	return string(userIconpath)
 }
 
-//Set the current user icon
+// Set the current user icon
 func (u *User) SetUserIcon(base64data string) {
 	u.parent.database.Write("auth", "profilepic/"+u.Username, []byte(base64data))
 }

--- a/src/mod/user/zz_logger.go
+++ b/src/mod/user/zz_logger.go
@@ -1,0 +1,5 @@
+package user
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var userLogger, _ = logger.NewTmpLogger()

--- a/src/mod/utils/utils.go
+++ b/src/mod/utils/utils.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -142,7 +142,8 @@ func IsDir(path string) bool {
 	}
 	fi, err := os.Stat(path)
 	if err != nil {
-		log.Fatal(err)
+		utilsLogger.PrintAndLog("Utils", fmt.Sprint(err), nil)
+		os.Exit(1)
 		return false
 	}
 	switch mode := fi.Mode(); {

--- a/src/mod/utils/zz_logger.go
+++ b/src/mod/utils/zz_logger.go
@@ -1,0 +1,5 @@
+package utils
+
+import logger "imuslab.com/arozos/mod/info/logger"
+
+var utilsLogger, _ = logger.NewTmpLogger()

--- a/src/module.go
+++ b/src/module.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 
@@ -128,15 +128,14 @@ func ModuleServiceInit() {
 
 	err := sysdb.NewTable("module")
 	if err != nil {
-		log.Fatal(err)
+		systemWideLogger.PrintAndLog("System", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 
 }
 
 /*
-	Handle endpoint registry for Module installer
-
+Handle endpoint registry for Module installer
 */
 func ModuleInstallerInit() {
 	//Register module installation setting
@@ -163,7 +162,7 @@ func ModuleInstallerInit() {
 
 }
 
-//Handle module installation request
+// Handle module installation request
 func HandleModuleInstall(w http.ResponseWriter, r *http.Request) {
 	opr, _ := utils.PostPara(r, "opr")
 

--- a/src/network.go
+++ b/src/network.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -343,7 +342,7 @@ func FileServerInit() {
 	SambaShareManager, err = samba.NewSambaShareManager(userHandler)
 	if err != nil {
 		//Disable samba if not installed or platform not supported
-		log.Println("[INFO] Samba Share Manager Disabled: " + err.Error())
+		systemWideLogger.PrintAndLog("System", "[INFO] Samba Share Manager Disabled: " + err.Error(), nil)
 	}
 
 	//Register Endpoints

--- a/src/startup.go
+++ b/src/startup.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	db "imuslab.com/arozos/mod/database"
@@ -22,7 +21,7 @@ func RunStartup() {
 
 	//Check if system or web both not exists and web.tar.gz exists. Unzip it for the user
 	if (!fs.FileExists("system/") || !fs.FileExists("web/")) && fs.FileExists("./web.tar.gz") {
-		log.Println("[Update] Unzipping system critical files from archive")
+		systemWideLogger.PrintAndLog("System", "[Update] Unzipping system critical files from archive", nil)
 		extErr := filesystem.ExtractTarGzipFile("./web.tar.gz", "./")
 		if extErr != nil {
 			//Extract failed

--- a/src/storage.go
+++ b/src/storage.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -148,7 +147,7 @@ func StoragePerformFileSystemAbstractionConnectionHeartbeat() {
 	for _, thisFsh := range allFsh {
 		err := thisFsh.FileSystemAbstraction.Heartbeat()
 		if err != nil {
-			log.Println("[Storage] File System Abstraction from " + thisFsh.Name + " report an error: " + err.Error())
+			systemWideLogger.PrintAndLog("System", "[Storage] File System Abstraction from " + thisFsh.Name + " report an error: " + err.Error(), nil)
 			//Retreive the old startup config and close the pool
 			originalStartOption := filesystem.FileSystemOption{}
 			js, _ := json.Marshal(thisFsh.StartOptions)
@@ -159,7 +158,7 @@ func StoragePerformFileSystemAbstractionConnectionHeartbeat() {
 				LocalBufferPath: *tmp_directory,
 			})
 			if err != nil {
-				log.Println("[Storage] Unable to reconnect " + thisFsh.Name + ": " + err.Error())
+				systemWideLogger.PrintAndLog("System", "[Storage] Unable to reconnect " + thisFsh.Name + ": " + err.Error(), nil)
 				continue
 			} else {
 				//New fsh created. Close the old one
@@ -180,7 +179,7 @@ func StoragePerformFileSystemAbstractionConnectionHeartbeat() {
 			for _, pool := range parentsp {
 				err := pool.AttachFsHandler(newfsh)
 				if err != nil {
-					log.Println("[Storage] Attach fsh to pool failed: " + err.Error())
+					systemWideLogger.PrintAndLog("System", "[Storage] Attach fsh to pool failed: " + err.Error(), nil)
 				}
 			}
 		}

--- a/src/storage.pool.go
+++ b/src/storage.pool.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -41,8 +41,9 @@ func StoragePoolEditorInit() {
 	//Create the required folder structure
 	err := os.MkdirAll("./system/storage", 0775)
 	if err != nil {
-		log.Println("Create storage pool setting folder failed: ")
-		log.Fatal(err)
+		systemWideLogger.PrintAndLog("System", "Create storage pool setting folder failed: ", nil)
+		systemWideLogger.PrintAndLog("System", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 
 	adminRouter.HandleFunc("/system/storage/pool/list", HandleListStoragePools)
@@ -99,7 +100,7 @@ func HandleFSHEdit(w http.ResponseWriter, r *http.Request) {
 			utils.SendErrorResponse(w, err.Error())
 			return
 		}
-		//systemWideLogger.PrintAndLog("Storage", newFsOption, nil)
+		//systemWideLogger.PrintAndLog("Storage", fmt.Sprint(newFsOption), nil)
 
 		uuid := newFsOption.Uuid
 

--- a/src/system.go
+++ b/src/system.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -105,13 +105,15 @@ func systemIdGenerateSystemUUID() {
 		}
 		err := os.WriteFile("./system/dev.uuid", []byte(thisuuid), 0755)
 		if err != nil {
-			log.Fatal(err)
+			systemWideLogger.PrintAndLog("System", fmt.Sprint(err), nil)
+			os.Exit(1)
 		}
 		deviceUUID = thisuuid
 	} else {
 		thisuuid, err := os.ReadFile("./system/dev.uuid")
 		if err != nil {
-			log.Fatal("Failed to read system uuid file (system/dev.uuid).")
+			systemWideLogger.PrintAndLog("System", "Failed to read system uuid file (system/dev.uuid).", nil)
+			os.Exit(1)
 		}
 		deviceUUID = string(thisuuid)
 	}
@@ -121,7 +123,8 @@ func systemIdGetSystemUUID() string {
 	fileUUID, err := os.ReadFile("./system/dev.uuid")
 	if err != nil {
 		systemWideLogger.PrintAndLog("Storage", "Unable to read system UUID from dev.uuid file", err)
-		log.Fatal(err)
+		systemWideLogger.PrintAndLog("System", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 
 	return string(fileUUID)

--- a/src/system.resetpw.go
+++ b/src/system.resetpw.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	auth "imuslab.com/arozos/mod/auth"
@@ -136,7 +137,8 @@ func system_resetpw_handlePasswordReset(w http.ResponseWriter, r *http.Request) 
 		"rkey":        resetkey,
 	})
 	if err != nil {
-		log.Fatal(err)
+		systemWideLogger.PrintAndLog("System", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	w.Write([]byte(template))
@@ -154,7 +156,8 @@ func system_resetpw_serveIdEnterInterface(w http.ResponseWriter, r *http.Request
 		"host_name":   *host_name,
 	})
 	if err != nil {
-		log.Fatal(err)
+		systemWideLogger.PrintAndLog("System", fmt.Sprint(err), nil)
+		os.Exit(1)
 	}
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	w.Write([]byte(template))


### PR DESCRIPTION
Replace all log.Println, log.Printf, log.Print, log.Fatal, log.Fatalln, and log.Fatalf calls with the arozos logger package's PrintAndLog method.

- Main package files use the existing systemWideLogger instance
- Each module package gets a new zz_logger.go file declaring a package-level logger var (e.g. databaseLogger) via NewTmpLogger()
- log.Fatal* calls are replaced with PrintAndLog + os.Exit(1)
- Multi-arg calls are wrapped with fmt.Sprint/fmt.Sprintf as appropriate
- Non-string arguments (errors, variables) are wrapped with fmt.Sprint
- Commented-out log calls and the logger package itself are left unchanged