### PR TITLE
Route AGI script console output through structured logger

### DIFF
--- a/src/agi.go
+++ b/src/agi.go
@@ -22,6 +22,7 @@ func AGIInit() {
 		ModuleRegisterParser: moduleHandler.RegisterModuleFromAGI,
 		ModuleListProvider:   moduleHandler.GetModuleListJSONForUser,
 		PackageManager:       packageManager,
+		Logger:               systemWideLogger,
 		UserHandler:          userHandler,
 		StartupRoot:          "./web",
 		ActivateScope:        []string{"./web", "./subservice"},

--- a/src/mod/agi/agi.go
+++ b/src/mod/agi/agi.go
@@ -19,6 +19,7 @@ import (
 	apt "imuslab.com/arozos/mod/apt"
 	"imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 	metadata "imuslab.com/arozos/mod/filesystem/metadata"
 	"imuslab.com/arozos/mod/iot"
 	"imuslab.com/arozos/mod/share"
@@ -54,6 +55,7 @@ type AgiSysInfo struct {
 	LoadedModule    []string
 
 	//System Handlers
+	Logger               *logger.Logger
 	UserHandler          *user.UserHandler
 	ReservedTables       []string
 	PackageManager       *apt.AptPackageManager

--- a/src/mod/agi/agi.system.go
+++ b/src/mod/agi/agi.system.go
@@ -38,6 +38,19 @@ func (g *Gateway) injectStandardLibs(vm *otto.Otto, scriptFile string, scriptSco
 	// Available in every AGI script — use it for log correlation, deduplication, etc.
 	vm.Set("EXECUTION_ID", execID)
 
+	// Override otto's built-in console.log (which maps to fmt.Println) so that
+	// script output goes through the structured logger and carries the execID.
+	vm.Set("_agi_console_log", func(call otto.FunctionCall) otto.Value {
+		parts := make([]string, 0, len(call.ArgumentList))
+		for _, arg := range call.ArgumentList {
+			str, _ := arg.ToString()
+			parts = append(parts, str)
+		}
+		agiLogger.PrintAndLog("AGI", "["+execID+"] "+strings.Join(parts, " "), nil)
+		return otto.UndefinedValue()
+	})
+	vm.Run(`var console = { log: _agi_console_log, warn: _agi_console_log, error: _agi_console_log, info: _agi_console_log };`) //nolint:errcheck
+
 	//Response related
 	vm.Set("sendResp", func(call otto.FunctionCall) otto.Value {
 		argString, _ := call.Argument(0).ToString()

--- a/src/mod/agi/agi.system.go
+++ b/src/mod/agi/agi.system.go
@@ -40,13 +40,19 @@ func (g *Gateway) injectStandardLibs(vm *otto.Otto, scriptFile string, scriptSco
 
 	// Override otto's built-in console.log (which maps to fmt.Println) so that
 	// script output goes through the structured logger and carries the execID.
+	// Use the system-wide logger (with file output) when available; fall back to
+	// agiLogger (stdout only) if the Gateway was created without one.
+	scriptLogger := agiLogger
+	if g.Option.Logger != nil {
+		scriptLogger = g.Option.Logger
+	}
 	vm.Set("_agi_console_log", func(call otto.FunctionCall) otto.Value {
 		parts := make([]string, 0, len(call.ArgumentList))
 		for _, arg := range call.ArgumentList {
 			str, _ := arg.ToString()
 			parts = append(parts, str)
 		}
-		agiLogger.PrintAndLog("AGI", "["+execID+"] "+strings.Join(parts, " "), nil)
+		scriptLogger.PrintAndLog("AGI", "["+execID+"] "+strings.Join(parts, " "), nil)
 		return otto.UndefinedValue()
 	})
 	vm.Run(`var console = { log: _agi_console_log, warn: _agi_console_log, error: _agi_console_log, info: _agi_console_log };`) //nolint:errcheck


### PR DESCRIPTION
## Summary
This change enhances AGI script logging by routing `console.log()` and related console methods through the system's structured logger instead of using otto's default implementation. This ensures script output is properly logged with execution IDs for better traceability and debugging.

## Key Changes
- **Console method override**: Replaced otto's built-in `console.log`, `console.warn`, `console.error`, and `console.info` with a custom implementation that routes output through the structured logger
- **Execution ID correlation**: All script console output now includes the execution ID in the log message for better correlation and deduplication
- **Logger selection**: Uses the system-wide logger when available (with file output), falling back to the AGI-specific logger (stdout only) if the Gateway was created without one
- **Logger injection**: Added `Logger` field to `AgiSysInfo` struct and passed the system-wide logger instance during AGI initialization

## Implementation Details
- The custom console implementation converts all arguments to strings and joins them with spaces, matching standard console behavior
- Output is logged using the `PrintAndLog` method with "AGI" as the module identifier and the execution ID prepended to the message
- The console object is created via JavaScript code injection to override all four common console methods with the same handler

https://claude.ai/code/session_01EHns6vxckbmLuuMcZnzBmS