### PR TITLE
Added JSON support for the system logger, unified all logger

### DIFF
--- a/src/locale.go
+++ b/src/locale.go
@@ -14,8 +14,8 @@ import (
 
 // localeFileSchema is the top-level structure shared by all locale JSON files.
 type localeFileSchema struct {
-	Author string                     `json:"author"`
-	Keys   map[string]localeKeyEntry  `json:"keys"`
+	Author string                    `json:"author"`
+	Keys   map[string]localeKeyEntry `json:"keys"`
 }
 
 type localeKeyEntry struct {

--- a/src/main.flags.go
+++ b/src/main.flags.go
@@ -98,6 +98,7 @@ var enable_buffering = flag.Bool("enable_buffpool", true, "Enable buffer pool fo
 var enable_beta_scanning_support = flag.Bool("beta_scan", false, "Allow compatibility to ArOZ Online Beta Clusters")
 var enable_console = flag.Bool("console", false, "Enable the debugging console.")
 var enable_logging = flag.Bool("logging", true, "Enable logging to file for debug purpose")
+var log_format = flag.String("log_format", "text", "Console log output format: text or json")
 
 // Flags related to running on Cloud Environment or public domain
 var allow_public_registry = flag.Bool("public_reg", false, "Enable public register interface for account creation")

--- a/src/main.go
+++ b/src/main.go
@@ -93,6 +93,7 @@ func main() {
 	// Initialize a temporary stdout-only logger so calls before RunStartup are safe.
 	// RunStartup will replace this with a file-backed logger.
 	systemWideLogger, _ = logger.NewTmpLogger()
+	logger.SetDefaultLogger(systemWideLogger)
 
 	//Print copyRight information
 	systemWideLogger.PrintAndLog("System", "ArozOS(C) "+strconv.Itoa(time.Now().Year())+" "+deviceVendor+".", nil)

--- a/src/main.go
+++ b/src/main.go
@@ -71,6 +71,7 @@ func executeShutdownSequence() {
 func main() {
 	//Parse startup flags and paramters
 	flag.Parse()
+	logger.SetGlobalJSONOutput(*log_format == "json")
 
 	//Handle version printing
 	if *show_version {
@@ -92,7 +93,6 @@ func main() {
 	// Initialize a temporary stdout-only logger so calls before RunStartup are safe.
 	// RunStartup will replace this with a file-backed logger.
 	systemWideLogger, _ = logger.NewTmpLogger()
-	systemWideLogger.PrintJSON = (*log_format == "json")
 
 	//Print copyRight information
 	systemWideLogger.PrintAndLog("System", "ArozOS(C) "+strconv.Itoa(time.Now().Year())+" "+deviceVendor+".", nil)

--- a/src/main.go
+++ b/src/main.go
@@ -92,6 +92,7 @@ func main() {
 	// Initialize a temporary stdout-only logger so calls before RunStartup are safe.
 	// RunStartup will replace this with a file-backed logger.
 	systemWideLogger, _ = logger.NewTmpLogger()
+	systemWideLogger.PrintJSON = (*log_format == "json")
 
 	//Print copyRight information
 	systemWideLogger.PrintAndLog("System", "ArozOS(C) "+strconv.Itoa(time.Now().Year())+" "+deviceVendor+".", nil)

--- a/src/mod/agi/agi.appdata.go
+++ b/src/mod/agi/agi.appdata.go
@@ -10,6 +10,7 @@ import (
 	"github.com/robertkrimen/otto"
 	"imuslab.com/arozos/mod/agi/static"
 	"imuslab.com/arozos/mod/filesystem"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -28,7 +29,7 @@ var webRoot string = "./web" //The web folder root
 func (g *Gateway) AppdataLibRegister() {
 	err := g.RegisterLib("appdata", g.injectAppdataLibFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }

--- a/src/mod/agi/agi.audio.go
+++ b/src/mod/agi/agi.audio.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -20,7 +21,7 @@ import (
 func (g *Gateway) AudioLibRegister() {
 	err := g.RegisterLib("audio", g.injectAudioFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }

--- a/src/mod/agi/agi.ffmpeg.go
+++ b/src/mod/agi/agi.ffmpeg.go
@@ -11,6 +11,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"imuslab.com/arozos/mod/agi/static"
 	"imuslab.com/arozos/mod/agi/static/ffmpegutil"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -27,12 +28,12 @@ import (
 func (g *Gateway) FFmpegLibRegister() {
 	_, err := exec.LookPath("ffmpeg")
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", "ffmpeg not found in PATH", nil)
+		logger.PrintAndLog("Agi", "ffmpeg not found in PATH", nil)
 		os.Exit(1)
 	}
 	err = g.RegisterLib("ffmpeg", g.injectFFmpegFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }

--- a/src/mod/agi/agi.file.go
+++ b/src/mod/agi/agi.file.go
@@ -16,6 +16,7 @@ import (
 	"imuslab.com/arozos/mod/agi/static"
 	"imuslab.com/arozos/mod/filesystem/fssort"
 	"imuslab.com/arozos/mod/filesystem/hidden"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -30,7 +31,7 @@ import (
 func (g *Gateway) FileLibRegister() {
 	err := g.RegisterLib("filelib", g.injectFileLibFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }
@@ -282,7 +283,7 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 			}
 
 			if !fssort.SortModeIsSupported(userSortMode) {
-				agiLogger.PrintAndLog("Agi", "[AGI] Sort mode: "+userSortMode+" not supported. Using default", nil)
+				logger.PrintAndLog("Agi", "[AGI] Sort mode: "+userSortMode+" not supported. Using default", nil)
 				userSortMode = "default"
 			}
 
@@ -360,7 +361,7 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 		}
 
 		if !fssort.SortModeIsSupported(userSortMode) {
-			agiLogger.PrintAndLog("Agi", "[AGI] Sort mode: "+userSortMode+" not supported. Using default", nil)
+			logger.PrintAndLog("Agi", "[AGI] Sort mode: "+userSortMode+" not supported. Using default", nil)
 			userSortMode = "default"
 		}
 
@@ -437,7 +438,7 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 		}
 
 		if !fssort.SortModeIsSupported(userSortMode) {
-			agiLogger.PrintAndLog("Agi", "[AGI] Sort mode: "+userSortMode+" not supported. Using default", nil)
+			logger.PrintAndLog("Agi", "[AGI] Sort mode: "+userSortMode+" not supported. Using default", nil)
 			userSortMode = "default"
 		}
 
@@ -625,14 +626,14 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 		//Translate the path to realpath
 		fsh, rdir, err := static.VirtualPathToRealPath(vdir, u)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", err.Error(), nil)
+			logger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 
 		//Create the directory at rdir location
 		err = fsh.FileSystemAbstraction.MkdirAll(rdir, 0755)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", err.Error(), nil)
+			logger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 
@@ -732,13 +733,13 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 
 		fsh, rpath, err := static.VirtualPathToRealPath(vpath, u)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", err.Error(), nil)
+			logger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 
 		info, err := fsh.FileSystemAbstraction.Stat(rpath)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", err.Error(), nil)
+			logger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 
@@ -780,7 +781,7 @@ func (g *Gateway) injectFileLibFunctions(payload *static.AgiLibInjectionPayload)
 		//Get the target vpath
 		fsh, rpath, err := static.VirtualPathToRealPath(vpath, u)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", err.Error(), nil)
+			logger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.FalseValue()
 		}
 

--- a/src/mod/agi/agi.go
+++ b/src/mod/agi/agi.go
@@ -20,6 +20,7 @@ import (
 	"imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
 	metadata "imuslab.com/arozos/mod/filesystem/metadata"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/iot"
 	"imuslab.com/arozos/mod/share"
 	"imuslab.com/arozos/mod/time/nightly"
@@ -115,12 +116,12 @@ func (g *Gateway) RegisterNightlyOperations() {
 					if static.CheckUserAccessToScript(userinfo, scriptFile, "") {
 						//This user can access the module that provide this script.
 						//Execute this script on his account.
-						agiLogger.PrintAndLog("Agi", "[AGI_Nightly] WIP ("+scriptFile+")", nil)
+						logger.PrintAndLog("Agi", "[AGI_Nightly] WIP ("+scriptFile+")", nil)
 					}
 				}
 			} else {
 				//Invalid script. Skipping
-				agiLogger.PrintAndLog("Agi", "[AGI_Nightly] Invalid script file: "+scriptFile, nil)
+				logger.PrintAndLog("Agi", "[AGI_Nightly] Invalid script file: "+scriptFile, nil)
 			}
 		}
 	})
@@ -131,7 +132,7 @@ func (g *Gateway) InitiateAllWebAppModules() {
 	for _, script := range startupScripts {
 		scriptContentByte, _ := os.ReadFile(script)
 		scriptContent := string(scriptContentByte)
-		agiLogger.PrintAndLog("Agi", "[AGI] Gateway script loaded ("+script+")", nil)
+		logger.PrintAndLog("Agi", "[AGI] Gateway script loaded ("+script+")", nil)
 		//Create a new vm for this request
 		vm := otto.New()
 
@@ -142,8 +143,8 @@ func (g *Gateway) InitiateAllWebAppModules() {
 		})
 		_, err := vm.Run(scriptContent)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", "[AGI] Load Failed: "+script+". Skipping.", nil)
-			agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+			logger.PrintAndLog("Agi", "[AGI] Load Failed: "+script+". Skipping.", nil)
+			logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 			continue
 		}
 	}
@@ -158,7 +159,7 @@ func (g *Gateway) RunScript(script string) error {
 
 	_, err := vm.Run(script)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint("[AGI] Script Execution Failed: ", err.Error()), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint("[AGI] Script Execution Failed: ", err.Error()), nil)
 		return err
 	}
 
@@ -169,7 +170,7 @@ func (g *Gateway) RaiseError(err error) {
 	if err == nil {
 		return
 	}
-	agiLogger.PrintAndLog("Agi", "[AGI] Runtime Error "+err.Error(), nil)
+	logger.PrintAndLog("Agi", "[AGI] Runtime Error "+err.Error(), nil)
 
 	//To be implemented
 }
@@ -322,7 +323,7 @@ func (g *Gateway) ExecuteAGIScript(scriptContent string, fsh *filesystem.FileSys
 		if thisuser != nil {
 			username = thisuser.Username
 		}
-		agiLogger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Script error in %s (user: %s): %s", scriptFile, username, err.Error()), nil)
+		logger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Script error in %s (user: %s): %s", scriptFile, username, err.Error()), nil)
 
 		if devMode {
 			// Return a detailed JSON error payload for developer inspection
@@ -392,14 +393,14 @@ func (g *Gateway) ExecuteAGIScriptAsUser(fsh *filesystem.FileSystemHandler, scri
 	defer func() {
 		if caught := recover(); caught != nil {
 			if caught == errTimeout {
-				agiLogger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Execution timeout: %s (user: %s)", scriptFile, targetUser.Username), nil)
+				logger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Execution timeout: %s (user: %s)", scriptFile, targetUser.Username), nil)
 				return
 			} else if caught == errExitcall {
 				//Exit gracefully
 				return
 			} else {
 				//Something screwed. Return Internal Server Error
-				agiLogger.PrintAndLog("Agi", fmt.Sprintf("[AGI] VM crash in %s (user: %s): %v", scriptFile, targetUser.Username, caught), nil)
+				logger.PrintAndLog("Agi", fmt.Sprintf("[AGI] VM crash in %s (user: %s): %v", scriptFile, targetUser.Username, caught), nil)
 				if w != nil {
 					devMode := r != nil && r.URL.Query().Get("agi_devmode") == "true"
 					if devMode {
@@ -445,7 +446,7 @@ func (g *Gateway) ExecuteAGIScriptAsUser(fsh *filesystem.FileSystemHandler, scri
 
 	_, err = vm.Run(scriptContent)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Script error in %s (user: %s): %s", scriptFile, targetUser.Username, err.Error()), nil)
+		logger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Script error in %s (user: %s): %s", scriptFile, targetUser.Username, err.Error()), nil)
 		return execID, "", err
 	}
 

--- a/src/mod/agi/agi.http.go
+++ b/src/mod/agi/agi.http.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/robertkrimen/otto"
 	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -28,7 +29,7 @@ import (
 func (g *Gateway) HTTPLibRegister() {
 	err := g.RegisterLib("http", g.injectHTTPFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }
@@ -96,7 +97,7 @@ func (g *Gateway) injectHTTPFunctions(payload *static.AgiLibInjectionPayload) {
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+			logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 			return otto.NullValue()
 		}
 		defer resp.Body.Close()
@@ -251,7 +252,7 @@ func (g *Gateway) injectHTTPFunctions(payload *static.AgiLibInjectionPayload) {
 
 		r, err := otto.ToValue(string(sEnc))
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", err.Error(), nil)
+			logger.PrintAndLog("Agi", err.Error(), nil)
 			return otto.NullValue()
 		}
 		return r

--- a/src/mod/agi/agi.image.go
+++ b/src/mod/agi/agi.image.go
@@ -23,6 +23,7 @@ import (
 
 	"imuslab.com/arozos/mod/agi/static"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -36,7 +37,7 @@ import (
 func (g *Gateway) ImageLibRegister() {
 	err := g.RegisterLib("imagelib", g.injectImageLibFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }

--- a/src/mod/agi/agi.iot.go
+++ b/src/mod/agi/agi.iot.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/robertkrimen/otto"
 	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/iot"
 )
 
@@ -22,7 +23,7 @@ import (
 func (g *Gateway) IoTLibRegister() {
 	err := g.RegisterLib("iot", g.injectIoTFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }
@@ -121,7 +122,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 		//Just leave it to the front end to handle :P
 		devStatus, err := dev.Handler.Status(dev)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", "*AGI IoT* "+err.Error(), nil)
+			logger.PrintAndLog("Agi", "*AGI IoT* "+err.Error(), nil)
 			return otto.FalseValue()
 		}
 
@@ -153,7 +154,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 		dev := g.Option.IotManager.GetDeviceByID(devID)
 		if dev == nil {
 			//Device not found
-			agiLogger.PrintAndLog("Agi", "*AGI IoT* Given device ID do not match any IoT devices", nil)
+			logger.PrintAndLog("Agi", "*AGI IoT* Given device ID do not match any IoT devices", nil)
 			return otto.FalseValue()
 		}
 
@@ -170,7 +171,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 
 		if targetEp == nil {
 			//Endpoint not found
-			agiLogger.PrintAndLog("Agi", "*AGI IoT* Failed to get endpoint by name in this device", nil)
+			logger.PrintAndLog("Agi", "*AGI IoT* Failed to get endpoint by name in this device", nil)
 			return otto.FalseValue()
 		}
 
@@ -182,7 +183,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 
 			err = json.Unmarshal([]byte(payload), &payloadMap)
 			if err != nil {
-				agiLogger.PrintAndLog("Agi", "*AGI IoT* Failed to parse input payload: "+err.Error(), nil)
+				logger.PrintAndLog("Agi", "*AGI IoT* Failed to parse input payload: "+err.Error(), nil)
 				return otto.FalseValue()
 			}
 
@@ -195,7 +196,7 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 		}
 
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", "*AGI IoT* Failed to execute request to device: "+err.Error(), nil)
+			logger.PrintAndLog("Agi", "*AGI IoT* Failed to execute request to device: "+err.Error(), nil)
 			return otto.FalseValue()
 		}
 
@@ -291,6 +292,6 @@ func (g *Gateway) injectIoTFunctions(payload *static.AgiLibInjectionPayload) {
 	`)
 
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint("*AGI* IoT Functions Injection Error", err.Error()), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint("*AGI* IoT Functions Injection Error", err.Error()), nil)
 	}
 }

--- a/src/mod/agi/agi.scheduler.go
+++ b/src/mod/agi/agi.scheduler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/robertkrimen/otto"
 	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -68,7 +69,7 @@ func (g *Gateway) RegisterSchedulerLib(callbacks *SchedulerCallbacks) {
 	})
 	if err != nil {
 		// Library already registered – not fatal, just warn
-		agiLogger.PrintAndLog("Agi", fmt.Sprint("[AGI] scheduler lib already registered:", err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint("[AGI] scheduler lib already registered:", err), nil)
 	}
 }
 

--- a/src/mod/agi/agi.share.go
+++ b/src/mod/agi/agi.share.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/robertkrimen/otto"
 	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 func (g *Gateway) ShareLibRegister() {
 	err := g.RegisterLib("share", g.injectShareFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }
@@ -42,7 +43,7 @@ func (g *Gateway) injectShareFunctions(payload *static.AgiLibInjectionPayload) {
 		vpathSourceFsh := u.GetRootFSHFromVpathInUserScope(vpath)
 		shareID, err := g.Option.ShareManager.CreateNewShare(u, vpathSourceFsh, vpath)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", "[AGI] Create Share Failed: "+err.Error(), nil)
+			logger.PrintAndLog("Agi", "[AGI] Create Share Failed: "+err.Error(), nil)
 			return otto.New().MakeCustomError("Share failed", err.Error())
 		}
 
@@ -50,7 +51,7 @@ func (g *Gateway) injectShareFunctions(payload *static.AgiLibInjectionPayload) {
 			go func(timeout int) {
 				time.Sleep(time.Duration(timeout) * time.Second)
 				g.Option.ShareManager.RemoveShareByUUID(u, shareID.UUID)
-				agiLogger.PrintAndLog("Agi", "[AGI] Share auto-removed: "+shareID.UUID, nil)
+				logger.PrintAndLog("Agi", "[AGI] Share auto-removed: "+shareID.UUID, nil)
 			}(int(timeout))
 		}
 
@@ -65,7 +66,7 @@ func (g *Gateway) injectShareFunctions(payload *static.AgiLibInjectionPayload) {
 		}
 		err = g.Option.ShareManager.RemoveShareByUUID(u, shareUUID)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", "[AGI] Share remove failed: "+err.Error(), nil)
+			logger.PrintAndLog("Agi", "[AGI] Share remove failed: "+err.Error(), nil)
 			return otto.New().MakeCustomError("Failed to remove share", err.Error())
 		}
 
@@ -75,13 +76,13 @@ func (g *Gateway) injectShareFunctions(payload *static.AgiLibInjectionPayload) {
 	vm.Set("_share_getShareUUID", func(call otto.FunctionCall) otto.Value {
 		vpath, err := call.Argument(0).ToString()
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", "[AGI] Failed to get share UUID: filepath not given", nil)
+			logger.PrintAndLog("Agi", "[AGI] Failed to get share UUID: filepath not given", nil)
 			return otto.NullValue()
 		}
 
 		shareObject := g.Option.ShareManager.GetShareObjectFromUserAndVpath(u, vpath)
 		if shareObject == nil {
-			agiLogger.PrintAndLog("Agi", "[AGI] Failed to get share UUID: File not shared", nil)
+			logger.PrintAndLog("Agi", "[AGI] Failed to get share UUID: File not shared", nil)
 			return otto.NullValue()
 		}
 

--- a/src/mod/agi/agi.sysinfo.go
+++ b/src/mod/agi/agi.sysinfo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/robertkrimen/otto"
 	"imuslab.com/arozos/mod/agi/static"
 	"imuslab.com/arozos/mod/disk/diskspace"
+	"imuslab.com/arozos/mod/info/logger"
 	usageinfo "imuslab.com/arozos/mod/info/usageinfo"
 	"imuslab.com/arozos/mod/network/netstat"
 )
@@ -41,7 +42,7 @@ var (
 func (g *Gateway) SysinfoLibRegister() {
 	err := g.RegisterLib("sysinfo", g.injectSysinfoLibFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }

--- a/src/mod/agi/agi.system.go
+++ b/src/mod/agi/agi.system.go
@@ -12,6 +12,7 @@ import (
 	"github.com/robertkrimen/otto"
 	uuid "github.com/satori/go.uuid"
 	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -337,7 +338,7 @@ func (g *Gateway) injectStandardLibs(vm *otto.Otto, scriptFile string, scriptSco
 			_, err = vm.Run(string(scriptContent))
 			if err != nil {
 				//Script execution failed
-				agiLogger.PrintAndLog("Agi", fmt.Sprint("Script Execution Failed: ", err.Error()), nil)
+				logger.PrintAndLog("Agi", fmt.Sprint("Script Execution Failed: ", err.Error()), nil)
 				g.RaiseError(err)
 				return otto.FalseValue()
 			}

--- a/src/mod/agi/agi.user.go
+++ b/src/mod/agi/agi.user.go
@@ -12,6 +12,7 @@ import (
 	"imuslab.com/arozos/mod/agi/static"
 	"imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 	user "imuslab.com/arozos/mod/user"
 )
 
@@ -29,17 +30,17 @@ func (g *Gateway) injectUserFunctions(vm *otto.Otto, fsh *filesystem.FileSystemH
 
 	//File system and path related
 	vm.Set("decodeVirtualPath", func(call otto.FunctionCall) otto.Value {
-		agiLogger.PrintAndLog("Agi", "Call to deprecated function decodeVirtualPath", nil)
+		logger.PrintAndLog("Agi", "Call to deprecated function decodeVirtualPath", nil)
 		return otto.FalseValue()
 	})
 
 	vm.Set("decodeAbsoluteVirtualPath", func(call otto.FunctionCall) otto.Value {
-		agiLogger.PrintAndLog("Agi", "Call to deprecated function decodeAbsoluteVirtualPath", nil)
+		logger.PrintAndLog("Agi", "Call to deprecated function decodeAbsoluteVirtualPath", nil)
 		return otto.FalseValue()
 	})
 
 	vm.Set("encodeRealPath", func(call otto.FunctionCall) otto.Value {
-		agiLogger.PrintAndLog("Agi", "Call to deprecated function encodeRealPath", nil)
+		logger.PrintAndLog("Agi", "Call to deprecated function encodeRealPath", nil)
 		return otto.FalseValue()
 	})
 
@@ -229,7 +230,7 @@ func (g *Gateway) injectUserFunctions(vm *otto.Otto, fsh *filesystem.FileSystemH
 				return otto.TrueValue()
 			} else {
 				//Lib not exists
-				agiLogger.PrintAndLog("Agi", "Lib not found: "+libname, nil)
+				logger.PrintAndLog("Agi", "Lib not found: "+libname, nil)
 				return otto.FalseValue()
 			}
 		}
@@ -275,7 +276,7 @@ func (g *Gateway) injectUserFunctions(vm *otto.Otto, fsh *filesystem.FileSystemH
 			_, err = vm.Run(string(scriptContent))
 			if err != nil {
 				//Script execution failed
-				agiLogger.PrintAndLog("Agi", fmt.Sprint("Script Execution Failed: ", err.Error()), nil)
+				logger.PrintAndLog("Agi", fmt.Sprint("Script Execution Failed: ", err.Error()), nil)
 				g.RaiseError(err)
 			}
 		}()

--- a/src/mod/agi/agi.websocket.go
+++ b/src/mod/agi/agi.websocket.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/robertkrimen/otto"
 	uuid "github.com/satori/go.uuid"
+	"imuslab.com/arozos/mod/info/logger"
 	user "imuslab.com/arozos/mod/user"
 )
 
@@ -68,8 +69,8 @@ type wsMsg struct {
 type wsConn struct {
 	conn        *websocket.Conn
 	msgChan     chan wsMsg // filled by the background reader goroutine
-	closed      int32     // 1 when closed; use atomic load/store
-	lastOprTime int64     // unix seconds of last activity; use atomic load/store
+	closed      int32      // 1 when closed; use atomic load/store
+	lastOprTime int64      // unix seconds of last activity; use atomic load/store
 }
 
 func newWsConn(c *websocket.Conn) *wsConn {
@@ -141,7 +142,7 @@ func dispatchOnMessage(vm *otto.Otto, msg wsMsg) {
 			websocket.onMessage(_ws_incoming);
 		}
 	`); err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint("*AGI WebSocket* onMessage handler error:", err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint("*AGI WebSocket* onMessage handler error:", err), nil)
 	}
 	vm.Set("_ws_incoming", otto.UndefinedValue())
 }
@@ -161,7 +162,7 @@ func (g *Gateway) injectWebSocketFunctions(vm *otto.Otto, u *user.User, w http.R
 
 		c, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
-			agiLogger.PrintAndLog("Agi", fmt.Sprint("*AGI WebSocket* upgrade failed:", err), nil)
+			logger.PrintAndLog("Agi", fmt.Sprint("*AGI WebSocket* upgrade failed:", err), nil)
 			return otto.FalseValue()
 		}
 
@@ -191,7 +192,7 @@ func (g *Gateway) injectWebSocketFunctions(vm *otto.Otto, u *user.User, w http.R
 					Type:      msgType,
 				}:
 				default:
-					agiLogger.PrintAndLog("Agi", "*AGI WebSocket* inbound buffer full, dropping frame", nil)
+					logger.PrintAndLog("Agi", "*AGI WebSocket* inbound buffer full, dropping frame", nil)
 				}
 			}
 		}()
@@ -206,7 +207,7 @@ func (g *Gateway) injectWebSocketFunctions(vm *otto.Otto, u *user.User, w http.R
 					return
 				}
 				if time.Now().Unix()-wsc.getLastOpr() > timeout {
-					agiLogger.PrintAndLog("Agi", "*AGI WebSocket* idle timeout — closing connection", nil)
+					logger.PrintAndLog("Agi", "*AGI WebSocket* idle timeout — closing connection", nil)
 					c.Close()
 					return
 				}

--- a/src/mod/agi/agi.zip.go
+++ b/src/mod/agi/agi.zip.go
@@ -14,6 +14,7 @@ import (
 	"imuslab.com/arozos/mod/agi/static"
 	"imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -27,7 +28,7 @@ import (
 func (g *Gateway) ZipLibRegister() {
 	err := g.RegisterLib("ziplib", g.injectZipFileLibFunctions)
 	if err != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 }

--- a/src/mod/agi/externalReqHandler.go
+++ b/src/mod/agi/externalReqHandler.go
@@ -10,6 +10,7 @@ import (
 
 	uuid "github.com/satori/go.uuid"
 	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -212,7 +213,7 @@ func (g *Gateway) ExtAPIHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !fsh.FileSystemAbstraction.FileExists(realPath) {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint("[Remote AGI] ", pathFromDb, " cannot be found on "+realPath), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint("[Remote AGI] ", pathFromDb, " cannot be found on "+realPath), nil)
 		http.Error(w, "invalid request: backend script not exists", http.StatusBadRequest)
 		return
 	}
@@ -227,7 +228,7 @@ func (g *Gateway) ExtAPIHandler(w http.ResponseWriter, r *http.Request) {
 	g.recordExecution(endpointUUID, pathFromDb, execID, r.Method, durationMs, execErr)
 
 	if execErr != nil {
-		agiLogger.PrintAndLog("Agi", fmt.Sprint("[Remote AGI] ", pathFromDb, " failed to execute", execErr.Error()), nil)
+		logger.PrintAndLog("Agi", fmt.Sprint("[Remote AGI] ", pathFromDb, " failed to execute", execErr.Error()), nil)
 		utils.SendErrorResponse(w, execErr.Error())
 		return
 	}

--- a/src/mod/agi/moduleManager.go
+++ b/src/mod/agi/moduleManager.go
@@ -5,6 +5,7 @@ import (
 
 	"imuslab.com/arozos/mod/agi/static"
 	apt "imuslab.com/arozos/mod/apt"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -60,7 +61,7 @@ func (g *Gateway) LoadAllFunctionalModules() {
 	if ffmpegExists {
 		g.FFmpegLibRegister()
 	} else {
-		agiLogger.PrintAndLog("Agi", "[AGI] ffmpeg not installed on host OS. Bypassing module.", nil)
+		logger.PrintAndLog("Agi", "[AGI] ffmpeg not installed on host OS. Bypassing module.", nil)
 	}
 
 }

--- a/src/mod/agi/zz_logger.go
+++ b/src/mod/agi/zz_logger.go
@@ -1,5 +1,0 @@
-package agi
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var agiLogger, _ = logger.NewTmpLogger()

--- a/src/mod/apt/apt.go
+++ b/src/mod/apt/apt.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -38,7 +40,7 @@ func (a *AptPackageManager) InstallIfNotExists(pkgname string, mustComply bool) 
 
 	installed, err := PackageExists(pkgname)
 	if err != nil {
-		aptLogger.PrintAndLog("Apt", err.Error(), nil)
+		logger.PrintAndLog("Apt", err.Error(), nil)
 	}
 
 	//log.Println(packageInfo)
@@ -47,7 +49,7 @@ func (a *AptPackageManager) InstallIfNotExists(pkgname string, mustComply bool) 
 	}
 
 	//Package not installed. Install if now if running in sudo mode
-	aptLogger.PrintAndLog("Apt", "Installing package "+pkgname+"...", nil)
+	logger.PrintAndLog("Apt", "Installing package "+pkgname+"...", nil)
 	cmd := exec.Command("apt-get", "install", "-y", pkgname)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -55,10 +57,10 @@ func (a *AptPackageManager) InstallIfNotExists(pkgname string, mustComply bool) 
 	if err != nil {
 		if mustComply {
 			//Panic and terminate server process
-			aptLogger.PrintAndLog("Apt", "Installation failed on package: "+pkgname, nil)
+			logger.PrintAndLog("Apt", "Installation failed on package: "+pkgname, nil)
 			os.Exit(1)
 		} else {
-			aptLogger.PrintAndLog("Apt", "Installation failed on package: "+pkgname, nil)
+			logger.PrintAndLog("Apt", "Installation failed on package: "+pkgname, nil)
 		}
 		return err
 	}

--- a/src/mod/apt/zz_logger.go
+++ b/src/mod/apt/zz_logger.go
@@ -1,5 +1,0 @@
-package apt
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var aptLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/accesscontrol/blacklist/blacklist.go
+++ b/src/mod/auth/accesscontrol/blacklist/blacklist.go
@@ -6,6 +6,7 @@ import (
 
 	"imuslab.com/arozos/mod/auth/accesscontrol"
 	db "imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -30,7 +31,7 @@ func NewBlacklistManager(sysdb *db.Database) *BlackList {
 	if sysdb.KeyExists("ipblacklist", "enable") {
 		err := sysdb.Read("ipblacklist", "enable", &blacklistEnabled)
 		if err != nil {
-			blacklistLogger.PrintAndLog("Blacklist", "[Auth/Blacklist] Unable to load previous enable state from database. Using default.", nil)
+			logger.PrintAndLog("Blacklist", "[Auth/Blacklist] Unable to load previous enable state from database. Using default.", nil)
 		}
 	}
 

--- a/src/mod/auth/accesscontrol/blacklist/zz_logger.go
+++ b/src/mod/auth/accesscontrol/blacklist/zz_logger.go
@@ -1,5 +1,0 @@
-package blacklist
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var blacklistLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/accesscontrol/utils.go
+++ b/src/mod/auth/accesscontrol/utils.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-//Break an ip range text into independent ip strings
+// Break an ip range text into independent ip strings
 func BreakdownIpRange(ipRange string) []string {
 	ipRange = strings.ReplaceAll(ipRange, " ", "")
 	err := ValidateIpRange(ipRange)
@@ -46,7 +46,7 @@ func BreakdownIpRange(ipRange string) []string {
 	return results
 }
 
-//Check if an given ip in the given range
+// Check if an given ip in the given range
 func IpInRange(ip string, ipRange string) bool {
 	ip = strings.TrimSpace(ip)
 	ipRange = strings.ReplaceAll(ipRange, " ", "")
@@ -82,7 +82,7 @@ func IpInRange(ip string, ipRange string) bool {
 	return false
 }
 
-//Check if the given IP Range string is actually an IP range
+// Check if the given IP Range string is actually an IP range
 func ValidateIpRange(ipRange string) error {
 	ipRange = strings.TrimSpace(ipRange)
 	ipRange = strings.ReplaceAll(ipRange, " ", "")

--- a/src/mod/auth/accesscontrol/whitelist/whitelist.go
+++ b/src/mod/auth/accesscontrol/whitelist/whitelist.go
@@ -6,6 +6,7 @@ import (
 
 	"imuslab.com/arozos/mod/auth/accesscontrol"
 	"imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -25,7 +26,7 @@ func NewWhitelistManager(sysdb *database.Database) *WhiteList {
 	if sysdb.KeyExists("ipwhitelist", "enable") {
 		err := sysdb.Read("ipwhitelist", "enable", &whitelistEnabled)
 		if err != nil {
-			whitelistLogger.PrintAndLog("Whitelist", "[Auth/Whitelist] Unable to load previous enable state from database. Using default.", nil)
+			logger.PrintAndLog("Whitelist", "[Auth/Whitelist] Unable to load previous enable state from database. Using default.", nil)
 		}
 	}
 

--- a/src/mod/auth/accesscontrol/whitelist/zz_logger.go
+++ b/src/mod/auth/accesscontrol/whitelist/zz_logger.go
@@ -1,5 +1,0 @@
-package whitelist
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var whitelistLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/accountSwitch.go
+++ b/src/mod/auth/accountSwitch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/sessions"
 	uuid "github.com/satori/go.uuid"
 	"imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -75,7 +76,7 @@ func NewSwitchableAccountPoolManager(sysdb *database.Database, parent *AuthAgent
 func (m *SwitchableAccountPoolManager) RunNightlyCleanup() {
 	pools, err := m.GetAllPools()
 	if err != nil {
-		authLogger.PrintAndLog("Auth", "[auth] Unable to load account switching pools. Cleaning skipped: "+err.Error(), nil)
+		logger.PrintAndLog("Auth", "[auth] Unable to load account switching pools. Cleaning skipped: "+err.Error(), nil)
 		return
 	}
 

--- a/src/mod/auth/auth.go
+++ b/src/mod/auth/auth.go
@@ -37,6 +37,7 @@ import (
 	"imuslab.com/arozos/mod/auth/authlogger"
 	"imuslab.com/arozos/mod/auth/explogin"
 	db "imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/network"
 	"imuslab.com/arozos/mod/utils"
 )
@@ -85,7 +86,7 @@ func NewAuthenticationAgent(sessionName string, key []byte, sysdb *db.Database, 
 	store := sessions.NewCookieStore(key)
 	err := sysdb.NewTable("auth")
 	if err != nil {
-		authLogger.PrintAndLog("Auth", "Failed to create auth database. Terminating.", nil)
+		logger.PrintAndLog("Auth", "Failed to create auth database. Terminating.", nil)
 		panic(err)
 	}
 
@@ -178,7 +179,7 @@ func (a *AuthAgent) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	username, err := utils.PostPara(r, "username")
 	if err != nil {
 		//Username not defined
-		authLogger.PrintAndLog("Auth", "[System Auth] Someone trying to login with username: "+username, nil)
+		logger.PrintAndLog("Auth", "[System Auth] Someone trying to login with username: "+username, nil)
 		//Write to log
 		a.Logger.LogAuth(r, false)
 		sendErrorResponse(w, "Username not defined or empty.")
@@ -232,12 +233,12 @@ func (a *AuthAgent) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		a.SwitchableAccountManager.MatchPoolCreatorOrResetPoolID(username, w, r)
 
 		//Print the login message to console
-		authLogger.PrintAndLog("Auth", username+" logged in.", nil)
+		logger.PrintAndLog("Auth", username+" logged in.", nil)
 		a.Logger.LogAuth(r, true)
 		sendOK(w)
 	} else {
 		//Password incorrect
-		authLogger.PrintAndLog("Auth", username+" login request rejected: "+rejectionReason, nil)
+		logger.PrintAndLog("Auth", username+" login request rejected: "+rejectionReason, nil)
 
 		//Add to retry count
 		a.ExpDelayHandler.AddUserRetrycount(username, r)
@@ -332,7 +333,7 @@ func (a *AuthAgent) LoginUserByRequest(w http.ResponseWriter, r *http.Request, u
 func (a *AuthAgent) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	username, _ := a.GetUserName(w, r)
 	if username != "" {
-		authLogger.PrintAndLog("Auth", username+" logged out.", nil)
+		logger.PrintAndLog("Auth", username+" logged out.", nil)
 	}
 
 	//Clear user switchable account pools
@@ -431,7 +432,7 @@ func (a *AuthAgent) HandleRegister(w http.ResponseWriter, r *http.Request) {
 
 	//Return to the client with OK
 	sendOK(w)
-	authLogger.PrintAndLog("Auth", "[System Auth] New user "+newusername+" added to system.", nil)
+	logger.PrintAndLog("Auth", "[System Auth] New user "+newusername+" added to system.", nil)
 	return
 }
 
@@ -478,7 +479,7 @@ func (a *AuthAgent) HandleUnregister(w http.ResponseWriter, r *http.Request) {
 
 	//Return to the client with OK
 	sendOK(w)
-	authLogger.PrintAndLog("Auth", "[system_auth] User "+username+" has been removed from the system.", nil)
+	logger.PrintAndLog("Auth", "[system_auth] User "+username+" has been removed from the system.", nil)
 	return
 }
 
@@ -515,7 +516,7 @@ func (a *AuthAgent) GetUserCounts() int {
 	}
 
 	if usercount == 0 {
-		authLogger.PrintAndLog("Auth", "There are no user in the database.", nil)
+		logger.PrintAndLog("Auth", "There are no user in the database.", nil)
 	}
 	return usercount
 }

--- a/src/mod/auth/authlogger/authlogger.go
+++ b/src/mod/auth/authlogger/authlogger.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -112,8 +113,8 @@ func (l *Logger) LogAuthByRequestInfo(username string, remoteAddr string, timest
 	entryKey := strconv.Itoa(int(time.Now().UnixNano()))
 	err := l.database.Write(tableName, entryKey, thisRecord)
 	if err != nil {
-		authloggerLogger.PrintAndLog("Authlogger", "*ERROR* Failed to write authentication log. Is the storage fulled?", nil)
-		authloggerLogger.PrintAndLog("Authlogger", err.Error(), nil)
+		logger.PrintAndLog("Authlogger", "*ERROR* Failed to write authentication log. Is the storage fulled?", nil)
+		logger.PrintAndLog("Authlogger", err.Error(), nil)
 		return err
 	}
 

--- a/src/mod/auth/authlogger/handlers.go
+++ b/src/mod/auth/authlogger/handlers.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -23,11 +24,11 @@ func (s summaryDate) Less(i, j int) bool {
 	layout := "Jan-2006"
 	timei, err := time.Parse(layout, s[i])
 	if err != nil {
-		authloggerLogger.PrintAndLog("Authlogger", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Authlogger", fmt.Sprint(err), nil)
 	}
 	timej, err := time.Parse(layout, s[j])
 	if err != nil {
-		authloggerLogger.PrintAndLog("Authlogger", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Authlogger", fmt.Sprint(err), nil)
 	}
 	return timei.Unix() > timej.Unix()
 }

--- a/src/mod/auth/authlogger/zz_logger.go
+++ b/src/mod/auth/authlogger/zz_logger.go
@@ -1,5 +1,0 @@
-package authlogger
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var authloggerLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/autologin.go
+++ b/src/mod/auth/autologin.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/sessions"
 	uuid "github.com/satori/go.uuid"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -107,7 +108,7 @@ func (a *AuthAgent) HandleAutologinTokenLogin(w http.ResponseWriter, r *http.Req
 	if a.AllowAutoLogin == false {
 		w.WriteHeader(http.StatusForbidden)
 		w.Write([]byte("403 - Forbidden"))
-		authLogger.PrintAndLog("Auth", "Someone is requesting autologin while this function is turned off.", nil)
+		logger.PrintAndLog("Auth", "Someone is requesting autologin while this function is turned off.", nil)
 		return
 	}
 
@@ -153,7 +154,7 @@ func (a *AuthAgent) HandleAutologinTokenLogin(w http.ResponseWriter, r *http.Req
 	session.Values["username"] = username
 	session.Values["rememberMe"] = false
 
-	authLogger.PrintAndLog("Auth", username+" logged in via auto-login token", nil)
+	logger.PrintAndLog("Auth", username+" logged in via auto-login token", nil)
 
 	//Check if remember me is clicked. If yes, set the maxage to 1 week.
 	session.Options = &sessions.Options{

--- a/src/mod/auth/autologin/autologin.go
+++ b/src/mod/auth/autologin/autologin.go
@@ -18,7 +18,7 @@ func NewAutoLoginHandler(uh *user.UserHandler) *AutoLoginHandler {
 	}
 }
 
-//List the token given the username
+// List the token given the username
 func (a *AutoLoginHandler) HandleUserTokensListing(w http.ResponseWriter, r *http.Request) {
 	username, err := utils.GetPara(r, "username")
 	if err != nil {
@@ -40,7 +40,7 @@ func (a *AutoLoginHandler) HandleUserTokensListing(w http.ResponseWriter, r *htt
 	utils.SendJSONResponse(w, string(jsonString))
 }
 
-//Handle User Token Creation, require username. Please use adminrouter to handle this function
+// Handle User Token Creation, require username. Please use adminrouter to handle this function
 func (a *AutoLoginHandler) HandleUserTokenCreation(w http.ResponseWriter, r *http.Request) {
 	username, err := utils.GetPara(r, "username")
 	if err != nil {
@@ -61,7 +61,7 @@ func (a *AutoLoginHandler) HandleUserTokenCreation(w http.ResponseWriter, r *htt
 	utils.SendJSONResponse(w, string(jsonString))
 }
 
-//Remove the user token given the token
+// Remove the user token given the token
 func (a *AutoLoginHandler) HandleUserTokenRemoval(w http.ResponseWriter, r *http.Request) {
 	token, err := utils.GetPara(r, "token")
 	if err != nil {

--- a/src/mod/auth/batch.go
+++ b/src/mod/auth/batch.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -131,7 +132,7 @@ func (a *AuthAgent) ExportUserListAsCSV() string {
 			//Get usergroup
 			usergroup := []string{}
 			a.Database.Read("auth", "group/"+username, &usergroup)
-			authLogger.PrintAndLog("Auth", fmt.Sprint(usergroup), nil)
+			logger.PrintAndLog("Auth", fmt.Sprint(usergroup), nil)
 			//Get user password hash
 			passhash := string(keypairs[1])
 

--- a/src/mod/auth/explogin/explogin.go
+++ b/src/mod/auth/explogin/explogin.go
@@ -32,7 +32,7 @@ type ExpLoginHandler struct {
 	DelayCeiling int       //Max delay time
 }
 
-//Create a new exponential login handler object
+// Create a new exponential login handler object
 func NewExponentialLoginHandler(baseDelay int, ceiling int) *ExpLoginHandler {
 	recordMap := sync.Map{}
 
@@ -43,7 +43,7 @@ func NewExponentialLoginHandler(baseDelay int, ceiling int) *ExpLoginHandler {
 	}
 }
 
-//Check allow access now, if false return how many seconds till next retry
+// Check allow access now, if false return how many seconds till next retry
 func (e *ExpLoginHandler) AllowImmediateAccess(username string, r *http.Request) (bool, int64) {
 	userip, err := getIpFromRequest(r)
 	if err != nil {
@@ -70,7 +70,7 @@ func (e *ExpLoginHandler) AllowImmediateAccess(username string, r *http.Request)
 	return true, 0
 }
 
-//Add a user retry count after failed login
+// Add a user retry count after failed login
 func (e *ExpLoginHandler) AddUserRetrycount(username string, r *http.Request) {
 	userip, err := getIpFromRequest(r)
 	if err != nil {
@@ -103,7 +103,7 @@ func (e *ExpLoginHandler) AddUserRetrycount(username string, r *http.Request) {
 	}
 }
 
-//Reset a user retry count after successful login
+// Reset a user retry count after successful login
 func (e *ExpLoginHandler) ResetUserRetryCount(username string, r *http.Request) {
 	userip, err := getIpFromRequest(r)
 	if err != nil {
@@ -115,7 +115,7 @@ func (e *ExpLoginHandler) ResetUserRetryCount(username string, r *http.Request) 
 	e.LoginRecord.Delete(key)
 }
 
-//Reset all Login exponential record
+// Reset all Login exponential record
 func (e *ExpLoginHandler) ResetAllUserRetryCounter() {
 	e.LoginRecord.Range(func(key interface{}, value interface{}) bool {
 		e.LoginRecord.Delete(key)
@@ -123,7 +123,7 @@ func (e *ExpLoginHandler) ResetAllUserRetryCounter() {
 	})
 }
 
-//Get the next delay time
+// Get the next delay time
 func (e *ExpLoginHandler) getDelayTimeFromRetryCount(retryCount int) int64 {
 	delaySecs := int64(math.Floor((math.Pow(2, float64(retryCount)) - 1) * 0.5))
 	if delaySecs > int64(e.DelayCeiling)-int64(e.BaseDelay) {

--- a/src/mod/auth/internal.go
+++ b/src/mod/auth/internal.go
@@ -5,12 +5,12 @@ import (
 	"net/http"
 )
 
-//Common functions
+// Common functions
 func sendTextResponse(w http.ResponseWriter, msg string) {
 	w.Write([]byte(msg))
 }
 
-//Send JSON response, with an extra json header
+// Send JSON response, with an extra json header
 func sendJSONResponse(w http.ResponseWriter, json string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(json))
@@ -26,7 +26,7 @@ func sendOK(w http.ResponseWriter) {
 	w.Write([]byte("\"OK\""))
 }
 
-//TODO: Deprecate this Mv
+// TODO: Deprecate this Mv
 func Mv(r *http.Request, getParamter string, postMode bool) (string, error) {
 	if postMode == false {
 		//Access the paramter via GET

--- a/src/mod/auth/ldap/ldap.go
+++ b/src/mod/auth/ldap/ldap.go
@@ -10,6 +10,7 @@ import (
 	"imuslab.com/arozos/mod/auth/oauth2/syncdb"
 	reg "imuslab.com/arozos/mod/auth/register"
 	db "imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	permission "imuslab.com/arozos/mod/permission"
 	"imuslab.com/arozos/mod/time/nightly"
 	"imuslab.com/arozos/mod/user"
@@ -52,10 +53,10 @@ type syncorizeUserReturnInterface struct {
 // NewLdapHandler xxx
 func NewLdapHandler(authAgent *auth.AuthAgent, register *reg.RegisterHandler, coreDb *db.Database, permissionHandler *permission.PermissionHandler, userHandler *user.UserHandler, nightlyManager *nightly.TaskManager, iconSystem string) *ldapHandler {
 	//ldap handler init
-	ldapLogger.PrintAndLog("Ldap", "Starting LDAP client...", nil)
+	logger.PrintAndLog("Ldap", "Starting LDAP client...", nil)
 	err := coreDb.NewTable("ldap")
 	if err != nil {
-		ldapLogger.PrintAndLog("Ldap", "Failed to create LDAP database. Terminating.", nil)
+		logger.PrintAndLog("Ldap", "Failed to create LDAP database. Terminating.", nil)
 		panic(err)
 	}
 
@@ -143,7 +144,7 @@ func (ldap *ldapHandler) NightlySync() {
 	if checkLDAPenabled == "true" {
 		err := ldap.SynchronizeUserFromLDAP()
 		if err != nil {
-			ldapLogger.PrintAndLog("Ldap", fmt.Sprint(err), nil)
+			logger.PrintAndLog("Ldap", fmt.Sprint(err), nil)
 		}
 	}
 }

--- a/src/mod/auth/ldap/ldapreader/reader.go
+++ b/src/mod/auth/ldap/ldapreader/reader.go
@@ -14,7 +14,7 @@ type LdapReader struct {
 	basedn   string
 }
 
-//NewOauthHandler xxx
+// NewOauthHandler xxx
 func NewLDAPReader(username string, password string, server string, basedn string) *LdapReader {
 
 	LDAPHandler := LdapReader{

--- a/src/mod/auth/ldap/web_login.go
+++ b/src/mod/auth/ldap/web_login.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -75,7 +76,7 @@ func (ldap *ldapHandler) HandleNewPasswordPage(w http.ResponseWriter, r *http.Re
 		"key":          key,
 	})
 	if err != nil {
-		ldapLogger.PrintAndLog("Ldap", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Ldap", fmt.Sprint(err), nil)
 		os.Exit(1)
 	}
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
@@ -92,7 +93,7 @@ func (ldap *ldapHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	username, err := utils.PostPara(r, "username")
 	if err != nil {
 		//Username not defined
-		ldapLogger.PrintAndLog("Ldap", "[System Auth] Someone trying to login with username: "+username, nil)
+		logger.PrintAndLog("Ldap", "[System Auth] Someone trying to login with username: "+username, nil)
 		//Write to log
 		ldap.ag.Logger.LogAuth(r, false)
 		utils.SendErrorResponse(w, "Username not defined or empty.")
@@ -120,7 +121,7 @@ func (ldap *ldapHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		ldap.ag.Logger.LogAuth(r, false)
 		utils.SendErrorResponse(w, "Unable to connect to LDAP server")
-		ldapLogger.PrintAndLog("Ldap", "LDAP Authentication error, "+err.Error(), nil)
+		logger.PrintAndLog("Ldap", "LDAP Authentication error, "+err.Error(), nil)
 		return
 	}
 	//The database contain this user information. Check its password if it is correct
@@ -134,13 +135,13 @@ func (ldap *ldapHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 			// Set user as authenticated
 			ldap.ag.LoginUserByRequest(w, r, username, rememberme)
 			//Print the login message to console
-			ldapLogger.PrintAndLog("Ldap", username+" logged in.", nil)
+			logger.PrintAndLog("Ldap", username+" logged in.", nil)
 			ldap.ag.Logger.LogAuth(r, true)
 			utils.SendOK(w)
 		}
 	} else {
 		//Password incorrect
-		ldapLogger.PrintAndLog("Ldap", username+" has entered an invalid username or password", nil)
+		logger.PrintAndLog("Ldap", username+" has entered an invalid username or password", nil)
 		utils.SendErrorResponse(w, "Invalid username or password")
 		ldap.ag.Logger.LogAuth(r, false)
 		return
@@ -198,7 +199,7 @@ func (ldap *ldapHandler) HandleSetPassword(w http.ResponseWriter, r *http.Reques
 		}
 	} else {
 		utils.SendErrorResponse(w, "Improper key detected")
-		ldapLogger.PrintAndLog("Ldap", r.RemoteAddr+" attempted to use invaild key to create new user but failed", nil)
+		logger.PrintAndLog("Ldap", r.RemoteAddr+" attempted to use invaild key to create new user but failed", nil)
 		return
 	}
 }

--- a/src/mod/auth/ldap/zz_logger.go
+++ b/src/mod/auth/ldap/zz_logger.go
@@ -1,5 +1,0 @@
-package ldap
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var ldapLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/oauth2/discovery.go
+++ b/src/mod/auth/oauth2/discovery.go
@@ -12,17 +12,17 @@ import (
 // OIDCDiscovery is the OpenID Connect Discovery document served at
 // {issuer}/.well-known/openid-configuration (RFC 8414 / OIDC Core §4).
 type OIDCDiscovery struct {
-	Issuer                            string   `json:"issuer"`
-	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
-	TokenEndpoint                     string   `json:"token_endpoint"`
-	UserinfoEndpoint                  string   `json:"userinfo_endpoint"`
-	JwksURI                           string   `json:"jwks_uri"`
-	ScopesSupported                   []string `json:"scopes_supported"`
-	ResponseTypesSupported            []string `json:"response_types_supported"`
-	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
-	SubjectTypesSupported             []string `json:"subject_types_supported"`
-	ClaimsSupported                   []string `json:"claims_supported"`
-	GrantTypesSupported               []string `json:"grant_types_supported"`
+	Issuer                           string   `json:"issuer"`
+	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
+	TokenEndpoint                    string   `json:"token_endpoint"`
+	UserinfoEndpoint                 string   `json:"userinfo_endpoint"`
+	JwksURI                          string   `json:"jwks_uri"`
+	ScopesSupported                  []string `json:"scopes_supported"`
+	ResponseTypesSupported           []string `json:"response_types_supported"`
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	ClaimsSupported                  []string `json:"claims_supported"`
+	GrantTypesSupported              []string `json:"grant_types_supported"`
 }
 
 // DiscoveryResult is the trimmed view returned to the frontend via HandleDiscover.

--- a/src/mod/auth/oauth2/oauth2.go
+++ b/src/mod/auth/oauth2/oauth2.go
@@ -15,6 +15,7 @@ import (
 	syncdb "imuslab.com/arozos/mod/auth/oauth2/syncdb"
 	reg "imuslab.com/arozos/mod/auth/register"
 	db "imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -62,7 +63,7 @@ type Config struct {
 // NewOauthHandler creates and initialises the OAuth2 handler.
 func NewOauthHandler(authAgent *auth.AuthAgent, register *reg.RegisterHandler, coreDb *db.Database) *OauthHandler {
 	if err := coreDb.NewTable("oauth"); err != nil {
-		oauth2Logger.PrintAndLog("Oauth2", "Failed to create oauth database. Terminating.", nil)
+		logger.PrintAndLog("Oauth2", "Failed to create oauth database. Terminating.", nil)
 		panic(err)
 	}
 	return &OauthHandler{
@@ -179,7 +180,7 @@ func (oh *OauthHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	oauth2Logger.PrintAndLog("Oauth2", username+" logged in via OAuth.", nil)
+	logger.PrintAndLog("Oauth2", username+" logged in via OAuth.", nil)
 	oh.ag.LoginUserByRequest(w, r, username, true)
 
 	remoteIP := r.Header.Get("X-FORWARDED-FOR")

--- a/src/mod/auth/oauth2/oauth2_discovery_test.go
+++ b/src/mod/auth/oauth2/oauth2_discovery_test.go
@@ -50,15 +50,15 @@ func TestBuildWellKnownURL_PathPrefix(t *testing.T) {
 // minimalDiscoveryDoc returns a valid OIDC discovery JSON body for a given base URL.
 func minimalDiscoveryDoc(base string) []byte {
 	doc := map[string]interface{}{
-		"issuer":                 base,
-		"authorization_endpoint": base + "/oauth2/authorize",
-		"token_endpoint":         base + "/oauth2/token",
-		"userinfo_endpoint":      base + "/oauth2/userinfo",
-		"jwks_uri":               base + "/oauth2/jwks",
-		"scopes_supported":       []string{"openid", "email", "profile"},
-		"claims_supported":       []string{"sub", "email", "name", "preferred_username"},
+		"issuer":                   base,
+		"authorization_endpoint":   base + "/oauth2/authorize",
+		"token_endpoint":           base + "/oauth2/token",
+		"userinfo_endpoint":        base + "/oauth2/userinfo",
+		"jwks_uri":                 base + "/oauth2/jwks",
+		"scopes_supported":         []string{"openid", "email", "profile"},
+		"claims_supported":         []string{"sub", "email", "name", "preferred_username"},
 		"response_types_supported": []string{"code"},
-		"grant_types_supported":  []string{"authorization_code"},
+		"grant_types_supported":    []string{"authorization_code"},
 	}
 	b, _ := json.Marshal(doc)
 	return b

--- a/src/mod/auth/oauth2/oauth2_handler_test.go
+++ b/src/mod/auth/oauth2/oauth2_handler_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	db "imuslab.com/arozos/mod/database"
 	syncdb "imuslab.com/arozos/mod/auth/oauth2/syncdb"
+	db "imuslab.com/arozos/mod/database"
 )
 
 // ── Test infrastructure ───────────────────────────────────────────────────────

--- a/src/mod/auth/oauth2/zz_logger.go
+++ b/src/mod/auth/oauth2/zz_logger.go
@@ -1,5 +1,0 @@
-package oauth2
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var oauth2Logger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/register/register.go
+++ b/src/mod/auth/register/register.go
@@ -21,6 +21,7 @@ import (
 
 	auth "imuslab.com/arozos/mod/auth"
 	db "imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	permission "imuslab.com/arozos/mod/permission"
 	"imuslab.com/arozos/mod/utils"
 )
@@ -102,7 +103,7 @@ func (h *RegisterHandler) HandleRegisterInterface(w http.ResponseWriter, r *http
 			"vendor_logo": imagecontent,
 		})
 		if err != nil {
-			registerLogger.PrintAndLog("Register", "Template not found: system/auth/register.html", nil)
+			logger.PrintAndLog("Register", "Template not found: system/auth/register.html", nil)
 			http.NotFound(w, r)
 			return
 		}
@@ -245,7 +246,7 @@ func (h *RegisterHandler) HandleRegisterRequest(w http.ResponseWriter, r *http.R
 	defaultGroup := h.DefaultUserGroup
 	if h.permissionHandler.GroupExists(defaultGroup) == false {
 		//Public registry user group not exists. Raise 500 Error
-		registerLogger.PrintAndLog("Register", "[CRITICAL] PUBLIC REGISTRY USER GROUP NOT FOUND! PLEASE RESTART YOUR SYSTEM!", nil)
+		logger.PrintAndLog("Register", "[CRITICAL] PUBLIC REGISTRY USER GROUP NOT FOUND! PLEASE RESTART YOUR SYSTEM!", nil)
 		utils.SendErrorResponse(w, "Internal Server Error")
 		return
 	}
@@ -261,7 +262,7 @@ func (h *RegisterHandler) HandleRegisterRequest(w http.ResponseWriter, r *http.R
 	h.database.Write("register", "user/email/"+username, email)
 
 	utils.SendOK(w)
-	registerLogger.PrintAndLog("Register", fmt.Sprint("New User Registered: ", email, username, strings.Repeat("*", len(password))), nil)
+	logger.PrintAndLog("Register", fmt.Sprint("New User Registered: ", email, username, strings.Repeat("*", len(password))), nil)
 
 }
 

--- a/src/mod/auth/register/zz_logger.go
+++ b/src/mod/auth/register/zz_logger.go
@@ -1,5 +1,0 @@
-package register
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var registerLogger, _ = logger.NewTmpLogger()

--- a/src/mod/auth/token.go
+++ b/src/mod/auth/token.go
@@ -18,7 +18,7 @@ type token struct {
 	CreationTime int64
 }
 
-//Create a new token based on the given HTTP request
+// Create a new token based on the given HTTP request
 func (a *AuthAgent) NewTokenFromRequest(w http.ResponseWriter, r *http.Request) (string, error) {
 	if !a.CheckAuth(r) {
 		return "", errors.New("User not logged in")
@@ -32,7 +32,7 @@ func (a *AuthAgent) NewTokenFromRequest(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-//Generate and return a new token that will be valid for the given time
+// Generate and return a new token that will be valid for the given time
 func (a *AuthAgent) NewToken(owner string) string {
 	//Generate a new token
 	newToken := uuid.NewV4().String()
@@ -47,7 +47,7 @@ func (a *AuthAgent) NewToken(owner string) string {
 	return newToken
 }
 
-//Get the token owner from the given token
+// Get the token owner from the given token
 func (a *AuthAgent) GetTokenOwner(tokenString string) (string, error) {
 	if val, ok := a.tokenStore.Load(tokenString); ok {
 		return val.(token).Owner, nil
@@ -56,7 +56,7 @@ func (a *AuthAgent) GetTokenOwner(tokenString string) (string, error) {
 	}
 }
 
-//validate if the given token is valid
+// validate if the given token is valid
 func (a *AuthAgent) TokenValid(tokenString string) bool {
 	//Check if the token validation is disabled
 	if a.ExpireTime == 0 {
@@ -79,7 +79,7 @@ func (a *AuthAgent) TokenValid(tokenString string) bool {
 	return false
 }
 
-//Run a token store scan and remove all expired tokens
+// Run a token store scan and remove all expired tokens
 func (a *AuthAgent) ClearTokenStore() {
 	currentTime := time.Now().Unix()
 	a.tokenStore.Range(func(k interface{}, v interface{}) bool {

--- a/src/mod/auth/zz_logger.go
+++ b/src/mod/auth/zz_logger.go
@@ -1,5 +1,0 @@
-package auth
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var authLogger, _ = logger.NewTmpLogger()

--- a/src/mod/compatibility/browser.go
+++ b/src/mod/compatibility/browser.go
@@ -7,13 +7,13 @@ import (
 )
 
 /*
-	FirefoxBrowserVersionForBypassUploadMetaHeaderCheck
+FirefoxBrowserVersionForBypassUploadMetaHeaderCheck
 
-	This function check if Firefox version is between 84 and 93.
-	If yes, this function will return TRUE and upload logic should not need to handle
-	META header for upload. If FALSE, please extract the relative filepath from the meta header.
-	Example Firefox userAgent header:
-	Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.02021/11/23
+This function check if Firefox version is between 84 and 93.
+If yes, this function will return TRUE and upload logic should not need to handle
+META header for upload. If FALSE, please extract the relative filepath from the meta header.
+Example Firefox userAgent header:
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.02021/11/23
 */
 func FirefoxBrowserVersionForBypassUploadMetaHeaderCheck(userAgent string) bool {
 	if strings.Contains(userAgent, "Mozilla") && strings.Contains(userAgent, "Firefox/") {
@@ -42,7 +42,7 @@ func FirefoxBrowserVersionForBypassUploadMetaHeaderCheck(userAgent string) bool 
 	return true
 }
 
-//Handle browser compatibility issue regarding some special format type
+// Handle browser compatibility issue regarding some special format type
 func BrowserCompatibilityOverrideContentType(userAgent string, filename string, contentType string) string {
 	if strings.Contains(userAgent, "Mozilla") && strings.Contains(userAgent, "Firefox/") {
 		//Firefox. Handle specal content-type serving

--- a/src/mod/console/console.go
+++ b/src/mod/console/console.go
@@ -2,31 +2,30 @@ package console
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strings"
-	"fmt"
 )
 
-type Console struct{
+type Console struct {
 	Handler func(string) string
 }
 
-func NewConsole(handler func(string) string) *Console{
+func NewConsole(handler func(string) string) *Console {
 	return &Console{
 		Handler: handler,
 	}
 }
 
-func (c *Console)ListenAndHandle(){
+func (c *Console) ListenAndHandle() {
 	for {
 		reader := bufio.NewReader(os.Stdin)
 		text, _ := reader.ReadString('\n')
 		text = strings.TrimSpace(text)
-		if len(text) > 0{
+		if len(text) > 0 {
 			fmt.Println("▌" + c.Handler(text))
-		}else{
+		} else {
 			fmt.Println("▌Invalid Command")
 		}
 	}
 }
-

--- a/src/mod/database/database.go
+++ b/src/mod/database/database.go
@@ -33,35 +33,38 @@ func (d *Database) UpdateReadWriteMode(readOnly bool) {
 	d.ReadOnly = readOnly
 }
 
-//Dump the whole db into a log file
+// Dump the whole db into a log file
 func (d *Database) Dump(filename string) ([]string, error) {
 	return d.dump(filename)
 }
 
-//Create a new table
+// Create a new table
 func (d *Database) NewTable(tableName string) error {
 	return d.newTable(tableName)
 }
 
-//Check is table exists
+// Check is table exists
 func (d *Database) TableExists(tableName string) bool {
 	return d.tableExists(tableName)
 }
 
-//Drop the given table
+// Drop the given table
 func (d *Database) DropTable(tableName string) error {
 	return d.dropTable(tableName)
 }
 
 /*
-	Write to database with given tablename and key. Example Usage:
+Write to database with given tablename and key. Example Usage:
+
 	type demo struct{
 		content string
 	}
+
 	thisDemo := demo{
 		content: "Hello World",
 	}
-	err := sysdb.Write("MyTable", "username/message",thisDemo);
+
+err := sysdb.Write("MyTable", "username/message",thisDemo);
 */
 func (d *Database) Write(tableName string, key string, value interface{}) error {
 	return d.write(tableName, key, value)
@@ -86,9 +89,9 @@ func (d *Database) KeyExists(tableName string, key string) bool {
 }
 
 /*
-	Delete a value from the database table given tablename and key
+Delete a value from the database table given tablename and key
 
-	err := sysdb.Delete("MyTable", "username/message");
+err := sysdb.Delete("MyTable", "username/message");
 */
 func (d *Database) Delete(tableName string, key string) error {
 	return d.delete(tableName, key)

--- a/src/mod/database/database_core.go
+++ b/src/mod/database/database_core.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/boltdb/bolt"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 func newDatabase(dbfile string, readOnlyMode bool) (*Database, error) {
@@ -40,7 +41,7 @@ func (d *Database) dump(filename string) ([]string, error) {
 	d.Tables.Range(func(tableName, v interface{}) bool {
 		entries, err := d.ListTable(tableName.(string))
 		if err != nil {
-			databaseLogger.PrintAndLog("Database", "Reading table "+tableName.(string)+" failed: "+err.Error(), nil)
+			logger.PrintAndLog("Database", "Reading table "+tableName.(string)+" failed: "+err.Error(), nil)
 			return false
 		}
 		for _, keypairs := range entries {
@@ -133,7 +134,7 @@ func (d *Database) keyExists(tableName string, key string) bool {
 	resultIsNil := false
 	if !d.TableExists(tableName) {
 		//Table not exists. Do not proceed accessing key
-		databaseLogger.PrintAndLog("Database", "[DB] ERROR: Requesting key from table that didn't exist!!!", nil)
+		logger.PrintAndLog("Database", "[DB] ERROR: Requesting key from table that didn't exist!!!", nil)
 		return false
 	}
 	err := d.Db.(*bolt.DB).View(func(tx *bolt.Tx) error {

--- a/src/mod/database/database_openwrt.go
+++ b/src/mod/database/database_openwrt.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 func newDatabase(dbfile string, readOnlyMode bool) (*Database, error) {
@@ -33,7 +35,7 @@ func newDatabase(dbfile string, readOnlyMode bool) (*Database, error) {
 		}
 	}
 
-	databaseLogger.PrintAndLog("Database", "Filesystem Emulated Key-value Database Service Started: "+dbRootPath, nil)
+	logger.PrintAndLog("Database", "Filesystem Emulated Key-value Database Service Started: "+dbRootPath, nil)
 	return &Database{
 		Db:       dbRootPath,
 		Tables:   tableMap,

--- a/src/mod/database/zz_logger.go
+++ b/src/mod/database/zz_logger.go
@@ -1,5 +1,0 @@
-package database
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var databaseLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/diskfs/diskfs.go
+++ b/src/mod/disk/diskfs/diskfs.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -228,7 +229,7 @@ func UnmountDevice(devicePath string) error {
 	// Run the command
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		diskfsLogger.PrintAndLog("Diskfs", "[RAID] Unable to unmount device: "+string(output), nil)
+		logger.PrintAndLog("Diskfs", "[RAID] Unable to unmount device: "+string(output), nil)
 		return fmt.Errorf("error unmounting device: %v", err)
 	}
 

--- a/src/mod/disk/diskfs/zz_logger.go
+++ b/src/mod/disk/diskfs/zz_logger.go
@@ -1,5 +1,0 @@
-package diskfs
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var diskfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/diskmg/diskmg.go
+++ b/src/mod/disk/diskmg/diskmg.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	fs "imuslab.com/arozos/mod/filesystem"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -111,7 +112,7 @@ func HandleView(w http.ResponseWriter, r *http.Request) {
 			utils.SendJSONResponse(w, string(js))
 
 		} else {
-			diskmgLogger.PrintAndLog("Diskmg", "system/disk/diskmg/DiskmgWin.exe NOT FOUND. Unable to load Window's disk information", nil)
+			logger.PrintAndLog("Diskmg", "system/disk/diskmg/DiskmgWin.exe NOT FOUND. Unable to load Window's disk information", nil)
 			utils.SendErrorResponse(w, "DiskmgWin.exe not found")
 			return
 		}
@@ -297,7 +298,7 @@ func HandleFormat(w http.ResponseWriter, r *http.Request, fsHandlers []*fs.FileS
 	mounted, err := checkDeviceMounted(devID)
 	if err != nil {
 		//Fail to check if disk mounted
-		diskmgLogger.PrintAndLog("Diskmg", err.Error(), nil)
+		logger.PrintAndLog("Diskmg", err.Error(), nil)
 		utils.SendErrorResponse(w, "Failed to check disk mount status")
 		return
 	}
@@ -311,7 +312,7 @@ func HandleFormat(w http.ResponseWriter, r *http.Request, fsHandlers []*fs.FileS
 			return
 		}
 
-		diskmgLogger.PrintAndLog("Diskmg", "Unmounting "+mountpt+" for format", nil)
+		logger.PrintAndLog("Diskmg", "Unmounting "+mountpt+" for format", nil)
 		//Unmount the devices
 		out, err := Unmount(mountpt, fsHandlers)
 		if err != nil {
@@ -337,16 +338,16 @@ func HandleFormat(w http.ResponseWriter, r *http.Request, fsHandlers []*fs.FileS
 	}
 
 	//Execute format comamnd
-	diskmgLogger.PrintAndLog("Diskmg", "Formatting of "+"/dev/"+devID+" Started", nil)
+	logger.PrintAndLog("Diskmg", "Formatting of "+"/dev/"+devID+" Started", nil)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		diskmgLogger.PrintAndLog("Diskmg", "Format failed: "+string(output), nil)
+		logger.PrintAndLog("Diskmg", "Format failed: "+string(output), nil)
 		utils.SendErrorResponse(w, string(output))
 		return
 	}
 
 	//Reply ok
-	diskmgLogger.PrintAndLog("Diskmg", string(output), nil)
+	logger.PrintAndLog("Diskmg", string(output), nil)
 
 	//Let the system to reload the disk
 	time.Sleep(2 * time.Second)
@@ -363,11 +364,11 @@ func Mount(devID string, mountpt string, mountingTool string, fsHandlers []*fs.F
 		}
 	}
 
-	diskmgLogger.PrintAndLog("Diskmg", fmt.Sprint("Executing Mount Command: ", "mount", "-t", mountingTool, "/dev/"+devID, mountpt), nil)
+	logger.PrintAndLog("Diskmg", fmt.Sprint("Executing Mount Command: ", "mount", "-t", mountingTool, "/dev/"+devID, mountpt), nil)
 	cmd := exec.Command("mount", "-t", mountingTool, "/dev/"+devID, mountpt)
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		diskmgLogger.PrintAndLog("Diskmg", fmt.Sprint("Failed to mount "+devID, string(o)), nil)
+		logger.PrintAndLog("Diskmg", fmt.Sprint("Failed to mount "+devID, string(o)), nil)
 	}
 	return string(o), err
 }
@@ -381,7 +382,7 @@ func Unmount(mountpt string, fsHandlers []*fs.FileSystemHandler) (string, error)
 			fsh.Closed = true
 		}
 	}
-	diskmgLogger.PrintAndLog("Diskmg", fmt.Sprint("Executing Umount Command: ", "umount", mountpt), nil)
+	logger.PrintAndLog("Diskmg", fmt.Sprint("Executing Umount Command: ", "umount", mountpt), nil)
 	cmd := exec.Command("umount", mountpt)
 	o, err := cmd.CombinedOutput()
 	return string(o), err

--- a/src/mod/disk/diskmg/diskmg_test.go
+++ b/src/mod/disk/diskmg/diskmg_test.go
@@ -22,9 +22,9 @@ func TestCheckDeviceValidRejectsBadNames(t *testing.T) {
 		valid bool
 	}{
 		{"../etc/passwd", false},
-		{"sda", false},    // no partition number
-		{"sda0", false},   // partition number must be 1–9
-		{"sda10", false},  // two-digit partition
+		{"sda", false},   // no partition number
+		{"sda0", false},  // partition number must be 1–9
+		{"sda10", false}, // two-digit partition
 		{"nvme0n1", false},
 		{"/dev/sda1", false}, // full path not matched by the regex alone
 	}

--- a/src/mod/disk/diskmg/zz_logger.go
+++ b/src/mod/disk/diskmg/zz_logger.go
@@ -1,5 +1,0 @@
-package diskmg
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var diskmgLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/diskspace/diskspace.go
+++ b/src/mod/disk/diskspace/diskspace.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -38,7 +40,7 @@ func GetAllLogicDiskInfo() []LogicalDiskSpaceInfo {
 		cmd := exec.Command("wmic", "logicaldisk", "get", "caption,size,freespace")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			diskspaceLogger.PrintAndLog("Diskspace", "wmic not supported.", nil)
+			logger.PrintAndLog("Diskspace", "wmic not supported.", nil)
 			return []LogicalDiskSpaceInfo{}
 		}
 		lines := strings.Split(string(out), "\n")

--- a/src/mod/disk/diskspace/zz_logger.go
+++ b/src/mod/disk/diskspace/zz_logger.go
@@ -1,5 +1,0 @@
-package diskspace
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var diskspaceLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/raid/handler.go
+++ b/src/mod/disk/raid/handler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"imuslab.com/arozos/mod/disk/diskfs"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -48,7 +49,7 @@ func (m *Manager) HandleRemoveDiskFromRAIDVol(w http.ResponseWriter, r *http.Req
 	//Check if the disk is already failed
 	diskAlreadyFailed, err := m.DiskIsFailed(mdDev, sdXDev)
 	if err != nil {
-		raidLogger.PrintAndLog("Raid", "[RAID] Unable to validate if disk failed: "+err.Error(), nil)
+		logger.PrintAndLog("Raid", "[RAID] Unable to validate if disk failed: "+err.Error(), nil)
 		utils.SendErrorResponse(w, err.Error())
 		return
 	}
@@ -70,7 +71,7 @@ func (m *Manager) HandleRemoveDiskFromRAIDVol(w http.ResponseWriter, r *http.Req
 		utils.SendErrorResponse(w, err.Error())
 		return
 	}
-	raidLogger.PrintAndLog("Raid", "[RAID] Memeber disk "+sdXDev+" removed from RAID volume "+mdDev, nil)
+	logger.PrintAndLog("Raid", "[RAID] Memeber disk "+sdXDev+" removed from RAID volume "+mdDev, nil)
 	utils.SendOK(w)
 }
 
@@ -141,7 +142,7 @@ func (m *Manager) HandleAddDiskToRAIDVol(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	raidLogger.PrintAndLog("Raid", "[RAID] Device "+sdXDev+" added to RAID volume "+mdDev, nil)
+	logger.PrintAndLog("Raid", "[RAID] Device "+sdXDev+" added to RAID volume "+mdDev, nil)
 
 	utils.SendOK(w)
 }
@@ -201,7 +202,7 @@ func (m *Manager) HandlListChildrenDeviceInfo(w http.ResponseWriter, r *http.Req
 	for _, blockdevice := range raidDevice.Members {
 		bdm, err := diskfs.GetBlockDeviceMeta("/dev/" + blockdevice.Name)
 		if err != nil {
-			raidLogger.PrintAndLog("Raid", "[RAID] Unable to load block device info: "+err.Error(), nil)
+			logger.PrintAndLog("Raid", "[RAID] Unable to load block device info: "+err.Error(), nil)
 			results[blockdevice.Name] = &diskfs.BlockDeviceMeta{
 				Name: blockdevice.Name,
 				Size: -1,
@@ -506,7 +507,7 @@ func (m *Manager) HandleRemoveRaideDevice(w http.ResponseWriter, r *http.Request
 		m.Options.Logger.PrintAndLog("RAID", targetDevice+" is mounted. Trying to unmount...", nil)
 		err = diskfs.UnmountDevice(targetDevice)
 		if err != nil {
-			raidLogger.PrintAndLog("Raid", "[RAID] Unmount failed: "+err.Error(), nil)
+			logger.PrintAndLog("Raid", "[RAID] Unmount failed: "+err.Error(), nil)
 			utils.SendErrorResponse(w, err.Error())
 			return
 		}

--- a/src/mod/disk/raid/mdadm.go
+++ b/src/mod/disk/raid/mdadm.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -198,7 +199,7 @@ func (m *Manager) GetRAIDDevicesFromProcMDStat() ([]RAIDDevice, error) {
 			seqInt, err := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(tmp[1]), "]"))
 			if err != nil {
 				//Not an integer?
-				raidLogger.PrintAndLog("Raid", "[RAID] Unable to parse "+disk+" sequence ID", nil)
+				logger.PrintAndLog("Raid", "[RAID] Unable to parse "+disk+" sequence ID", nil)
 				continue
 			}
 			member := RAIDMember{

--- a/src/mod/disk/raid/mdadmConf.go
+++ b/src/mod/disk/raid/mdadmConf.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"imuslab.com/arozos/mod/disk/diskfs"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -35,17 +36,17 @@ func (m *Manager) FlushReload() error {
 		//Check if it is mounted. If yes, skip this
 		devMounted, err := diskfs.DeviceIsMounted("/dev/" + rd.Name)
 		if devMounted || err != nil {
-			raidLogger.PrintAndLog("Raid", "[RAID] "+"/dev/"+rd.Name+" is in use. Skipping.", nil)
+			logger.PrintAndLog("Raid", "[RAID] "+"/dev/"+rd.Name+" is in use. Skipping.", nil)
 			continue
 		}
-		raidLogger.PrintAndLog("Raid", "[RAID] Stopping "+rd.Name, nil)
+		logger.PrintAndLog("Raid", "[RAID] Stopping "+rd.Name, nil)
 
 		cmdMdadm := exec.Command("sudo", "mdadm", "--stop", "/dev/"+rd.Name)
 
 		// Run the command and capture its output
 		_, err = cmdMdadm.Output()
 		if err != nil {
-			raidLogger.PrintAndLog("Raid", "[RAID] Unable to stop "+rd.Name+". Skipping", nil)
+			logger.PrintAndLog("Raid", "[RAID] Unable to stop "+rd.Name+". Skipping", nil)
 			continue
 		}
 	}
@@ -157,10 +158,10 @@ func (m *Manager) UpdateMDADMConfig() error {
 		for _, volumeUUID := range poolUUIDToBeRemoved {
 			err = m.RemoveVolumeFromMDADMConfig(volumeUUID)
 			if err != nil {
-				raidLogger.PrintAndLog("Raid", "[RAID] Error when trying to remove old RAID volume from config: "+err.Error(), nil)
+				logger.PrintAndLog("Raid", "[RAID] Error when trying to remove old RAID volume from config: "+err.Error(), nil)
 				return err
 			} else {
-				raidLogger.PrintAndLog("Raid", "[RAID] RAID volume "+volumeUUID+" removed from config file", nil)
+				logger.PrintAndLog("Raid", "[RAID] RAID volume "+volumeUUID+" removed from config file", nil)
 			}
 		}
 
@@ -168,7 +169,7 @@ func (m *Manager) UpdateMDADMConfig() error {
 
 	if len(newConfigLines) == 0 {
 		//Nothing to write
-		raidLogger.PrintAndLog("Raid", "[RAID] Nothing to write. Skipping mdadm config update.", nil)
+		logger.PrintAndLog("Raid", "[RAID] Nothing to write. Skipping mdadm config update.", nil)
 		return nil
 	}
 

--- a/src/mod/disk/raid/zz_logger.go
+++ b/src/mod/disk/raid/zz_logger.go
@@ -1,5 +1,0 @@
-package raid
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var raidLogger, _ = logger.NewTmpLogger()

--- a/src/mod/disk/smart/helper.go
+++ b/src/mod/disk/smart/helper.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 func execCommand(executable string, args ...string) string {
 	shell := exec.Command(executable, args...) // Run command
 	output, err := shell.CombinedOutput()      // Response from cmdline
 	if err != nil && string(output) == "" {    // If done w/ errors then
-		smartLogger.PrintAndLog("Smart", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Smart", fmt.Sprint(err), nil)
 		return ""
 	}
 

--- a/src/mod/disk/smart/smart.go
+++ b/src/mod/disk/smart/smart.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 	//"time"
 )
@@ -35,7 +36,7 @@ type SMARTListener struct {
 func NewSmartListener() (*SMARTListener, error) {
 	smartExec := getBinary()
 
-	smartLogger.PrintAndLog("Smart", "Starting SMART mointoring", nil)
+	logger.PrintAndLog("Smart", "Starting SMART mointoring", nil)
 
 	if smartExec == "" {
 		return &SMARTListener{}, errors.New("not supported platform")
@@ -139,12 +140,12 @@ func (s *SMARTListener) GetSMART(w http.ResponseWriter, r *http.Request) {
 func getBinary() string {
 	// Prefer system-installed smartctl (more up-to-date, supports newer drives).
 	if path, err := exec.LookPath("smartctl"); err == nil {
-		smartLogger.PrintAndLog("Smart", fmt.Sprint("[SMART] Using system-installed smartctl:", path), nil)
+		logger.PrintAndLog("Smart", fmt.Sprint("[SMART] Using system-installed smartctl:", path), nil)
 		return path
 	}
 
 	// Fall back to the pre-built binary bundled with arozos.
-	smartLogger.PrintAndLog("Smart", "[SMART] System smartctl not found, falling back to bundled binary", nil)
+	logger.PrintAndLog("Smart", "[SMART] System smartctl not found, falling back to bundled binary", nil)
 	switch runtime.GOOS {
 	case "windows":
 		return ".\\system\\disk\\smart\\win\\smartctl.exe"

--- a/src/mod/disk/smart/zz_logger.go
+++ b/src/mod/disk/smart/zz_logger.go
@@ -1,5 +1,0 @@
-package smart
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var smartLogger, _ = logger.NewTmpLogger()

--- a/src/mod/fileservers/fileservers.go
+++ b/src/mod/fileservers/fileservers.go
@@ -6,7 +6,7 @@ package fileservers
 	This module handle the functions related to file server managements
 */
 
-//Utilities
+// Utilities
 func GetFileServerById(servers []*Server, id string) *Server {
 	for _, server := range servers {
 		if server.ID == id {

--- a/src/mod/fileservers/servers/dirserv/dirserv.go
+++ b/src/mod/fileservers/servers/dirserv/dirserv.go
@@ -33,7 +33,7 @@ type Manager struct {
 	option  *Option
 }
 
-//Create a new web directory server
+// Create a new web directory server
 func NewDirectoryServer(option *Option) *Manager {
 	//Create a table to store which user enabled dirlisting on their own root
 	option.Sysdb.NewTable("dirserv")

--- a/src/mod/fileservers/servers/ftpserv/handler.go
+++ b/src/mod/fileservers/servers/ftpserv/handler.go
@@ -10,7 +10,7 @@ import (
 	"imuslab.com/arozos/mod/utils"
 )
 
-//Start the FTP Server by request
+// Start the FTP Server by request
 func (m *Manager) HandleFTPServerStart(w http.ResponseWriter, r *http.Request) {
 	err := m.StartFtpServer()
 	if err != nil {
@@ -19,13 +19,13 @@ func (m *Manager) HandleFTPServerStart(w http.ResponseWriter, r *http.Request) {
 	utils.SendOK(w)
 }
 
-//Stop the FTP server by request
+// Stop the FTP server by request
 func (m *Manager) HandleFTPServerStop(w http.ResponseWriter, r *http.Request) {
 	m.StopFtpServer()
 	utils.SendOK(w)
 }
 
-//Get the FTP server status
+// Get the FTP server status
 func (m *Manager) HandleFTPServerStatus(w http.ResponseWriter, r *http.Request) {
 	status, err := m.GetFtpServerStatus()
 	if err != nil {
@@ -37,7 +37,7 @@ func (m *Manager) HandleFTPServerStatus(w http.ResponseWriter, r *http.Request) 
 	utils.SendJSONResponse(w, string(js))
 }
 
-//Update UPnP setting on FTP server
+// Update UPnP setting on FTP server
 func (m *Manager) HandleFTPUPnP(w http.ResponseWriter, r *http.Request) {
 	enable, _ := utils.GetPara(r, "enable")
 	if enable == "true" {
@@ -55,7 +55,7 @@ func (m *Manager) HandleFTPUPnP(w http.ResponseWriter, r *http.Request) {
 	utils.SendOK(w)
 }
 
-//Update access permission on FTP server
+// Update access permission on FTP server
 func (m *Manager) HandleFTPAccessUpdate(w http.ResponseWriter, r *http.Request) {
 	//Get groups paramter from post req
 	groupString, err := utils.PostPara(r, "groups")
@@ -79,7 +79,7 @@ func (m *Manager) HandleFTPAccessUpdate(w http.ResponseWriter, r *http.Request) 
 	utils.SendOK(w)
 }
 
-//Handle FTP Set access port
+// Handle FTP Set access port
 func (m *Manager) HandleFTPSetPort(w http.ResponseWriter, r *http.Request) {
 	port, err := utils.PostPara(r, "port")
 	if err != nil {
@@ -104,11 +104,11 @@ func (m *Manager) HandleFTPSetPort(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	Handle the settings for passive mode related files
+Handle the settings for passive mode related files
 
-	Example set commands
-	set=ip&ip=123.456.789.1
-	set=mode&passive=true
+Example set commands
+set=ip&ip=123.456.789.1
+set=mode&passive=true
 */
 func (m *Manager) HandleFTPPassiveModeSettings(w http.ResponseWriter, r *http.Request) {
 	set, err := utils.PostPara(r, "set")

--- a/src/mod/fileservers/servers/samba/handlers.go
+++ b/src/mod/fileservers/servers/samba/handlers.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -390,14 +391,14 @@ func (s *ShareManager) ActivateUserAccount(w http.ResponseWriter, r *http.Reques
 			//Try to create the share
 			fshShareAbsolutePath, err := filepath.Abs(fshSharePath)
 			if err != nil {
-				sambaLogger.PrintAndLog("Samba", "[Samba] Unable to generate share config for path: "+fshSharePath, nil)
+				logger.PrintAndLog("Samba", "[Samba] Unable to generate share config for path: "+fshSharePath, nil)
 				continue
 			}
 
 			//Check if that folder exists
 			if !utils.FileExists(fshShareAbsolutePath) {
 				//Folder not exists. Continue
-				sambaLogger.PrintAndLog("Samba", "[Samba] Path not exists for file system handler: "+fshSharePath, nil)
+				logger.PrintAndLog("Samba", "[Samba] Path not exists for file system handler: "+fshSharePath, nil)
 				continue
 			}
 
@@ -412,7 +413,7 @@ func (s *ShareManager) ActivateUserAccount(w http.ResponseWriter, r *http.Reques
 			})
 
 			if err != nil {
-				sambaLogger.PrintAndLog("Samba", "[Samba] Failed to create share: "+err.Error(), nil)
+				logger.PrintAndLog("Samba", "[Samba] Failed to create share: "+err.Error(), nil)
 				utils.SendErrorResponse(w, err.Error())
 				return
 			}
@@ -420,7 +421,7 @@ func (s *ShareManager) ActivateUserAccount(w http.ResponseWriter, r *http.Reques
 			//Share exists. Add this user to such share
 			err = s.AddUserToSambaShare(fshID, userInfo.Username)
 			if err != nil {
-				sambaLogger.PrintAndLog("Samba", "[Samba] Failed to add user "+userInfo.Username+" to share "+fshID+": "+err.Error(), nil)
+				logger.PrintAndLog("Samba", "[Samba] Failed to add user "+userInfo.Username+" to share "+fshID+": "+err.Error(), nil)
 				utils.SendErrorResponse(w, err.Error())
 				return
 			}
@@ -491,7 +492,7 @@ func (s *ShareManager) DeactiveUserAccount(w http.ResponseWriter, r *http.Reques
 	for _, userAccessibleShare := range userAccessibleShares {
 		err = s.RemoveUserFromSambaShare(userAccessibleShare.Name, userInfo.Username)
 		if err != nil {
-			sambaLogger.PrintAndLog("Samba", "[Samba] Unable to remove user "+userInfo.Username+" from share: "+err.Error(), nil)
+			logger.PrintAndLog("Samba", "[Samba] Unable to remove user "+userInfo.Username+" from share: "+err.Error(), nil)
 			continue
 		}
 	}
@@ -531,7 +532,7 @@ func (s *ShareManager) HandleAccessUserUpdate(w http.ResponseWriter, r *http.Req
 	newUserList := []string{}
 	err = json.Unmarshal([]byte(newUserListJSON), &newUserList)
 	if err != nil {
-		sambaLogger.PrintAndLog("Samba", "[Samba] Parse new user list failed: "+err.Error(), nil)
+		logger.PrintAndLog("Samba", "[Samba] Parse new user list failed: "+err.Error(), nil)
 		utils.SendErrorResponse(w, "failed to parse the new user list")
 		return
 	}

--- a/src/mod/fileservers/servers/samba/required.go
+++ b/src/mod/fileservers/servers/samba/required.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"imuslab.com/arozos/mod/fileservers"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/user"
 )
 
@@ -20,7 +21,7 @@ func (m *ShareManager) ServerToggle(enabled bool) error {
 func (m *ShareManager) IsEnabled() bool {
 	smbdRunning, err := checkSmbdRunning()
 	if err != nil {
-		sambaLogger.PrintAndLog("Samba", "Unable to get smbd state: "+err.Error(), nil)
+		logger.PrintAndLog("Samba", "Unable to get smbd state: "+err.Error(), nil)
 		return false
 	}
 

--- a/src/mod/fileservers/servers/samba/sambashare.go
+++ b/src/mod/fileservers/servers/samba/sambashare.go
@@ -27,7 +27,7 @@ func (s *ShareConfig) SaveToConfig() error {
 	return shareManager.CreateNewSambaShare(&newShareConfig)
 }
 
-//Remove this share
+// Remove this share
 func (s *ShareConfig) Remove() error {
 	return s.parent.RemoveSambaShareConfig(s.Name)
 }

--- a/src/mod/fileservers/servers/samba/zz_logger.go
+++ b/src/mod/fileservers/servers/samba/zz_logger.go
@@ -1,5 +1,0 @@
-package samba
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var sambaLogger, _ = logger.NewTmpLogger()

--- a/src/mod/fileservers/servers/webdavserv/webdavserv.go
+++ b/src/mod/fileservers/servers/webdavserv/webdavserv.go
@@ -12,7 +12,7 @@ import (
 )
 
 /*
-	Handler for WebDAV
+Handler for WebDAV
 */
 type ManagerOption struct {
 	Sysdb       *database.Database
@@ -27,7 +27,7 @@ type Manager struct {
 	option        *ManagerOption
 }
 
-//Create a new WebDAV Manager for handling related requests
+// Create a new WebDAV Manager for handling related requests
 func NewWebDAVManager(option *ManagerOption) *Manager {
 	m := Manager{
 		option: option,
@@ -75,7 +75,7 @@ func (m *Manager) HandleStatusChange(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	Functions required by new service mounting infrastructure
+Functions required by new service mounting infrastructure
 */
 func (m *Manager) WebDavToogle(enabled bool) error {
 	m.WebDavHandler.Enabled = enabled
@@ -103,7 +103,7 @@ func (m *Manager) GetWebDavEnabled() bool {
 	return m.WebDavHandler.Enabled
 }
 
-//Mapper of the original Connection related features
+// Mapper of the original Connection related features
 func (m *Manager) HandleConnectionList(w http.ResponseWriter, r *http.Request) {
 	m.WebDavHandler.HandleConnectionList(w, r)
 }

--- a/src/mod/filesystem/abstractions/ftpfs/ftpfs.go
+++ b/src/mod/filesystem/abstractions/ftpfs/ftpfs.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jlaffaye/ftp"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -49,7 +50,7 @@ func NewFTPFSAbstraction(uuid string, hierarchy string, hostname string, usernam
 			}
 		}()
 	*/
-	ftpfsLogger.PrintAndLog("Ftpfs", "[FTP FS] "+hostname+" mounted via FTP-FS", nil)
+	logger.PrintAndLog("Ftpfs", "[FTP FS] "+hostname+" mounted via FTP-FS", nil)
 	return FTPFSAbstraction{
 		uuid:      uuid,
 		hierarchy: hierarchy,
@@ -83,7 +84,7 @@ func (l FTPFSAbstraction) makeConn() (*ftp.ServerConn, error) {
 	}
 
 	if !succ && lastError != nil {
-		ftpfsLogger.PrintAndLog("Ftpfs", "[FTPFS] Unable to dial TCP: "+lastError.Error(), nil)
+		logger.PrintAndLog("Ftpfs", "[FTPFS] Unable to dial TCP: "+lastError.Error(), nil)
 		return nil, lastError
 	}
 
@@ -340,7 +341,7 @@ func (l FTPFSAbstraction) ReadStream(filename string) (io.ReadCloser, error) {
 
 func (l FTPFSAbstraction) Walk(root string, walkFn filepath.WalkFunc) error {
 	root = filterFilepath(root)
-	ftpfsLogger.PrintAndLog("Ftpfs", "[FTP FS] Walking a root on FTP is extremely slow. Please consider rewritting this function. Scanning: "+root, nil)
+	logger.PrintAndLog("Ftpfs", "[FTP FS] Walking a root on FTP is extremely slow. Please consider rewritting this function. Scanning: "+root, nil)
 	c, err := l.makeConn()
 	if err != nil {
 		return err

--- a/src/mod/filesystem/abstractions/ftpfs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/ftpfs/zz_logger.go
@@ -1,5 +1,0 @@
-package ftpfs
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var ftpfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/abstractions/s3fs/s3fs.go
+++ b/src/mod/filesystem/abstractions/s3fs/s3fs.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -123,7 +124,7 @@ func NewS3FSAbstraction(uuid, hierarchy, endpoint, bucket, prefix, accessKey, se
 	if bucketRegion, rerr := manager.GetBucketRegion(discoverCtx, client, bucket); rerr == nil && bucketRegion != "" && bucketRegion != "us-east-1" {
 		if rc, rerr2 := newClient(bucketRegion); rerr2 == nil {
 			client = rc
-			s3fsLogger.PrintAndLog("S3fs", fmt.Sprintf("[S3 FS] Auto-discovered region %q for bucket %q\n", bucketRegion, bucket), nil)
+			logger.PrintAndLog("S3fs", fmt.Sprintf("[S3 FS] Auto-discovered region %q for bucket %q\n", bucketRegion, bucket), nil)
 		}
 	}
 
@@ -145,7 +146,7 @@ func NewS3FSAbstraction(uuid, hierarchy, endpoint, bucket, prefix, accessKey, se
 	uploader := manager.NewUploader(client)
 
 	prefix = strings.Trim(prefix, "/")
-	s3fsLogger.PrintAndLog("S3fs", fmt.Sprintf("[S3 FS] Mounted s3://%s/%s (endpoint=%s ssl=%v)\n", bucket, prefix, endpoint, useSSL), nil)
+	logger.PrintAndLog("S3fs", fmt.Sprintf("[S3 FS] Mounted s3://%s/%s (endpoint=%s ssl=%v)\n", bucket, prefix, endpoint, useSSL), nil)
 
 	return &S3FSAbstraction{
 		uuid:      uuid,

--- a/src/mod/filesystem/abstractions/s3fs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/s3fs/zz_logger.go
@@ -1,5 +1,0 @@
-package s3fs
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var s3fsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/abstractions/sftpfs/sftpFileUtil.go
+++ b/src/mod/filesystem/abstractions/sftpfs/sftpFileUtil.go
@@ -95,10 +95,10 @@ func (f *sftpFsFile) WriteString(s string) (n int, err error) {
 }
 
 /*
-	SFTP DirEntry
+SFTP DirEntry
 
-	Converting the legacy os.FileInfo into arozos required
-	fs.DirEntry for sftp client readDir returned values
+Converting the legacy os.FileInfo into arozos required
+fs.DirEntry for sftp client readDir returned values
 */
 type SftpDirEntry struct {
 	finfo fs.FileInfo

--- a/src/mod/filesystem/abstractions/sftpfs/sftpfs.go
+++ b/src/mod/filesystem/abstractions/sftpfs/sftpfs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -48,7 +49,7 @@ func NewSFTPFileSystemAbstraction(uuid string, hierarchy string, serverUrl strin
 
 	// Parse Host and Port
 
-	sftpfsLogger.PrintAndLog("Sftpfs", "[SFTP FS] Establishing connection with "+serverUrl+"...", nil)
+	logger.PrintAndLog("Sftpfs", "[SFTP FS] Establishing connection with "+serverUrl+"...", nil)
 
 	var auths []ssh.AuthMethod
 
@@ -71,18 +72,18 @@ func NewSFTPFileSystemAbstraction(uuid string, hierarchy string, serverUrl strin
 	// Connect to server
 	conn, err := ssh.Dial("tcp", addr, &config)
 	if err != nil {
-		sftpfsLogger.PrintAndLog("Sftpfs", fmt.Sprintf("[SFTP FS] Failed to connect to [%s] %v\n", addr, err), nil)
+		logger.PrintAndLog("Sftpfs", fmt.Sprintf("[SFTP FS] Failed to connect to [%s] %v\n", addr, err), nil)
 		return SFTPFileSystemAbstraction{}, err
 	}
 
 	// Create new SFTP client
 	sc, err := sftp.NewClient(conn)
 	if err != nil {
-		sftpfsLogger.PrintAndLog("Sftpfs", fmt.Sprintf("[SFTP FS] Unable to start SFTP subsystem: %v\n", err), nil)
+		logger.PrintAndLog("Sftpfs", fmt.Sprintf("[SFTP FS] Unable to start SFTP subsystem: %v\n", err), nil)
 		return SFTPFileSystemAbstraction{}, err
 	}
 
-	sftpfsLogger.PrintAndLog("Sftpfs", "[SFTP FS] Connected to remote: "+addr, nil)
+	logger.PrintAndLog("Sftpfs", "[SFTP FS] Connected to remote: "+addr, nil)
 	return SFTPFileSystemAbstraction{
 		uuid:        uuid,
 		hierarchy:   hierarchy,

--- a/src/mod/filesystem/abstractions/sftpfs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/sftpfs/zz_logger.go
@@ -1,5 +1,0 @@
-package sftpfs
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var sftpfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/abstractions/smbfs/smbfs.go
+++ b/src/mod/filesystem/abstractions/smbfs/smbfs.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hirochachacha/go-smb2"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -38,16 +39,16 @@ type ServerMessageBlockFileSystemAbstraction struct {
 }
 
 func NewServerMessageBlockFileSystemAbstraction(uuid string, hierarchy string, ipaddr string, rootShare string, username string, password string) (ServerMessageBlockFileSystemAbstraction, error) {
-	smbfsLogger.PrintAndLog("Smbfs", "[SMB-FS] Connecting to "+uuid+":/ ("+ipaddr+")", nil)
+	logger.PrintAndLog("Smbfs", "[SMB-FS] Connecting to "+uuid+":/ ("+ipaddr+")", nil)
 	//Patch the ip address if port not found
 	if !strings.Contains(ipaddr, ":") {
-		smbfsLogger.PrintAndLog("Smbfs", "[SMB-FS] Port not set. Using default SMB port (:445)", nil)
+		logger.PrintAndLog("Smbfs", "[SMB-FS] Port not set. Using default SMB port (:445)", nil)
 		ipaddr = ipaddr + ":445" //Default port for SMB
 	}
 	nd := net.Dialer{Timeout: 10 * time.Second}
 	conn, err := nd.Dial("tcp", ipaddr)
 	if err != nil {
-		smbfsLogger.PrintAndLog("Smbfs", fmt.Sprint("[SMB-FS] Unable to connect to remote: ", err.Error()), nil)
+		logger.PrintAndLog("Smbfs", fmt.Sprint("[SMB-FS] Unable to connect to remote: ", err.Error()), nil)
 		return ServerMessageBlockFileSystemAbstraction{}, err
 	}
 
@@ -60,7 +61,7 @@ func NewServerMessageBlockFileSystemAbstraction(uuid string, hierarchy string, i
 
 	s, err := d.Dial(conn)
 	if err != nil {
-		smbfsLogger.PrintAndLog("Smbfs", fmt.Sprint("[SMB-FS] Unable to connect to remote: ", err.Error()), nil)
+		logger.PrintAndLog("Smbfs", fmt.Sprint("[SMB-FS] Unable to connect to remote: ", err.Error()), nil)
 		return ServerMessageBlockFileSystemAbstraction{}, err
 	}
 
@@ -75,10 +76,10 @@ func NewServerMessageBlockFileSystemAbstraction(uuid string, hierarchy string, i
 	//Mound remote storage
 	fs, err := s.Mount(thisSmbRoot)
 	if err != nil {
-		smbfsLogger.PrintAndLog("Smbfs", fmt.Sprint("[SMB-FS] Unable to connect to remote: ", err.Error()), nil)
+		logger.PrintAndLog("Smbfs", fmt.Sprint("[SMB-FS] Unable to connect to remote: ", err.Error()), nil)
 		return ServerMessageBlockFileSystemAbstraction{}, err
 	}
-	smbfsLogger.PrintAndLog("Smbfs", "[SMB-FS] Mounted SMB Root Share: "+thisSmbRoot, nil)
+	logger.PrintAndLog("Smbfs", "[SMB-FS] Mounted SMB Root Share: "+thisSmbRoot, nil)
 
 	done := make(chan bool)
 	fsAbstraction := ServerMessageBlockFileSystemAbstraction{

--- a/src/mod/filesystem/abstractions/smbfs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/smbfs/zz_logger.go
@@ -1,5 +1,0 @@
-package smbfs
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var smbfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/abstractions/webdavfs/webdavfs.go
+++ b/src/mod/filesystem/abstractions/webdavfs/webdavfs.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/studio-b12/gowebdav"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -37,10 +38,10 @@ func NewWebDAVMount(UUID string, Hierarchy string, root string, user string, pas
 	c := gowebdav.NewClient(root, user, password)
 	err := c.Connect()
 	if err != nil {
-		webdavfsLogger.PrintAndLog("Webdavfs", fmt.Sprint("[WebDAV FS] Unable to connect to remote: ", err.Error()), nil)
+		logger.PrintAndLog("Webdavfs", fmt.Sprint("[WebDAV FS] Unable to connect to remote: ", err.Error()), nil)
 		return nil, err
 	} else {
-		webdavfsLogger.PrintAndLog("Webdavfs", "[WebDAV FS] Connected to remote: "+root, nil)
+		logger.PrintAndLog("Webdavfs", "[WebDAV FS] Connected to remote: "+root, nil)
 	}
 	return &WebDAVFileSystem{
 		UUID:      UUID,
@@ -178,7 +179,7 @@ func (e WebDAVFileSystem) GetFileSize(filename string) int64 {
 	filename = filterFilepath(filepath.ToSlash(filepath.Clean(filename)))
 	s, err := e.Stat(filename)
 	if err != nil {
-		webdavfsLogger.PrintAndLog("Webdavfs", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Webdavfs", fmt.Sprint(err), nil)
 		return 0
 	}
 

--- a/src/mod/filesystem/abstractions/webdavfs/zz_logger.go
+++ b/src/mod/filesystem/abstractions/webdavfs/zz_logger.go
@@ -1,5 +1,0 @@
-package webdavfs
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var webdavfsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/fileOpr.go
+++ b/src/mod/filesystem/fileOpr.go
@@ -27,6 +27,7 @@ import (
 
 	"imuslab.com/arozos/mod/filesystem/arozfs"
 	"imuslab.com/arozos/mod/filesystem/hidden"
+	"imuslab.com/arozos/mod/info/logger"
 
 	archiver "github.com/mholt/archiver/v3"
 )
@@ -747,7 +748,7 @@ func FileMove(srcFsh *FileSystemHandler, src string, destFsh *FileSystemHandler,
 			time.Sleep(1 * time.Second)
 			os.Remove(src)
 			counter++
-			filesystemLogger.PrintAndLog("Filesystem", "Retrying to remove file: "+src, nil)
+			logger.PrintAndLog("Filesystem", "Retrying to remove file: "+src, nil)
 			if counter > 10 {
 				return errors.New("Source file remove failed.")
 			}
@@ -820,7 +821,7 @@ func dirCopy(srcFsh *FileSystemHandler, src string, destFsh *FileSystemHandler, 
 			//Move the file using BLFC
 			f, err := srcFshAbs.ReadStream(fileSrc)
 			if err != nil {
-				filesystemLogger.PrintAndLog("Filesystem", fmt.Sprint(err), nil)
+				logger.PrintAndLog("Filesystem", fmt.Sprint(err), nil)
 				return err
 			}
 			defer f.Close()
@@ -917,7 +918,7 @@ func IsDir(path string) bool {
 	}
 	fi, err := os.Stat(path)
 	if err != nil {
-		filesystemLogger.PrintAndLog("Filesystem", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Filesystem", fmt.Sprint(err), nil)
 		os.Exit(1)
 		return false
 	}

--- a/src/mod/filesystem/filesystem.go
+++ b/src/mod/filesystem/filesystem.go
@@ -31,6 +31,7 @@ import (
 	"imuslab.com/arozos/mod/filesystem/abstractions/smbfs"
 	"imuslab.com/arozos/mod/filesystem/abstractions/webdavfs"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -125,7 +126,7 @@ func NewFileSystemHandlersFromJSON(jsonContent []byte, runtimePersistenceConfig 
 	for _, option := range options {
 		thisHandler, err := NewFileSystemHandler(option, runtimePersistenceConfig)
 		if err != nil {
-			filesystemLogger.PrintAndLog("Filesystem", "[File System] Failed to create system handler for "+option.Name, nil)
+			logger.PrintAndLog("Filesystem", "[File System] Failed to create system handler for "+option.Name, nil)
 			//log.Println(err.Error())
 			continue
 		}
@@ -147,10 +148,10 @@ func NewFileSystemHandler(option FileSystemOption, RuntimePersistenceConfig Runt
 			actualMountDev := option.Mountdev
 			if option.DiskUUID != "" {
 				if resolvedPath, err := ResolveDeviceByUUID(option.DiskUUID); err == nil {
-					filesystemLogger.PrintAndLog("Filesystem", "[Storage] Resolved device by UUID "+option.DiskUUID+" -> "+resolvedPath, nil)
+					logger.PrintAndLog("Filesystem", "[Storage] Resolved device by UUID "+option.DiskUUID+" -> "+resolvedPath, nil)
 					actualMountDev = resolvedPath
 				} else {
-					filesystemLogger.PrintAndLog("Filesystem", "[Storage] UUID lookup failed for "+option.DiskUUID+", falling back to device path "+option.Mountdev, nil)
+					logger.PrintAndLog("Filesystem", "[Storage] UUID lookup failed for "+option.DiskUUID+", falling back to device path "+option.Mountdev, nil)
 				}
 			}
 			err := MountDevice(option.Mountpt, actualMountDev, option.Filesystem)
@@ -216,7 +217,7 @@ func NewFileSystemHandler(option FileSystemOption, RuntimePersistenceConfig Runt
 		pathChunks := strings.Split(strings.ReplaceAll(option.Path, "\\", "/"), "/")
 
 		if len(pathChunks) < 2 {
-			filesystemLogger.PrintAndLog("Filesystem", "[File System] Invalid configured smb filepath: Path format not matching [ip_addr]:[port]/[root_share path]", nil)
+			logger.PrintAndLog("Filesystem", "[File System] Invalid configured smb filepath: Path format not matching [ip_addr]:[port]/[root_share path]", nil)
 			return nil, errors.New("Invalid configured smb filepath: Path format not matching [ip_addr]:[port]/[root_share path]")
 		}
 
@@ -384,7 +385,7 @@ func NewFileSystemHandler(option FileSystemOption, RuntimePersistenceConfig Runt
 
 	} else if option.Filesystem == "virtual" {
 		//Virtual filesystem, deprecated
-		filesystemLogger.PrintAndLog("Filesystem", "[File System] Deprecated file system type: Virtual", nil)
+		logger.PrintAndLog("Filesystem", "[File System] Deprecated file system type: Virtual", nil)
 	}
 
 	return nil, errors.New("Not supported file system: " + fstype)
@@ -515,7 +516,7 @@ func (fsh *FileSystemHandler) GetDirctorySizeFromVpath(vpath string, username st
 
 // Reload the target file system abstraction
 func (fsh *FileSystemHandler) ReloadFileSystelAbstraction() error {
-	filesystemLogger.PrintAndLog("Filesystem", "[File System] Reloading File System Abstraction for "+fsh.Name, nil)
+	logger.PrintAndLog("Filesystem", "[File System] Reloading File System Abstraction for "+fsh.Name, nil)
 	//Load the start option for this fsh
 	originalStartOption := fsh.StartOptions
 	runtimePersistenceConfig := fsh.RuntimePersistenceConfig
@@ -550,7 +551,7 @@ func (fsh *FileSystemHandler) Close() {
 	//Close the file system object
 	err := fsh.FileSystemAbstraction.Close()
 	if err != nil {
-		filesystemLogger.PrintAndLog("Filesystem", "[File System]  Unable to close File System Abstraction for Handler: "+fsh.UUID+". Skipping.", nil)
+		logger.PrintAndLog("Filesystem", "[File System]  Unable to close File System Abstraction for Handler: "+fsh.UUID+". Skipping.", nil)
 	}
 }
 

--- a/src/mod/filesystem/fspermission/fspermission.go
+++ b/src/mod/filesystem/fspermission/fspermission.go
@@ -8,6 +8,7 @@ import (
 
 	"imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -69,7 +70,7 @@ func SetFilePermisson(fsh *filesystem.FileSystemHandler, file string, permission
 		}
 
 		//Convert the value into a file mode
-		fspermissionLogger.PrintAndLog("Fspermission", "Updating "+file+" permission to "+strconv.Itoa(finalMode), nil)
+		logger.PrintAndLog("Fspermission", "Updating "+file+" permission to "+strconv.Itoa(finalMode), nil)
 
 		//Magic way to convert dec to oct
 		output, _ := strconv.ParseInt("0"+strconv.Itoa(finalMode), 8, 64)

--- a/src/mod/filesystem/fspermission/zz_logger.go
+++ b/src/mod/filesystem/fspermission/zz_logger.go
@@ -1,5 +1,0 @@
-package fspermission
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var fspermissionLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/fssort/fssort_test.go
+++ b/src/mod/filesystem/fssort/fssort_test.go
@@ -16,12 +16,12 @@ type mockFileInfo struct {
 	isDir   bool
 }
 
-func (m *mockFileInfo) Name() string      { return m.name }
-func (m *mockFileInfo) Size() int64       { return m.size }
-func (m *mockFileInfo) Mode() fs.FileMode { return 0644 }
+func (m *mockFileInfo) Name() string       { return m.name }
+func (m *mockFileInfo) Size() int64        { return m.size }
+func (m *mockFileInfo) Mode() fs.FileMode  { return 0644 }
 func (m *mockFileInfo) ModTime() time.Time { return m.modTime }
-func (m *mockFileInfo) IsDir() bool       { return m.isDir }
-func (m *mockFileInfo) Sys() any          { return nil }
+func (m *mockFileInfo) IsDir() bool        { return m.isDir }
+func (m *mockFileInfo) Sys() any           { return nil }
 
 func newMockFileInfo(name string, size int64, modTime time.Time) fs.FileInfo {
 	return &mockFileInfo{

--- a/src/mod/filesystem/fuzzy/fuzzy.go
+++ b/src/mod/filesystem/fuzzy/fuzzy.go
@@ -56,7 +56,7 @@ func (m *Matcher) Match(filename string) bool {
 	return true
 }
 
-//Check if a fuzzyKey require precise searching
+// Check if a fuzzyKey require precise searching
 func buildFuzzyChunks(fuzzyInput string, caseSensitive bool) ([]string, []string) {
 	includeList := []string{}
 	excludeList := []string{}

--- a/src/mod/filesystem/hidden/hidden.go
+++ b/src/mod/filesystem/hidden/hidden.go
@@ -14,12 +14,12 @@ import (
 
 */
 
-//Hide a given folder
+// Hide a given folder
 func HideFile(folderpath string) error {
 	return hide(folderpath)
 }
 
-//Check if a given file is hidden. Set recursive to true if you want to check if the file located inside a hidden folder
+// Check if a given file is hidden. Set recursive to true if you want to check if the file located inside a hidden folder
 func IsHidden(filename string, recursive bool) (bool, error) {
 	if recursive {
 		filename = filepath.ToSlash(filename)

--- a/src/mod/filesystem/localversion/localversion.go
+++ b/src/mod/filesystem/localversion/localversion.go
@@ -180,7 +180,7 @@ func CreateFileSnapshot(fsh *filesystem.FileSystemHandler, realFilepath string) 
 	return fshAbs.WriteStream(targetVersionFilepath, srcf, 0775)
 }
 
-//Clearn expired version backups that is older than maxReserveTime
+// Clearn expired version backups that is older than maxReserveTime
 func CleanExpiredVersionBackups(fsh *filesystem.FileSystemHandler, walkRoot string, maxReserveTime int64) {
 	fshAbs := fsh.FileSystemAbstraction
 	localVerFolders := []string{}

--- a/src/mod/filesystem/metadata/folder.go
+++ b/src/mod/filesystem/metadata/folder.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nfnt/resize"
 	"imuslab.com/arozos/mod/filesystem"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -108,7 +109,7 @@ func generateThumbnailForFolder(fsh *filesystem.FileSystemHandler, cacheFolder s
 		//Fail to decode the image. Try to remove the damaged iamge file
 		image3.Close()
 		fshAbs.Remove(contentCache[0])
-		metadataLogger.PrintAndLog("Metadata", "Failed to decode cahce image for: "+contentCache[0]+". Removing thumbnail cache", nil)
+		logger.PrintAndLog("Metadata", "Failed to decode cahce image for: "+contentCache[0]+". Removing thumbnail cache", nil)
 		return "", errors.New("failed to decode: " + err.Error())
 	}
 	defer image3.Close()
@@ -119,7 +120,7 @@ func generateThumbnailForFolder(fsh *filesystem.FileSystemHandler, cacheFolder s
 
 	outfile, err := fshAbs.Create(filepath.Join(cacheFolder, filepath.Base(file)+".png"))
 	if err != nil {
-		metadataLogger.PrintAndLog("Metadata", fmt.Sprintf("failed to create: %s", err), nil)
+		logger.PrintAndLog("Metadata", fmt.Sprintf("failed to create: %s", err), nil)
 		os.Exit(1)
 	}
 	png.Encode(outfile, resultThumbnail)

--- a/src/mod/filesystem/metadata/metadata.go
+++ b/src/mod/filesystem/metadata/metadata.go
@@ -17,6 +17,7 @@ import (
 	"imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/fssort"
 	hidden "imuslab.com/arozos/mod/filesystem/hidden"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -219,7 +220,7 @@ func (rh *RenderHandler) generateCache(fsh *filesystem.FileSystemHandler, cacheF
 
 func (rh *RenderHandler) fileIsBusy(path string) bool {
 	if rh == nil {
-		metadataLogger.PrintAndLog("Metadata", "RenderHandler is null!", nil)
+		logger.PrintAndLog("Metadata", "RenderHandler is null!", nil)
 		return true
 	}
 	_, ok := rh.renderingFiles.Load(path)
@@ -266,7 +267,7 @@ func (rh *RenderHandler) HandleLoadCache(w http.ResponseWriter, r *http.Request,
 	upgrader.CheckOrigin = func(r *http.Request) bool { return true }
 	c, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		metadataLogger.PrintAndLog("Metadata", fmt.Sprint("upgrade:", err), nil)
+		logger.PrintAndLog("Metadata", fmt.Sprint("upgrade:", err), nil)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("500 - Internal Server Error"))
 		return

--- a/src/mod/filesystem/metadata/metadata_test.go
+++ b/src/mod/filesystem/metadata/metadata_test.go
@@ -542,13 +542,13 @@ func TestGetSizeForType_AllTypes(t *testing.T) {
 		expected  uint32
 	}{
 		{1, 1}, {2, 1}, {6, 1}, {7, 1}, // BYTE, ASCII, SBYTE, UNDEFINED
-		{3, 2}, {8, 2},                   // SHORT, SSHORT
-		{4, 4}, {9, 4},                   // LONG, SLONG
-		{5, 8}, {10, 8},                  // RATIONAL, SRATIONAL
-		{11, 4},                           // FLOAT
-		{12, 8},                           // DOUBLE
-		{0, 0},                            // index 0 = 0
-		{99, 1},                           // unknown type → default 1
+		{3, 2}, {8, 2}, // SHORT, SSHORT
+		{4, 4}, {9, 4}, // LONG, SLONG
+		{5, 8}, {10, 8}, // RATIONAL, SRATIONAL
+		{11, 4}, // FLOAT
+		{12, 8}, // DOUBLE
+		{0, 0},  // index 0 = 0
+		{99, 1}, // unknown type → default 1
 	}
 	for _, tc := range tests {
 		got := getSizeForType(tc.fieldType)

--- a/src/mod/filesystem/metadata/zz_logger.go
+++ b/src/mod/filesystem/metadata/zz_logger.go
@@ -1,5 +1,0 @@
-package metadata
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var metadataLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/renderer/renderer.go
+++ b/src/mod/filesystem/renderer/renderer.go
@@ -3,6 +3,7 @@ package renderer
 import (
 	. "github.com/fogleman/fauxgl"
 	"github.com/nfnt/resize"
+	"imuslab.com/arozos/mod/info/logger"
 
 	"errors"
 	"image"
@@ -62,7 +63,7 @@ func (r *Renderer) RenderModel(filename string) (image.Image, error) {
 		}
 		mesh = m
 	} else {
-		rendererLogger.PrintAndLog("Renderer", "Not supported format, given: "+filepath.Ext(filename), nil)
+		logger.PrintAndLog("Renderer", "Not supported format, given: "+filepath.Ext(filename), nil)
 		return nil, errors.New("Not supported model format")
 	}
 

--- a/src/mod/filesystem/renderer/zz_logger.go
+++ b/src/mod/filesystem/renderer/zz_logger.go
@@ -1,5 +1,0 @@
-package renderer
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var rendererLogger, _ = logger.NewTmpLogger()

--- a/src/mod/filesystem/shortcut/shortcut.go
+++ b/src/mod/filesystem/shortcut/shortcut.go
@@ -39,7 +39,7 @@ func ReadShortcut(shortcutContent []byte) (*arozfs.ShortcutData, error) {
 	return &result, nil
 }
 
-//Generate the content of a shortcut base the the four important field of shortcut information
+// Generate the content of a shortcut base the the four important field of shortcut information
 func GenerateShortcutBytes(shortcutTarget string, shortcutType string, shortcutText string, shortcutIcon string) []byte {
 	//Check if there are desktop icon. If yes, override icon on module
 	if shortcutType == "module" && utils.FileExists(arozfs.ToSlash(filepath.Join("./web/", filepath.Dir(shortcutIcon), "/desktop_icon.png"))) {

--- a/src/mod/filesystem/static.go
+++ b/src/mod/filesystem/static.go
@@ -22,6 +22,7 @@ import (
 	"imuslab.com/arozos/mod/apt"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
 	"imuslab.com/arozos/mod/filesystem/shortcut"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 // Control Signals for background file operation tasks
@@ -193,9 +194,9 @@ func MountDevice(mountpt string, mountdev string, filesystem string) error {
 		}
 		//Mount the device
 		if CheckMounted(mountpt) {
-			filesystemLogger.PrintAndLog("Filesystem", mountpt+" already mounted.", nil)
+			logger.PrintAndLog("Filesystem", mountpt+" already mounted.", nil)
 		} else {
-			filesystemLogger.PrintAndLog("Filesystem", "Mounting "+mountdev+"("+filesystem+") to "+filepath.Clean(mountpt), nil)
+			logger.PrintAndLog("Filesystem", "Mounting "+mountdev+"("+filesystem+") to "+filepath.Clean(mountpt), nil)
 			cmd := exec.Command("mount", "-t", filesystem, mountdev, filepath.Clean(mountpt))
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr

--- a/src/mod/filesystem/zz_logger.go
+++ b/src/mod/filesystem/zz_logger.go
@@ -1,5 +1,0 @@
-package filesystem
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var filesystemLogger, _ = logger.NewTmpLogger()

--- a/src/mod/info/hardwareinfo/hardwareinfo.go
+++ b/src/mod/info/hardwareinfo/hardwareinfo.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -58,12 +59,12 @@ PrintSystemHardwareDebugMessage print system information on Windows.
 Which is lagging but helpful for debugging wmic on Windows
 */
 func PrintSystemHardwareDebugMessage() {
-	hardwareinfoLogger.PrintAndLog("Hardwareinfo", "Windows Version: "+wmicGetinfo("os", "Caption")[0], nil)
-	hardwareinfoLogger.PrintAndLog("Hardwareinfo", "Total Memory: "+wmicGetinfo("ComputerSystem", "TotalPhysicalMemory")[0]+"B", nil)
-	hardwareinfoLogger.PrintAndLog("Hardwareinfo", "Processor: "+wmicGetinfo("cpu", "Name")[0], nil)
-	hardwareinfoLogger.PrintAndLog("Hardwareinfo", "Following disk was detected:", nil)
+	logger.PrintAndLog("Hardwareinfo", "Windows Version: "+wmicGetinfo("os", "Caption")[0], nil)
+	logger.PrintAndLog("Hardwareinfo", "Total Memory: "+wmicGetinfo("ComputerSystem", "TotalPhysicalMemory")[0]+"B", nil)
+	logger.PrintAndLog("Hardwareinfo", "Processor: "+wmicGetinfo("cpu", "Name")[0], nil)
+	logger.PrintAndLog("Hardwareinfo", "Following disk was detected:", nil)
 	for _, info := range wmicGetinfo("diskdrive", "Model") {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(info), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(info), nil)
 	}
 }
 
@@ -71,7 +72,7 @@ func (s *Server) GetArOZInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(s.hostInfo)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return
 	}
 

--- a/src/mod/info/hardwareinfo/sysinfo.go
+++ b/src/mod/info/hardwareinfo/sysinfo.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -33,7 +34,7 @@ func Ifconfig(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -77,7 +78,7 @@ func GetDriveStat(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 
@@ -101,7 +102,7 @@ func GetUSB(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -178,7 +179,7 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(CPUInfo)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -197,7 +198,7 @@ func GetRamInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(ramSizeInt)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }

--- a/src/mod/info/hardwareinfo/sysinfo_darwin.go
+++ b/src/mod/info/hardwareinfo/sysinfo_darwin.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -48,7 +49,7 @@ func GetCPUFreq() string {
 	shell := exec.Command("bash", "-c", query_frequency_command) // Run command
 	freqByteArr, err := shell.CombinedOutput()                   // Response from cmdline
 	if err != nil {                                              // If done w/ errors then
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -68,7 +69,7 @@ func GetCPUModel() string {
 	shell := exec.Command("bash", "-c", query_cpumodel_command) // Run command
 	modelStr, err := shell.CombinedOutput()                     // Response from cmdline
 	if err != nil {                                             // If done w/ errors then
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -81,7 +82,7 @@ func GetCPUHardware() string {
 	shell := exec.Command("bash", "-c", query_cpuhardware_command) // Run command
 	hwStr, err := shell.CombinedOutput()                           // Response from cmdline
 	if err != nil {                                                // If done w/ errors then
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -94,7 +95,7 @@ func GetCPUArch() string {
 	shell := exec.Command("bash", "-c", query_cpuarch_command) // Run command
 	archStr, err := shell.CombinedOutput()                     // Response from cmdline
 	if err != nil {                                            // If done w/ errors then
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -114,7 +115,7 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(CPUInfo)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -139,7 +140,7 @@ func Ifconfig(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -184,7 +185,7 @@ func GetDriveStat(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 
@@ -211,7 +212,7 @@ func GetUSB(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -232,7 +233,7 @@ func GetRamInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(ramSizeInt)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }

--- a/src/mod/info/hardwareinfo/sysinfo_freebsd.go
+++ b/src/mod/info/hardwareinfo/sysinfo_freebsd.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -45,7 +46,7 @@ func GetCPUFreq() string {
 	shell := exec.Command("bash", "-c", query_frequency_command) // Run command
 	freqByteArr, err := shell.CombinedOutput()                   // Response from cmdline
 	if err != nil {                                              // If done w/ errors then
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -65,7 +66,7 @@ func GetCPUModel() string {
 	shell := exec.Command("bash", "-c", query_cpumodel_command) // Run command
 	modelStr, err := shell.CombinedOutput()                     // Response from cmdline
 	if err != nil {                                             // If done w/ errors then
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -78,7 +79,7 @@ func GetCPUHardware() string {
 	shell := exec.Command("bash", "-c", query_cpuhardware_command) // Run command
 	hwStr, err := shell.CombinedOutput()                           // Response from cmdline
 	if err != nil {                                                // If done w/ errors then
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -91,7 +92,7 @@ func GetCPUArch() string {
 	shell := exec.Command("bash", "-c", query_cpuarch_command) // Run command
 	archStr, err := shell.CombinedOutput()                     // Response from cmdline
 	if err != nil {                                            // If done w/ errors then
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 		return unknown_string
 	}
 
@@ -111,7 +112,7 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(CPUInfo)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -136,7 +137,7 @@ func Ifconfig(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -181,7 +182,7 @@ func GetDriveStat(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 
@@ -208,7 +209,7 @@ func GetUSB(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err = json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -229,7 +230,7 @@ func GetRamInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(ramSizeInt)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }

--- a/src/mod/info/hardwareinfo/sysinfo_window.go
+++ b/src/mod/info/hardwareinfo/sysinfo_window.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -25,7 +26,7 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(CPUInfo)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -39,7 +40,7 @@ func Ifconfig(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -63,7 +64,7 @@ func GetDriveStat(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -77,7 +78,7 @@ func GetUSB(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(arr)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }
@@ -92,7 +93,7 @@ func GetRamInfo(w http.ResponseWriter, r *http.Request) {
 	var jsonData []byte
 	jsonData, err := json.Marshal(RAMsize)
 	if err != nil {
-		hardwareinfoLogger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Hardwareinfo", fmt.Sprint(err), nil)
 	}
 	utils.SendTextResponse(w, string(jsonData))
 }

--- a/src/mod/info/hardwareinfo/zz_logger.go
+++ b/src/mod/info/hardwareinfo/zz_logger.go
@@ -1,5 +1,0 @@
-package hardwareinfo
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var hardwareinfoLogger, _ = logger.NewTmpLogger()

--- a/src/mod/info/logger/logger.go
+++ b/src/mod/info/logger/logger.go
@@ -17,12 +17,29 @@ import (
 	and replace the ton of log.Println in the system core
 */
 
-// globalPrintJSON is set once at startup via SetGlobalJSONOutput and applies to
-// every Logger instance, including the package-level tmp loggers in each module.
+// globalPrintJSON is set once at startup via SetGlobalJSONOutput.
 var globalPrintJSON bool
 
 func SetGlobalJSONOutput(enabled bool) {
 	globalPrintJSON = enabled
+}
+
+// defaultLogger is the single system-wide logger used by all packages.
+// It starts as a tmp (stdout-only) logger and is replaced by SetDefaultLogger
+// once the real logger is ready in main().
+var defaultLogger, _ = NewTmpLogger()
+
+// SetDefaultLogger replaces the default logger used by all packages.
+// Call this once in main() after the persistent logger is created.
+func SetDefaultLogger(l *Logger) {
+	defaultLogger = l
+}
+
+// PrintAndLog is a package-level convenience function that delegates to the
+// default logger. All modules should call this instead of keeping their own
+// logger instances.
+func PrintAndLog(title string, message string, originalError error) {
+	defaultLogger.PrintAndLog(title, message, originalError)
 }
 
 type Logger struct {

--- a/src/mod/info/logger/logger.go
+++ b/src/mod/info/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -18,10 +19,18 @@ import (
 
 type Logger struct {
 	LogToFile      bool     //Set enable write to file
+	PrintJSON      bool     //Print console output as JSON lines instead of plain text
 	Prefix         string   //Prefix for log files
 	LogFolder      string   //Folder to store the log  file
 	CurrentLogFile string   //Current writing filename
 	file           *os.File //File, empty if LogToFile is false
+}
+
+type jsonLogEntry struct {
+	Time    string `json:"time"`
+	Level   string `json:"level"`
+	Title   string `json:"title"`
+	Message string `json:"message"`
 }
 
 // Create a default logger
@@ -67,7 +76,26 @@ func (l *Logger) PrintAndLog(title string, message string, originalError error) 
 	go func() {
 		l.Log(title, message, originalError)
 	}()
-	log.Println("[" + title + "] " + message)
+	if l.PrintJSON {
+		level := "info"
+		if originalError != nil {
+			level = "error"
+		}
+		entry := jsonLogEntry{
+			Time:    time.Now().Format("2006-01-02T15:04:05.000000Z07:00"),
+			Level:   level,
+			Title:   title,
+			Message: message,
+		}
+		b, err := json.Marshal(entry)
+		if err != nil {
+			log.Println("[" + title + "] " + message)
+			return
+		}
+		fmt.Println(string(b))
+	} else {
+		log.Println("[" + title + "] " + message)
+	}
 }
 
 func (l *Logger) Log(title string, errorMessage string, originalError error) {

--- a/src/mod/info/logger/logger.go
+++ b/src/mod/info/logger/logger.go
@@ -17,6 +17,14 @@ import (
 	and replace the ton of log.Println in the system core
 */
 
+// globalPrintJSON is set once at startup via SetGlobalJSONOutput and applies to
+// every Logger instance, including the package-level tmp loggers in each module.
+var globalPrintJSON bool
+
+func SetGlobalJSONOutput(enabled bool) {
+	globalPrintJSON = enabled
+}
+
 type Logger struct {
 	LogToFile      bool     //Set enable write to file
 	PrintJSON      bool     //Print console output as JSON lines instead of plain text
@@ -76,7 +84,7 @@ func (l *Logger) PrintAndLog(title string, message string, originalError error) 
 	go func() {
 		l.Log(title, message, originalError)
 	}()
-	if l.PrintJSON {
+	if l.PrintJSON || globalPrintJSON {
 		level := "info"
 		if originalError != nil {
 			level = "error"

--- a/src/mod/info/logviewer/logviewer.go
+++ b/src/mod/info/logviewer/logviewer.go
@@ -44,7 +44,7 @@ func (v *Viewer) HandleListLog(w http.ResponseWriter, r *http.Request) {
 }
 
 // Read log of a given catergory and filename
-//Require GET varaible: file and catergory
+// Require GET varaible: file and catergory
 func (v *Viewer) HandleReadLog(w http.ResponseWriter, r *http.Request) {
 	filename, err := utils.GetPara(r, "file")
 	if err != nil {

--- a/src/mod/info/logviewer/logviewer_test.go
+++ b/src/mod/info/logviewer/logviewer_test.go
@@ -75,9 +75,9 @@ func TestListLogFilesWithLogs(t *testing.T) {
 	}
 
 	files := map[string]string{
-		filepath.Join(cat1, "alpha.log"): "log line alpha",
-		filepath.Join(cat1, "beta.log"):  "log line beta",
-		filepath.Join(cat2, "gamma.log"): "log line gamma",
+		filepath.Join(cat1, "alpha.log"):        "log line alpha",
+		filepath.Join(cat1, "beta.log"):         "log line beta",
+		filepath.Join(cat2, "gamma.log"):        "log line gamma",
 		filepath.Join(tmpRoot, "not_a_log.txt"): "should be ignored",
 	}
 	for path, content := range files {

--- a/src/mod/iot/assits.go
+++ b/src/mod/iot/assits.go
@@ -15,7 +15,7 @@ import (
 	The function implement here should have no effect to the core operation of the iot hub nor the iot pipeline.
 */
 
-//Handle the set and get nickname of a particular IoT device
+// Handle the set and get nickname of a particular IoT device
 func (m *Manager) HandleNickName(w http.ResponseWriter, r *http.Request) {
 	opr, err := utils.PostPara(r, "opr")
 	if err != nil {

--- a/src/mod/iot/handlerManager.go
+++ b/src/mod/iot/handlerManager.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -44,7 +45,7 @@ func (m *Manager) RegisterHandler(h ProtocolHandler) error {
 	err := h.Start()
 	if err != nil {
 		//Handler startup failed
-		iotLogger.PrintAndLog("Iot", fmt.Sprint("[IoT] *ERROR* Protocol Handler Startup Failed: ", err.Error()), nil)
+		logger.PrintAndLog("Iot", fmt.Sprint("[IoT] *ERROR* Protocol Handler Startup Failed: ", err.Error()), nil)
 		return err
 	}
 
@@ -205,7 +206,7 @@ func (m *Manager) ScanDevices() []*Device {
 		//Scan devices using this handler
 		thisProtcolDeviceList, err := ph.Scan()
 		if err != nil {
-			iotLogger.PrintAndLog("Iot", "[IoT] *ERROR* Scan Error: "+err.Error(), nil)
+			logger.PrintAndLog("Iot", "[IoT] *ERROR* Scan Error: "+err.Error(), nil)
 			continue
 		}
 

--- a/src/mod/iot/hds/hds.go
+++ b/src/mod/iot/hds/hds.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/iot"
 )
 
@@ -32,7 +33,7 @@ func NewProtocolHandler() *Handler {
 
 // Start the HDSv1 scanner, which no startup process is required
 func (h *Handler) Start() error {
-	hdsLogger.PrintAndLog("Hds", "[IoT] Home Dynamic System (Legacy) Loaded", nil)
+	logger.PrintAndLog("Hds", "[IoT] Home Dynamic System (Legacy) Loaded", nil)
 	return nil
 }
 
@@ -68,7 +69,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 
 	//Check if the IP range is supported by HDS protocol
 	if !valid {
-		hdsLogger.PrintAndLog("Hds", "[IoT] Home Dynamic Protocol requirement not satisfied. Skipping Scan", nil)
+		logger.PrintAndLog("Hds", "[IoT] Home Dynamic Protocol requirement not satisfied. Skipping Scan", nil)
 		return nil, nil
 	}
 
@@ -138,7 +139,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 				ControlEndpoints: endpoints,
 			})
 
-			hdsLogger.PrintAndLog("Hds", fmt.Sprint("*HDS* Found device ", devName, " at ", targetIP, " with UUID ", uuid), nil)
+			logger.PrintAndLog("Hds", fmt.Sprint("*HDS* Found device ", devName, " at ", targetIP, " with UUID ", uuid), nil)
 		}(&wg)
 	}
 

--- a/src/mod/iot/hds/utils.go
+++ b/src/mod/iot/hds/utils.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 func isJSON(s string) bool {
@@ -46,7 +48,7 @@ func tryGetHDSUUID(ip string) (string, error) {
 		return "", err
 	}
 
-	hdsLogger.PrintAndLog("Hds", fmt.Sprint(ip, uuid), nil)
+	logger.PrintAndLog("Hds", fmt.Sprint(ip, uuid), nil)
 	return uuid, nil
 }
 

--- a/src/mod/iot/hds/zz_logger.go
+++ b/src/mod/iot/hds/zz_logger.go
@@ -1,5 +1,0 @@
-package hds
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var hdsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/iot/hdsv2/hdsv2.go
+++ b/src/mod/iot/hdsv2/hdsv2.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/iot"
 	"imuslab.com/arozos/mod/network/mdns"
 )
@@ -37,7 +38,7 @@ func NewProtocolHandler(scanner *mdns.MDNSHost) *Handler {
 }
 
 func (h *Handler) Start() error {
-	hdsv2Logger.PrintAndLog("Hdsv2", "[IoT] Home Dynamic v2 Loaded", nil)
+	logger.PrintAndLog("Hdsv2", "[IoT] Home Dynamic v2 Loaded", nil)
 	return nil
 }
 
@@ -74,7 +75,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 		status, err := getStatusForDevice(&thisDevice)
 		if err != nil {
 			//This might be not a valid HDSv2 device. Skip this
-			hdsv2Logger.PrintAndLog("Hdsv2", fmt.Sprint("*HDSv2* Get status failed for device: ", host.HostName, err.Error()), nil)
+			logger.PrintAndLog("Hdsv2", fmt.Sprint("*HDSv2* Get status failed for device: ", host.HostName, err.Error()), nil)
 			continue
 		}
 		thisDevice.Status = status
@@ -83,7 +84,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 		eps, err := getEndpoints(&thisDevice)
 		if err != nil {
 			//This might be not a valid HDSv2 device. Skip this
-			hdsv2Logger.PrintAndLog("Hdsv2", fmt.Sprint("*HDSv2* Get endpoints failed for device: ", host.HostName, err.Error()), nil)
+			logger.PrintAndLog("Hdsv2", fmt.Sprint("*HDSv2* Get endpoints failed for device: ", host.HostName, err.Error()), nil)
 			continue
 		}
 		thisDevice.ControlEndpoints = eps

--- a/src/mod/iot/hdsv2/zz_logger.go
+++ b/src/mod/iot/hdsv2/zz_logger.go
@@ -1,5 +1,0 @@
-package hdsv2
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var hdsv2Logger, _ = logger.NewTmpLogger()

--- a/src/mod/iot/iot.go
+++ b/src/mod/iot/iot.go
@@ -7,7 +7,7 @@ package iot
 	(aka this is just a wrapper class. See independent IoT module for more information)
 */
 
-//Defination of a control endpoint
+// Defination of a control endpoint
 type Endpoint struct {
 	RelPath string //Relative path for this endpoint. If the access path is 192.168.0.100:8080/api1, then this value should be /api1
 	Name    string //Name of the this endpoint. E.g. "Toggle Light"
@@ -23,7 +23,7 @@ type Endpoint struct {
 	Steps float64
 }
 
-//Defination of an IoT device
+// Defination of an IoT device
 type Device struct {
 	Name         string //Name of the device
 	Port         int    //The communication port on the device. -1 for N/A

--- a/src/mod/iot/sonoff_s2x/sonoff_s2x.go
+++ b/src/mod/iot/sonoff_s2x/sonoff_s2x.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/iot"
 	"imuslab.com/arozos/mod/network/mdns"
 )
@@ -34,7 +35,7 @@ func NewProtocolHandler(scanner *mdns.MDNSHost) *Handler {
 }
 
 func (h *Handler) Start() error {
-	sonoff_s2xLogger.PrintAndLog("Sonoff_s2x", "[IoT] Sonoff Tasmoto S2X 6.4 scanner loaded", nil)
+	logger.PrintAndLog("Sonoff_s2x", "[IoT] Sonoff Tasmoto S2X 6.4 scanner loaded", nil)
 	return nil
 }
 
@@ -51,7 +52,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 			value, err := tryGet("http://" + dev.IPv4[0].String() + "/")
 			if err != nil {
 				//This things is not sonoff smart socket
-				sonoff_s2xLogger.PrintAndLog("Sonoff_s2x", dev.HostName+" is not sonoff", nil)
+				logger.PrintAndLog("Sonoff_s2x", dev.HostName+" is not sonoff", nil)
 				continue
 			}
 
@@ -62,7 +63,7 @@ func (h *Handler) Scan() ([]*iot.Device, error) {
 				info, err := tryGet("http://" + dev.IPv4[0].String() + "/in")
 				if err != nil {
 					//This things is not sonoff smart socket
-					sonoff_s2xLogger.PrintAndLog("Sonoff_s2x", dev.HostName+" failed to extract its MAC address from /in page", nil)
+					logger.PrintAndLog("Sonoff_s2x", dev.HostName+" failed to extract its MAC address from /in page", nil)
 					continue
 				}
 

--- a/src/mod/iot/sonoff_s2x/zz_logger.go
+++ b/src/mod/iot/sonoff_s2x/zz_logger.go
@@ -1,5 +1,0 @@
-package sonoff_s2x
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var sonoff_s2xLogger, _ = logger.NewTmpLogger()

--- a/src/mod/iot/zz_logger.go
+++ b/src/mod/iot/zz_logger.go
@@ -1,5 +1,0 @@
-package iot
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var iotLogger, _ = logger.NewTmpLogger()

--- a/src/mod/media/transcoder/transcoder.go
+++ b/src/mod/media/transcoder/transcoder.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"os/exec"
 	"time"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 type TranscodeOutputResolution string
@@ -64,7 +66,7 @@ func TranscodeAndStream(w http.ResponseWriter, r *http.Request, inputFile string
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		http.Error(w, "Failed to create error pipe", http.StatusInternalServerError)
-		transcoderLogger.PrintAndLog("Transcoder", fmt.Sprintf("Failed to create error pipe: %v", err), nil)
+		logger.PrintAndLog("Transcoder", fmt.Sprintf("Failed to create error pipe: %v", err), nil)
 		return
 	}
 
@@ -99,18 +101,18 @@ func TranscodeAndStream(w http.ResponseWriter, r *http.Request, inputFile string
 	go func() {
 		errOutput, _ := io.ReadAll(stderr)
 		if len(errOutput) > 0 {
-			transcoderLogger.PrintAndLog("Transcoder", fmt.Sprintf("FFmpeg error output: %s", string(errOutput)), nil)
+			logger.PrintAndLog("Transcoder", fmt.Sprintf("FFmpeg error output: %s", string(errOutput)), nil)
 		}
 	}()
 
 	go func() {
 		if err := cmd.Wait(); err != nil {
-			transcoderLogger.PrintAndLog("Transcoder", fmt.Sprintf("FFmpeg process exited: %v", err), nil)
+			logger.PrintAndLog("Transcoder", fmt.Sprintf("FFmpeg process exited: %v", err), nil)
 			return
 		}
 	}()
 
 	// Wait for the command to finish or client disconnect
 	<-done
-	transcoderLogger.PrintAndLog("Transcoder", "[Media Server] Transcode client disconnected", nil)
+	logger.PrintAndLog("Transcoder", "[Media Server] Transcode client disconnected", nil)
 }

--- a/src/mod/media/transcoder/zz_logger.go
+++ b/src/mod/media/transcoder/zz_logger.go
@@ -1,5 +1,0 @@
-package transcoder
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var transcoderLogger, _ = logger.NewTmpLogger()

--- a/src/mod/modules/installer.go
+++ b/src/mod/modules/installer.go
@@ -15,6 +15,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	agi "imuslab.com/arozos/mod/agi"
 	fs "imuslab.com/arozos/mod/filesystem"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -63,7 +64,7 @@ func (m *ModuleHandler) InstallViaZip(realpath string, gateway *agi.Gateway) err
 			os.RemoveAll(destPath)
 		}
 		if err := os.Rename(folder, destPath); err != nil {
-			modulesLogger.PrintAndLog("Modules", fmt.Sprint("*Module Installer* Failed to move module:", err), nil)
+			logger.PrintAndLog("Modules", fmt.Sprint("*Module Installer* Failed to move module:", err), nil)
 			return errors.New("Failed to install " + filepath.Base(folder) + ": " + err.Error())
 		}
 		installedFolders = append(installedFolders, destPath)
@@ -98,7 +99,7 @@ func (m *ModuleHandler) ReloadAllModules(gateway *agi.Gateway) error {
 // Install a module via git clone
 func (m *ModuleHandler) InstallModuleViaGit(gitURL string, gateway *agi.Gateway) error {
 	//Download the module from the gitURL
-	modulesLogger.PrintAndLog("Modules", fmt.Sprint("Starting module installation by Git cloning ", gitURL), nil)
+	logger.PrintAndLog("Modules", fmt.Sprint("Starting module installation by Git cloning ", gitURL), nil)
 	newDownloadUUID := uuid.NewV4().String()
 	downloadFolder := filepath.Join(m.tmpDirectory, "download", newDownloadUUID)
 	os.MkdirAll(downloadFolder, 0777)
@@ -131,7 +132,7 @@ func (m *ModuleHandler) InstallModuleViaGit(gitURL string, gateway *agi.Gateway)
 	/*
 		for _, src := range copyPendingList {
 			fs.FileCopy(src, "./web/", "skip", func(progress int, filename string) {
-				modulesLogger.PrintAndLog("Modules", fmt.Sprint("Copying ", filename), nil)
+				logger.PrintAndLog("Modules", fmt.Sprint("Copying ", filename), nil)
 			})
 		}
 	*/
@@ -159,15 +160,15 @@ func (m *ModuleHandler) ActivateModuleByRoot(moduleFolder string, gateway *agi.G
 			//Load this as an module
 			startDef, err := os.ReadFile(filepath.Join(thisModuleEstimataedRoot, "init.agi"))
 			if err != nil {
-				modulesLogger.PrintAndLog("Modules", "*Module Activator* Failed to read init.agi from "+filepath.Base(moduleFolder), nil)
+				logger.PrintAndLog("Modules", "*Module Activator* Failed to read init.agi from "+filepath.Base(moduleFolder), nil)
 				return errors.New("Failed to read init.agi from " + filepath.Base(moduleFolder))
 			}
 
 			//Execute the init script using AGI
-			modulesLogger.PrintAndLog("Modules", fmt.Sprint("Starting module: ", filepath.Base(moduleFolder)), nil)
+			logger.PrintAndLog("Modules", fmt.Sprint("Starting module: ", filepath.Base(moduleFolder)), nil)
 			err = gateway.RunScript(string(startDef))
 			if err != nil {
-				modulesLogger.PrintAndLog("Modules", "*Module Activator* "+filepath.Base(moduleFolder)+" Starting failed"+err.Error(), nil)
+				logger.PrintAndLog("Modules", "*Module Activator* "+filepath.Base(moduleFolder)+" Starting failed"+err.Error(), nil)
 				return errors.New(filepath.Base(moduleFolder) + " Starting failed: " + err.Error())
 
 			}
@@ -208,7 +209,7 @@ func (m *ModuleHandler) HandleModuleInstallationListing(w http.ResponseWriter, r
 		// Folder mod time (kept for backward compat)
 		mtime, err := fs.GetModTime(dirPath)
 		if err != nil {
-			modulesLogger.PrintAndLog("Modules", fmt.Sprint(err), nil)
+			logger.PrintAndLog("Modules", fmt.Sprint(err), nil)
 		}
 		t := time.Unix(mtime, 0)
 
@@ -263,7 +264,7 @@ func (m *ModuleHandler) UninstallModule(moduleName string) error {
 	//Check if the module exists
 	if utils.FileExists(filepath.Join("./web", moduleName)) {
 		//Remove the module
-		modulesLogger.PrintAndLog("Modules", fmt.Sprint("Removing Module: ", moduleName), nil)
+		logger.PrintAndLog("Modules", fmt.Sprint("Removing Module: ", moduleName), nil)
 		os.RemoveAll(filepath.Join("./web", moduleName))
 
 		//Unregister the module from loaded list

--- a/src/mod/modules/module.go
+++ b/src/mod/modules/module.go
@@ -48,7 +48,7 @@ func NewModuleHandler(userHandler *user.UserHandler, tmpFolderPath string) *Modu
 	}
 }
 
-//Register endpoint. Provide moduleInfo datastructure or unparsed json
+// Register endpoint. Provide moduleInfo datastructure or unparsed json
 func (m *ModuleHandler) RegisterModule(module ModuleInfo) {
 	m.LoadedModule = append(m.LoadedModule, &module)
 
@@ -59,14 +59,14 @@ func (m *ModuleHandler) RegisterModule(module ModuleInfo) {
 	}
 }
 
-//Sort the module list
+// Sort the module list
 func (m *ModuleHandler) ModuleSortList() {
 	sort.Slice(m.LoadedModule, func(i, j int) bool {
 		return m.LoadedModule[i].Name < m.LoadedModule[j].Name
 	})
 }
 
-//Register a module from JSON string
+// Register a module from JSON string
 func (m *ModuleHandler) RegisterModuleFromJSON(jsonstring string, allowReload bool) error {
 	var thisModuleInfo ModuleInfo
 	err := json.Unmarshal([]byte(jsonstring), &thisModuleInfo)
@@ -79,7 +79,7 @@ func (m *ModuleHandler) RegisterModuleFromJSON(jsonstring string, allowReload bo
 	return nil
 }
 
-//Register a module from AGI script
+// Register a module from AGI script
 func (m *ModuleHandler) RegisterModuleFromAGI(jsonstring string) error {
 	var thisModuleInfo ModuleInfo
 	err := json.Unmarshal([]byte(jsonstring), &thisModuleInfo)
@@ -104,7 +104,7 @@ func (m *ModuleHandler) DeregisterModule(moduleName string) {
 	m.LoadedModule = newLoadedModuleList
 }
 
-//Get a list of module names
+// Get a list of module names
 func (m *ModuleHandler) GetModuleNameList() []string {
 	result := []string{}
 	for _, module := range m.LoadedModule {
@@ -129,7 +129,7 @@ func (m *ModuleHandler) GetModuleListJSONForUser(username string) string {
 	return string(js)
 }
 
-//Handle Default Launcher
+// Handle Default Launcher
 func (m *ModuleHandler) HandleDefaultLauncher(w http.ResponseWriter, r *http.Request) {
 	username, _ := m.userHandler.GetAuthAgent().GetUserName(w, r)
 	opr, _ := utils.GetPara(r, "opr") //Operation, accept {get, set, launch}

--- a/src/mod/modules/zz_logger.go
+++ b/src/mod/modules/zz_logger.go
@@ -1,5 +1,0 @@
-package modules
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var modulesLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/dynamicproxy/dpcore/dpcore.go
+++ b/src/mod/network/dynamicproxy/dpcore/dpcore.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 var onExitFlushLoop func()
@@ -188,7 +190,7 @@ func (p *ReverseProxy) logf(format string, args ...interface{}) {
 	if p.ErrorLog != nil {
 		p.ErrorLog.Printf(format, args...)
 	} else {
-		dpcoreLogger.PrintAndLog("Dpcore", fmt.Sprintf(format, args...), nil)
+		logger.PrintAndLog("Dpcore", fmt.Sprintf(format, args...), nil)
 	}
 }
 

--- a/src/mod/network/dynamicproxy/dpcore/dpcore_test.go
+++ b/src/mod/network/dynamicproxy/dpcore/dpcore_test.go
@@ -107,7 +107,7 @@ type mockWF struct {
 }
 
 func (m *mockWF) Write(p []byte) (int, error) { return m.buf.Write(p) }
-func (m *mockWF) Flush()                       { m.flushed++ }
+func (m *mockWF) Flush()                      { m.flushed++ }
 
 func TestMaxLatencyWriter_WriteAndFlush(t *testing.T) {
 	mwf := &mockWF{}

--- a/src/mod/network/dynamicproxy/dpcore/zz_logger.go
+++ b/src/mod/network/dynamicproxy/dpcore/zz_logger.go
@@ -1,5 +1,0 @@
-package dpcore
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var dpcoreLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/dynamicproxy/dynamicproxy.go
+++ b/src/mod/network/dynamicproxy/dynamicproxy.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/network/dynamicproxy/dpcore"
 	"imuslab.com/arozos/mod/network/reverseproxy"
 )
@@ -85,7 +86,7 @@ func (router *Router) StartProxyService() error {
 	router.Running = true
 	go func() {
 		err := router.server.ListenAndServe()
-		dynamicproxyLogger.PrintAndLog("Dynamicproxy", "[DynamicProxy] "+err.Error(), nil)
+		logger.PrintAndLog("Dynamicproxy", "[DynamicProxy] "+err.Error(), nil)
 	}()
 
 	return nil
@@ -137,7 +138,7 @@ func (router *Router) AddProxyService(rootname string, domain string, requireTLS
 		Proxy:      proxy,
 	})
 
-	dynamicproxyLogger.PrintAndLog("Dynamicproxy", fmt.Sprint("Adding Proxy Rule: ", rootname+" to "+domain), nil)
+	logger.PrintAndLog("Dynamicproxy", fmt.Sprint("Adding Proxy Rule: ", rootname+" to "+domain), nil)
 	return nil
 }
 

--- a/src/mod/network/dynamicproxy/proxyRequestHandler.go
+++ b/src/mod/network/dynamicproxy/proxyRequestHandler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/network/websocketproxy"
 )
 
@@ -65,7 +66,7 @@ func (h *ProxyHandler) subdomainRequest(w http.ResponseWriter, r *http.Request, 
 	r.Host = r.URL.Host
 	err := target.Proxy.ServeHTTP(w, r)
 	if err != nil {
-		dynamicproxyLogger.PrintAndLog("Dynamicproxy", err.Error(), nil)
+		logger.PrintAndLog("Dynamicproxy", err.Error(), nil)
 	}
 
 }
@@ -93,6 +94,6 @@ func (h *ProxyHandler) proxyRequest(w http.ResponseWriter, r *http.Request, targ
 	r.Host = r.URL.Host
 	err := target.Proxy.ServeHTTP(w, r)
 	if err != nil {
-		dynamicproxyLogger.PrintAndLog("Dynamicproxy", err.Error(), nil)
+		logger.PrintAndLog("Dynamicproxy", err.Error(), nil)
 	}
 }

--- a/src/mod/network/dynamicproxy/subdomain.go
+++ b/src/mod/network/dynamicproxy/subdomain.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/network/reverseproxy"
 )
 
@@ -39,6 +40,6 @@ func (router *Router) AddSubdomainRoutingService(hostnameWithSubdomain string, d
 		Proxy:          proxy,
 	})
 
-	dynamicproxyLogger.PrintAndLog("Dynamicproxy", fmt.Sprint("Adding Subdomain Rule: ", hostnameWithSubdomain+" to "+domain), nil)
+	logger.PrintAndLog("Dynamicproxy", fmt.Sprint("Adding Subdomain Rule: ", hostnameWithSubdomain+" to "+domain), nil)
 	return nil
 }

--- a/src/mod/network/dynamicproxy/zz_logger.go
+++ b/src/mod/network/dynamicproxy/zz_logger.go
@@ -1,5 +1,0 @@
-package dynamicproxy
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var dynamicproxyLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/mdns/mdns.go
+++ b/src/mod/network/mdns/mdns.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/grandcat/zeroconf"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 type MDNSHost struct {
@@ -43,13 +44,13 @@ func NewMDNS(config NetworkHost, MacOverride string) (*MDNSHost, error) {
 	if err == nil {
 		macAddressBoardcast = strings.Join(macAddress, ",")
 	} else {
-		mdnsLogger.PrintAndLog("Mdns", fmt.Sprint("[mDNS] Unable to get MAC Address: ", err.Error()), nil)
+		logger.PrintAndLog("Mdns", fmt.Sprint("[mDNS] Unable to get MAC Address: ", err.Error()), nil)
 	}
 
 	//Register the mds services
 	server, err := zeroconf.Register(config.HostName, "_http._tcp", "local.", config.Port, []string{"version_build=" + config.BuildVersion, "version_minor=" + config.MinorVersion, "vendor=" + config.Vendor, "model=" + config.Model, "uuid=" + config.UUID, "domain=" + config.Domain, "mac_addr=" + macAddressBoardcast}, nil)
 	if err != nil {
-		mdnsLogger.PrintAndLog("Mdns", fmt.Sprint("[mDNS] Error when registering zeroconf broadcast message", err.Error()), nil)
+		logger.PrintAndLog("Mdns", fmt.Sprint("[mDNS] Error when registering zeroconf broadcast message", err.Error()), nil)
 		return &MDNSHost{}, err
 	}
 
@@ -59,7 +60,7 @@ func NewMDNS(config NetworkHost, MacOverride string) (*MDNSHost, error) {
 		ifaceIp := ""
 		ifaces, err := net.Interfaces()
 		if err != nil {
-			mdnsLogger.PrintAndLog("Mdns", "[mDNS] Unable to override iface MAC: "+err.Error()+". Resuming with default iface", nil)
+			logger.PrintAndLog("Mdns", "[mDNS] Unable to override iface MAC: "+err.Error()+". Resuming with default iface", nil)
 		}
 
 		foundMatching := false
@@ -96,9 +97,9 @@ func NewMDNS(config NetworkHost, MacOverride string) (*MDNSHost, error) {
 		}
 
 		if !foundMatching {
-			mdnsLogger.PrintAndLog("Mdns", "[mDNS] Unable to find the target iface with MAC address: "+MacOverride+". Resuming with default iface", nil)
+			logger.PrintAndLog("Mdns", "[mDNS] Unable to find the target iface with MAC address: "+MacOverride+". Resuming with default iface", nil)
 		} else {
-			mdnsLogger.PrintAndLog("Mdns", "[mDNS] Entering force MAC address mode, listening on: "+MacOverride+"(IP address: "+ifaceIp+")", nil)
+			logger.PrintAndLog("Mdns", "[mDNS] Entering force MAC address mode, listening on: "+MacOverride+"(IP address: "+ifaceIp+")", nil)
 		}
 	}
 
@@ -127,7 +128,7 @@ func (m *MDNSHost) Scan(timeout int, domainFilter string) []*NetworkHost {
 
 	resolver, err := zeroconf.NewResolver(zcoption)
 	if err != nil {
-		mdnsLogger.PrintAndLog("Mdns", fmt.Sprint("Failed to initialize resolver:", err.Error()), nil)
+		logger.PrintAndLog("Mdns", fmt.Sprint("Failed to initialize resolver:", err.Error()), nil)
 		os.Exit(1)
 	}
 
@@ -222,7 +223,7 @@ func (m *MDNSHost) Scan(timeout int, domainFilter string) []*NetworkHost {
 	defer cancel()
 	err = resolver.Browse(ctx, "_http._tcp", "local.", entries)
 	if err != nil {
-		mdnsLogger.PrintAndLog("Mdns", fmt.Sprint("Failed to browse:", err.Error()), nil)
+		logger.PrintAndLog("Mdns", fmt.Sprint("Failed to browse:", err.Error()), nil)
 		os.Exit(1)
 	}
 

--- a/src/mod/network/mdns/zz_logger.go
+++ b/src/mod/network/mdns/zz_logger.go
@@ -1,5 +1,0 @@
-package mdns
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var mdnsLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/neighbour/handler.go
+++ b/src/mod/network/neighbour/handler.go
@@ -20,7 +20,7 @@ type ScanResults struct {
 	NearbyHosts []*mdns.NetworkHost //Other hosts in the network
 }
 
-//Handle HTTP request for scanning and return the result
+// Handle HTTP request for scanning and return the result
 func (d *Discoverer) HandleScanningRequest(w http.ResponseWriter, r *http.Request) {
 	result := new(ScanResults)
 
@@ -41,7 +41,7 @@ func (d *Discoverer) HandleScanningRequest(w http.ResponseWriter, r *http.Reques
 	utils.SendJSONResponse(w, string(js))
 }
 
-//Get networkHosts that are offline
+// Get networkHosts that are offline
 func (d *Discoverer) HandleScanRecord(w http.ResponseWriter, r *http.Request) {
 	offlineNodes, err := d.GetOfflineHosts()
 	if err != nil {
@@ -58,7 +58,7 @@ func (d *Discoverer) HandleScanRecord(w http.ResponseWriter, r *http.Request) {
 	utils.SendJSONResponse(w, string(js))
 }
 
-//Send wake on land to target
+// Send wake on land to target
 func (d *Discoverer) HandleWakeOnLan(w http.ResponseWriter, r *http.Request) {
 	mac, err := utils.GetPara(r, "mac")
 	if err != nil {

--- a/src/mod/network/neighbour/neighbour.go
+++ b/src/mod/network/neighbour/neighbour.go
@@ -7,6 +7,7 @@ import (
 
 	"imuslab.com/arozos/mod/cluster/wakeonlan"
 	"imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/network/mdns"
 )
 
@@ -64,7 +65,7 @@ func (d *Discoverer) GetNearbyHosts() []*mdns.NetworkHost {
 
 // Start Scanning, interval and scan Duration in seconds
 func (d *Discoverer) StartScanning(interval int, scanDuration int) {
-	neighbourLogger.PrintAndLog("Neighbour", "ArozOS Neighbour Scanning Started", nil)
+	logger.PrintAndLog("Neighbour", "ArozOS Neighbour Scanning Started", nil)
 	if d.ScannerRunning() {
 		//Another scanner already running. Terminate it
 		d.StopScanning()
@@ -89,7 +90,7 @@ func (d *Discoverer) StartScanning(interval int, scanDuration int) {
 	go func() {
 		//Run initial scanning
 		d.UpdateScan(scanDuration)
-		neighbourLogger.PrintAndLog("Neighbour", fmt.Sprint("ArozOS Neighbour Scanning Completed, ", len(d.NearbyHosts), " neighbours found!"), nil)
+		logger.PrintAndLog("Neighbour", fmt.Sprint("ArozOS Neighbour Scanning Completed, ", len(d.NearbyHosts), " neighbours found!"), nil)
 	}()
 
 	//Update the Discoverer settings
@@ -135,7 +136,7 @@ func (d *Discoverer) GetOfflineHosts() ([]*HostRecord, error) {
 
 		if time.Now().Unix()-thisHostRecord.LastOnline > AutoDeleteRecordTime {
 			//Remove this record
-			neighbourLogger.PrintAndLog("Neighbour", "[Neighbour] Removing network host record due to long period offline: "+thisHostUUID+" ("+thisHostRecord.Name+")", nil)
+			logger.PrintAndLog("Neighbour", "[Neighbour] Removing network host record due to long period offline: "+thisHostUUID+" ("+thisHostRecord.Name+")", nil)
 			d.Database.Delete("neighbour", thisHostUUID)
 			continue
 		}
@@ -181,5 +182,5 @@ func (d *Discoverer) StopScanning() {
 		d.d = nil
 		d.t = nil
 	}
-	neighbourLogger.PrintAndLog("Neighbour", "ArozOS Neighbour Scanning Stopped", nil)
+	logger.PrintAndLog("Neighbour", "ArozOS Neighbour Scanning Stopped", nil)
 }

--- a/src/mod/network/neighbour/zz_logger.go
+++ b/src/mod/network/neighbour/zz_logger.go
@@ -1,5 +1,0 @@
-package neighbour
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var neighbourLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/network.go
+++ b/src/mod/network/network.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"gitlab.com/NebulousLabs/go-upnp"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -178,7 +179,7 @@ func GetNICInfo(w http.ResponseWriter, r *http.Request) {
 
 	jsonData, err := json.Marshal(NICList)
 	if err != nil {
-		networkLogger.PrintAndLog("Network", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Network", fmt.Sprint(err), nil)
 		utils.SendErrorResponse(w, "Failed to encode NIC data")
 		return
 	}

--- a/src/mod/network/reverseproxy/reverse.go
+++ b/src/mod/network/reverseproxy/reverse.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 var onExitFlushLoop func()
@@ -189,7 +191,7 @@ func (p *ReverseProxy) logf(format string, args ...interface{}) {
 	if p.ErrorLog != nil {
 		p.ErrorLog.Printf(format, args...)
 	} else {
-		reverseproxyLogger.PrintAndLog("Reverseproxy", fmt.Sprintf(format, args...), nil)
+		logger.PrintAndLog("Reverseproxy", fmt.Sprintf(format, args...), nil)
 	}
 }
 

--- a/src/mod/network/reverseproxy/reverseproxy_test.go
+++ b/src/mod/network/reverseproxy/reverseproxy_test.go
@@ -169,8 +169,8 @@ func TestDirector_UserAgent(t *testing.T) {
 // mockWriteFlusher implements both io.Writer and http.Flusher for testing
 // maxLatencyWriter / copyResponse with FlushInterval.
 type mockWriteFlusher struct {
-	buf      strings.Builder
-	flushed  int
+	buf     strings.Builder
+	flushed int
 }
 
 func (m *mockWriteFlusher) Write(p []byte) (int, error) {
@@ -570,8 +570,8 @@ func newMockHijackResponseWriter(conn net.Conn) *mockHijackResponseWriter {
 	}
 }
 
-func (m *mockHijackResponseWriter) Header() http.Header        { return m.header }
-func (m *mockHijackResponseWriter) WriteHeader(code int)       { m.statusCode = code }
+func (m *mockHijackResponseWriter) Header() http.Header         { return m.header }
+func (m *mockHijackResponseWriter) WriteHeader(code int)        { m.statusCode = code }
 func (m *mockHijackResponseWriter) Write(b []byte) (int, error) { return m.body.Write(b) }
 func (m *mockHijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	rw := bufio.NewReadWriter(

--- a/src/mod/network/reverseproxy/zz_logger.go
+++ b/src/mod/network/reverseproxy/zz_logger.go
@@ -1,5 +1,0 @@
-package reverseproxy
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var reverseproxyLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/ssdp/ssdp.go
+++ b/src/mod/network/ssdp/ssdp.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	ssdp "github.com/koron/go-ssdp"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -39,11 +40,11 @@ func NewSSDPHost(outboundIP string, port int, templateFile string, option SSDPOp
 		interfaceName, err := getFirstNetworkInterfaceName()
 		if err != nil {
 			//Ignore the interface binding
-			ssdpLogger.PrintAndLog("Ssdp", "[WARN] No connected network interface. Starting SSDP anyway.", nil)
+			logger.PrintAndLog("Ssdp", "[WARN] No connected network interface. Starting SSDP anyway.", nil)
 		} else {
 			mainNIC, err := net.InterfaceByName(interfaceName)
 			if err != nil {
-				ssdpLogger.PrintAndLog("Ssdp", "[WARN] Unable to get interface by name: "+interfaceName+". Starting SSDP on all IPv4 interfaces.", nil)
+				logger.PrintAndLog("Ssdp", "[WARN] Unable to get interface by name: "+interfaceName+". Starting SSDP on all IPv4 interfaces.", nil)
 			} else {
 				ssdp.Interfaces = []net.Interface{*mainNIC}
 			}
@@ -72,7 +73,7 @@ func NewSSDPHost(outboundIP string, port int, templateFile string, option SSDPOp
 func (a *SSDPHost) Start() {
 	//Advertise ssdp
 	http.HandleFunc("/ssdp.xml", a.handleSSDP)
-	ssdpLogger.PrintAndLog("Ssdp", "Starting SSDP Discovery Service: "+a.Option.URLBase, nil)
+	logger.PrintAndLog("Ssdp", "Starting SSDP Discovery Service: "+a.Option.URLBase, nil)
 	var aliveTick <-chan time.Time
 	aliveTick = time.Tick(time.Duration(5) * time.Second)
 

--- a/src/mod/network/ssdp/zz_logger.go
+++ b/src/mod/network/ssdp/zz_logger.go
@@ -1,5 +1,0 @@
-package ssdp
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var ssdpLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/upnp/upnp.go
+++ b/src/mod/network/upnp/upnp.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"gitlab.com/NebulousLabs/go-upnp"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -25,7 +26,7 @@ type UPnPClient struct {
 
 func NewUPNPClient(basePort int, hostname string) (*UPnPClient, error) {
 	//Create uPNP forwarding in the NAT router
-	upnpLogger.PrintAndLog("Upnp", "Discovering UPnP router in Local Area Network...", nil)
+	logger.PrintAndLog("Upnp", "Discovering UPnP router in Local Area Network...", nil)
 	d, err := upnp.Discover()
 	if err != nil {
 		return &UPnPClient{}, err
@@ -54,7 +55,7 @@ func NewUPNPClient(basePort int, hostname string) (*UPnPClient, error) {
 }
 
 func (u *UPnPClient) ForwardPort(portNumber int, ruleName string) error {
-	upnpLogger.PrintAndLog("Upnp", fmt.Sprint("UPnP forwarding new port: ", portNumber, "for "+ruleName+" service"), nil)
+	logger.PrintAndLog("Upnp", fmt.Sprint("UPnP forwarding new port: ", portNumber, "for "+ruleName+" service"), nil)
 
 	//Check if port already forwarded
 	_, ok := u.PolicyNames.Load(portNumber)
@@ -91,14 +92,14 @@ func (u *UPnPClient) ClosePort(portNumber int) error {
 		u.RequiredPorts = newRequiredPort
 
 		// Close the port
-		upnpLogger.PrintAndLog("Upnp", fmt.Sprint("Closing UPnP Port Forward: ", portNumber), nil)
+		logger.PrintAndLog("Upnp", fmt.Sprint("Closing UPnP Port Forward: ", portNumber), nil)
 		err := u.Connection.Clear(uint16(portNumber))
 
 		//Delete the name registry
 		u.PolicyNames.Delete(portNumber)
 
 		if err != nil {
-			upnpLogger.PrintAndLog("Upnp", fmt.Sprint(err), nil)
+			logger.PrintAndLog("Upnp", fmt.Sprint(err), nil)
 			return err
 		}
 	}
@@ -117,7 +118,7 @@ func (u *UPnPClient) RenewForwardRules() {
 		time.Sleep(100 * time.Millisecond)
 		u.ForwardPort(thisPort, ruleName.(string))
 	}
-	upnpLogger.PrintAndLog("Upnp", "UPnP Port Forward rule renew completed", nil)
+	logger.PrintAndLog("Upnp", "UPnP Port Forward rule renew completed", nil)
 }
 
 func (u *UPnPClient) Close() {
@@ -126,7 +127,7 @@ func (u *UPnPClient) Close() {
 		for _, portNumber := range u.RequiredPorts {
 			err := u.Connection.Clear(uint16(portNumber))
 			if err != nil {
-				upnpLogger.PrintAndLog("Upnp", fmt.Sprint(err), nil)
+				logger.PrintAndLog("Upnp", fmt.Sprint(err), nil)
 			}
 		}
 	}

--- a/src/mod/network/upnp/zz_logger.go
+++ b/src/mod/network/upnp/zz_logger.go
@@ -1,5 +1,0 @@
-package upnp
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var upnpLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/webdav/file.go
+++ b/src/mod/network/webdav/file.go
@@ -163,6 +163,7 @@ type memFS struct {
 //   - "/", "foo", false
 //   - "/foo/", "bar", false
 //   - "/foo/bar/", "x", true
+//
 // The frag argument will be empty only if dir is the root node and the walk
 // ends at that root node.
 func (fs *memFS) walk(op, fullname string, f func(dir *memFSNode, frag string, final bool) error) error {

--- a/src/mod/network/webdav/internal/xml/marshal.go
+++ b/src/mod/network/webdav/internal/xml/marshal.go
@@ -32,33 +32,33 @@ const (
 // elements containing the data.
 //
 // The name for the XML elements is taken from, in order of preference:
-//     - the tag on the XMLName field, if the data is a struct
-//     - the value of the XMLName field of type xml.Name
-//     - the tag of the struct field used to obtain the data
-//     - the name of the struct field used to obtain the data
-//     - the name of the marshalled type
+//   - the tag on the XMLName field, if the data is a struct
+//   - the value of the XMLName field of type xml.Name
+//   - the tag of the struct field used to obtain the data
+//   - the name of the struct field used to obtain the data
+//   - the name of the marshalled type
 //
 // The XML element for a struct contains marshalled elements for each of the
 // exported fields of the struct, with these exceptions:
-//     - the XMLName field, described above, is omitted.
-//     - a field with tag "-" is omitted.
-//     - a field with tag "name,attr" becomes an attribute with
-//       the given name in the XML element.
-//     - a field with tag ",attr" becomes an attribute with the
-//       field name in the XML element.
-//     - a field with tag ",chardata" is written as character data,
-//       not as an XML element.
-//     - a field with tag ",innerxml" is written verbatim, not subject
-//       to the usual marshalling procedure.
-//     - a field with tag ",comment" is written as an XML comment, not
-//       subject to the usual marshalling procedure. It must not contain
-//       the "--" string within it.
-//     - a field with a tag including the "omitempty" option is omitted
-//       if the field value is empty. The empty values are false, 0, any
-//       nil pointer or interface value, and any array, slice, map, or
-//       string of length zero.
-//     - an anonymous struct field is handled as if the fields of its
-//       value were part of the outer struct.
+//   - the XMLName field, described above, is omitted.
+//   - a field with tag "-" is omitted.
+//   - a field with tag "name,attr" becomes an attribute with
+//     the given name in the XML element.
+//   - a field with tag ",attr" becomes an attribute with the
+//     field name in the XML element.
+//   - a field with tag ",chardata" is written as character data,
+//     not as an XML element.
+//   - a field with tag ",innerxml" is written verbatim, not subject
+//     to the usual marshalling procedure.
+//   - a field with tag ",comment" is written as an XML comment, not
+//     subject to the usual marshalling procedure. It must not contain
+//     the "--" string within it.
+//   - a field with a tag including the "omitempty" option is omitted
+//     if the field value is empty. The empty values are false, 0, any
+//     nil pointer or interface value, and any array, slice, map, or
+//     string of length zero.
+//   - an anonymous struct field is handled as if the fields of its
+//     value were part of the outer struct.
 //
 // If a field uses a tag "a>b>c", then the element c will be nested inside
 // parent elements a and b. Fields that appear next to each other that name

--- a/src/mod/network/webdav/internal/xml/read.go
+++ b/src/mod/network/webdav/internal/xml/read.go
@@ -35,57 +35,57 @@ import (
 // In the rules, the tag of a field refers to the value associated with the
 // key 'xml' in the struct field's tag (see the example above).
 //
-//   * If the struct has a field of type []byte or string with tag
-//      ",innerxml", Unmarshal accumulates the raw XML nested inside the
-//      element in that field. The rest of the rules still apply.
+//   - If the struct has a field of type []byte or string with tag
+//     ",innerxml", Unmarshal accumulates the raw XML nested inside the
+//     element in that field. The rest of the rules still apply.
 //
-//   * If the struct has a field named XMLName of type xml.Name,
-//      Unmarshal records the element name in that field.
+//   - If the struct has a field named XMLName of type xml.Name,
+//     Unmarshal records the element name in that field.
 //
-//   * If the XMLName field has an associated tag of the form
-//      "name" or "namespace-URL name", the XML element must have
-//      the given name (and, optionally, name space) or else Unmarshal
-//      returns an error.
+//   - If the XMLName field has an associated tag of the form
+//     "name" or "namespace-URL name", the XML element must have
+//     the given name (and, optionally, name space) or else Unmarshal
+//     returns an error.
 //
-//   * If the XML element has an attribute whose name matches a
-//      struct field name with an associated tag containing ",attr" or
-//      the explicit name in a struct field tag of the form "name,attr",
-//      Unmarshal records the attribute value in that field.
+//   - If the XML element has an attribute whose name matches a
+//     struct field name with an associated tag containing ",attr" or
+//     the explicit name in a struct field tag of the form "name,attr",
+//     Unmarshal records the attribute value in that field.
 //
-//   * If the XML element contains character data, that data is
-//      accumulated in the first struct field that has tag ",chardata".
-//      The struct field may have type []byte or string.
-//      If there is no such field, the character data is discarded.
+//   - If the XML element contains character data, that data is
+//     accumulated in the first struct field that has tag ",chardata".
+//     The struct field may have type []byte or string.
+//     If there is no such field, the character data is discarded.
 //
-//   * If the XML element contains comments, they are accumulated in
-//      the first struct field that has tag ",comment".  The struct
-//      field may have type []byte or string. If there is no such
-//      field, the comments are discarded.
+//   - If the XML element contains comments, they are accumulated in
+//     the first struct field that has tag ",comment".  The struct
+//     field may have type []byte or string. If there is no such
+//     field, the comments are discarded.
 //
-//   * If the XML element contains a sub-element whose name matches
-//      the prefix of a tag formatted as "a" or "a>b>c", unmarshal
-//      will descend into the XML structure looking for elements with the
-//      given names, and will map the innermost elements to that struct
-//      field. A tag starting with ">" is equivalent to one starting
-//      with the field name followed by ">".
+//   - If the XML element contains a sub-element whose name matches
+//     the prefix of a tag formatted as "a" or "a>b>c", unmarshal
+//     will descend into the XML structure looking for elements with the
+//     given names, and will map the innermost elements to that struct
+//     field. A tag starting with ">" is equivalent to one starting
+//     with the field name followed by ">".
 //
-//   * If the XML element contains a sub-element whose name matches
-//      a struct field's XMLName tag and the struct field has no
-//      explicit name tag as per the previous rule, unmarshal maps
-//      the sub-element to that struct field.
+//   - If the XML element contains a sub-element whose name matches
+//     a struct field's XMLName tag and the struct field has no
+//     explicit name tag as per the previous rule, unmarshal maps
+//     the sub-element to that struct field.
 //
-//   * If the XML element contains a sub-element whose name matches a
-//      field without any mode flags (",attr", ",chardata", etc), Unmarshal
-//      maps the sub-element to that struct field.
+//   - If the XML element contains a sub-element whose name matches a
+//     field without any mode flags (",attr", ",chardata", etc), Unmarshal
+//     maps the sub-element to that struct field.
 //
-//   * If the XML element contains a sub-element that hasn't matched any
-//      of the above rules and the struct has a field with tag ",any",
-//      unmarshal maps the sub-element to that struct field.
+//   - If the XML element contains a sub-element that hasn't matched any
+//     of the above rules and the struct has a field with tag ",any",
+//     unmarshal maps the sub-element to that struct field.
 //
-//   * An anonymous struct field is handled as if the fields of its
-//      value were part of the outer struct.
+//   - An anonymous struct field is handled as if the fields of its
+//     value were part of the outer struct.
 //
-//   * A struct field with tag "-" is never unmarshalled into.
+//   - A struct field with tag "-" is never unmarshalled into.
 //
 // Unmarshal maps an XML element to a string or []byte by saving the
 // concatenation of that element's character data in the string or
@@ -110,7 +110,6 @@ import (
 //
 // Unmarshal maps an XML element to a pointer by setting the pointer
 // to a freshly allocated value and then mapping the element to that value.
-//
 func Unmarshal(data []byte, v interface{}) error {
 	return NewDecoder(bytes.NewReader(data)).Decode(v)
 }

--- a/src/mod/network/webdav/lock_test.go
+++ b/src/mod/network/webdav/lock_test.go
@@ -68,9 +68,9 @@ var lockTestDurations = []time.Duration{
 
 // lockTestNames are the names of a set of mutually compatible locks. For each
 // name fragment:
-//	- _ means no explicit lock.
-//	- i means an infinite-depth lock,
-//	- z means a zero-depth lock,
+//   - _ means no explicit lock.
+//   - i means an infinite-depth lock,
+//   - z means a zero-depth lock,
 var lockTestNames = []string{
 	"/_/_/_/_/z",
 	"/_/_/i",

--- a/src/mod/network/webdav/webdav_test.go
+++ b/src/mod/network/webdav/webdav_test.go
@@ -1100,4 +1100,3 @@ func TestReadPropfind_InvalidXML(t *testing.T) {
 		t.Errorf("expected 400, got %d", status)
 	}
 }
-

--- a/src/mod/network/websocketproxy/websocketproxy.go
+++ b/src/mod/network/websocketproxy/websocketproxy.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/websocket"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 var (
@@ -67,14 +68,14 @@ func NewProxy(target *url.URL) *WebsocketProxy {
 // ServeHTTP implements the http.Handler that proxies WebSocket connections.
 func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if w.Backend == nil {
-		websocketproxyLogger.PrintAndLog("Websocketproxy", "websocketproxy: backend function is not defined", nil)
+		logger.PrintAndLog("Websocketproxy", "websocketproxy: backend function is not defined", nil)
 		http.Error(rw, "internal server error (code: 1)", http.StatusInternalServerError)
 		return
 	}
 
 	backendURL := w.Backend(req)
 	if backendURL == nil {
-		websocketproxyLogger.PrintAndLog("Websocketproxy", "websocketproxy: backend URL is nil", nil)
+		logger.PrintAndLog("Websocketproxy", "websocketproxy: backend URL is nil", nil)
 		http.Error(rw, "internal server error (code: 2)", http.StatusInternalServerError)
 		return
 	}
@@ -136,13 +137,13 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// http://tools.ietf.org/html/draft-ietf-hybi-websocket-multiplexing-01
 	connBackend, resp, err := dialer.Dial(backendURL.String(), requestHeader)
 	if err != nil {
-		websocketproxyLogger.PrintAndLog("Websocketproxy", fmt.Sprintf("websocketproxy: couldn't dial to remote backend url %s", err), nil)
+		logger.PrintAndLog("Websocketproxy", fmt.Sprintf("websocketproxy: couldn't dial to remote backend url %s", err), nil)
 		if resp != nil {
 			// If the WebSocket handshake fails, ErrBadHandshake is returned
 			// along with a non-nil *http.Response so that callers can handle
 			// redirects, authentication, etcetera.
 			if err := copyResponse(rw, resp); err != nil {
-				websocketproxyLogger.PrintAndLog("Websocketproxy", fmt.Sprintf("websocketproxy: couldn't write response after failed remote backend handshake: %s", err), nil)
+				logger.PrintAndLog("Websocketproxy", fmt.Sprintf("websocketproxy: couldn't write response after failed remote backend handshake: %s", err), nil)
 			}
 		} else {
 			http.Error(rw, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
@@ -170,7 +171,7 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	upgrader.CheckOrigin = func(r *http.Request) bool { return true }
 	connPub, err := upgrader.Upgrade(rw, req, upgradeHeader)
 	if err != nil {
-		websocketproxyLogger.PrintAndLog("Websocketproxy", fmt.Sprintf("websocketproxy: couldn't upgrade %s", err), nil)
+		logger.PrintAndLog("Websocketproxy", fmt.Sprintf("websocketproxy: couldn't upgrade %s", err), nil)
 		return
 	}
 	defer connPub.Close()
@@ -211,7 +212,7 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	}
 	if e, ok := err.(*websocket.CloseError); !ok || e.Code == websocket.CloseAbnormalClosure {
-		websocketproxyLogger.PrintAndLog("Websocketproxy", fmt.Sprintf(message, err), nil)
+		logger.PrintAndLog("Websocketproxy", fmt.Sprintf(message, err), nil)
 	}
 }
 

--- a/src/mod/network/websocketproxy/zz_logger.go
+++ b/src/mod/network/websocketproxy/zz_logger.go
@@ -1,5 +1,0 @@
-package websocketproxy
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var websocketproxyLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/wifi/wifi.go
+++ b/src/mod/network/wifi/wifi.go
@@ -18,7 +18,7 @@ type WiFiManager struct {
 	wan_interface_name  string
 }
 
-//Create a new WiFi manager
+// Create a new WiFi manager
 func NewWiFiManager(database *db.Database, useSudo bool, wpapath string, wlanname string) *WiFiManager {
 	//Create a database table for wifi
 	database.NewTable("wifi")

--- a/src/mod/network/wifi/wifi_darwin.go
+++ b/src/mod/network/wifi/wifi_darwin.go
@@ -9,7 +9,7 @@ package wifi
 */
 import "errors"
 
-//Toggle WiFi On Off. Only allow on sudo mode
+// Toggle WiFi On Off. Only allow on sudo mode
 func (w *WiFiManager) SetInterfacePower(wlanInterface string, on bool) error {
 	return errors.New("Platform not supported")
 }

--- a/src/mod/network/wifi/wifi_freebsd.go
+++ b/src/mod/network/wifi/wifi_freebsd.go
@@ -9,7 +9,7 @@ package wifi
 */
 import "errors"
 
-//Toggle WiFi On Off. Only allow on sudo mode
+// Toggle WiFi On Off. Only allow on sudo mode
 func (w *WiFiManager) SetInterfacePower(wlanInterface string, on bool) error {
 	return errors.New("Platform not supported")
 }

--- a/src/mod/network/wifi/wifi_linux.go
+++ b/src/mod/network/wifi/wifi_linux.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -26,7 +27,7 @@ func (w *WiFiManager) SetInterfacePower(wlanInterface string, on bool) error {
 	cmd := exec.Command("ifconfig", wlanInterface, status)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		wifiLogger.PrintAndLog("Wifi", fmt.Sprint("*WiFi* WiFi toggle failed: ", string(out)), nil)
+		logger.PrintAndLog("Wifi", fmt.Sprint("*WiFi* WiFi toggle failed: ", string(out)), nil)
 		return err
 	}
 
@@ -85,7 +86,7 @@ func (w *WiFiManager) ScanNearbyWiFi(interfaceName string) ([]WiFiInfo, error) {
 		if strings.Contains(string(out), "Interface doesn't support scanning") {
 			//Try nmcli instead if exists
 			if pkg_exists("nmcli") {
-				wifiLogger.PrintAndLog("Wifi", "*WiFi* Running WiFi scan in nmcli compatibility mode", nil)
+				logger.PrintAndLog("Wifi", "*WiFi* Running WiFi scan in nmcli compatibility mode", nil)
 				cmd := exec.Command("bash", "-c", "nmcli d wifi list")
 				out, err := cmd.CombinedOutput()
 				if err != nil {
@@ -151,7 +152,7 @@ func (w *WiFiManager) ScanNearbyWiFi(interfaceName string) ([]WiFiInfo, error) {
 
 				return results, nil
 			} else {
-				wifiLogger.PrintAndLog("Wifi", fmt.Sprint("*WiFi* Scan Failed: ", err.Error()), nil)
+				logger.PrintAndLog("Wifi", fmt.Sprint("*WiFi* Scan Failed: ", err.Error()), nil)
 				return []WiFiInfo{}, errors.New("Interface doesn't support scanning")
 			}
 		}
@@ -303,8 +304,8 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 			cmd := exec.Command("nmcli", "con", "down", oldSSID)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				wifiLogger.PrintAndLog("Wifi", "*WiFi* Connecting previous SSID failed: "+string(out), nil)
-				wifiLogger.PrintAndLog("Wifi", "*WiFi* Trying to connect new AP anyway", nil)
+				logger.PrintAndLog("Wifi", "*WiFi* Connecting previous SSID failed: "+string(out), nil)
+				logger.PrintAndLog("Wifi", "*WiFi* Trying to connect new AP anyway", nil)
 			}
 		}
 
@@ -317,7 +318,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		cmd := exec.Command("nmcli", "device", "wifi", "connect", ssid, "password", password)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			wifiLogger.PrintAndLog("Wifi", "*WiFi* Connecting to SSID "+ssid+" failed: "+string(out), nil)
+			logger.PrintAndLog("Wifi", "*WiFi* Connecting to SSID "+ssid+" failed: "+string(out), nil)
 			return &WiFiConnectionResult{Success: false}, errors.New(string(out))
 		}
 
@@ -326,7 +327,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 			w.database.Write("wifi", ssid, password)
 		}
 
-		wifiLogger.PrintAndLog("Wifi", string(out), nil)
+		logger.PrintAndLog("Wifi", string(out), nil)
 		//Check and return the current connection ssid
 		//Wait until the WiFi is conencted
 		rescanCount := 0
@@ -334,9 +335,9 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		//Wait for 30 seconds
 		for rescanCount < 10 && connectedSSID == "" {
 			connectedSSID, _, _ = w.GetConnectedWiFi()
-			wifiLogger.PrintAndLog("Wifi", fmt.Sprint(connectedSSID), nil)
+			logger.PrintAndLog("Wifi", fmt.Sprint(connectedSSID), nil)
 			rescanCount = rescanCount + 1
-			wifiLogger.PrintAndLog("Wifi", "*WiFi* Waiting WiFi Connection (Retry "+strconv.Itoa(rescanCount)+"/10)", nil)
+			logger.PrintAndLog("Wifi", "*WiFi* Waiting WiFi Connection (Retry "+strconv.Itoa(rescanCount)+"/10)", nil)
 			time.Sleep(3 * time.Second)
 		}
 
@@ -378,7 +379,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		//Special case, for handling WiFi Switching without retyping the password
 		writeToConfig = false
 	} else {
-		wifiLogger.PrintAndLog("Wifi", "*WiFi* Unsupported connection type", nil)
+		logger.PrintAndLog("Wifi", "*WiFi* Unsupported connection type", nil)
 		return &WiFiConnectionResult{Success: false}, errors.New("Unsupported Connection Type")
 	}
 
@@ -388,15 +389,15 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	}
 
 	if writeToConfig == true {
-		wifiLogger.PrintAndLog("Wifi", "*WiFi* WiFi Config Generated. Writing to file...", nil)
+		logger.PrintAndLog("Wifi", "*WiFi* WiFi Config Generated. Writing to file...", nil)
 		//Write config file to disk
 		err := os.WriteFile("./system/network/wifi/ap/"+ssid+".config", []byte(networkConfigFile), 0755)
 		if err != nil {
-			wifiLogger.PrintAndLog("Wifi", err.Error(), nil)
+			logger.PrintAndLog("Wifi", err.Error(), nil)
 			return &WiFiConnectionResult{Success: false}, err
 		}
 	} else {
-		wifiLogger.PrintAndLog("Wifi", "*WiFi* Switching WiFi AP...", nil)
+		logger.PrintAndLog("Wifi", "*WiFi* Switching WiFi AP...", nil)
 	}
 
 	//Start creating the new wpa_supplicant file
@@ -404,7 +405,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	configHeader, err := os.ReadFile("./system/network/wifi/wpa_supplicant.conf_template.config")
 	if err != nil {
 		//Template header not found. Use default one from Raspberry Pi
-		wifiLogger.PrintAndLog("Wifi", "*WiFi* Warning! wpa_supplicant template file not found. Using default template.", nil)
+		logger.PrintAndLog("Wifi", "*WiFi* Warning! wpa_supplicant template file not found. Using default template.", nil)
 		configHeader = []byte(`ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 		update_config=1
 		{{networks}}
@@ -414,7 +415,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	//Build network informations
 	networksConfigs, err := filepath.Glob("./system/network/wifi/ap/*.config")
 	if err != nil {
-		wifiLogger.PrintAndLog("Wifi", err.Error(), nil)
+		logger.PrintAndLog("Wifi", err.Error(), nil)
 		return &WiFiConnectionResult{Success: false}, err
 	}
 
@@ -424,7 +425,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	for _, configFile := range networksConfigs {
 		thisNetworkConfig, err := os.ReadFile(configFile)
 		if err != nil {
-			wifiLogger.PrintAndLog("Wifi", "*WiFi* Failed to read Network Config File: "+configFile, nil)
+			logger.PrintAndLog("Wifi", "*WiFi* Failed to read Network Config File: "+configFile, nil)
 			continue
 		}
 
@@ -451,11 +452,11 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 	//Try to write the new config to wpa_supplicant
 	err = os.WriteFile(w.wpa_supplicant_path, []byte(newconfig), 0777)
 	if err != nil {
-		wifiLogger.PrintAndLog("Wifi", "*WiFi* Failed to update wpa_supplicant config, are you sure you have access permission to that file?", nil)
+		logger.PrintAndLog("Wifi", "*WiFi* Failed to update wpa_supplicant config, are you sure you have access permission to that file?", nil)
 		return &WiFiConnectionResult{Success: false}, err
 	}
 
-	wifiLogger.PrintAndLog("Wifi", "*WiFi* WiFi Config Updated. Restarting Wireless Interfaces...", nil)
+	logger.PrintAndLog("Wifi", "*WiFi* WiFi Config Updated. Restarting Wireless Interfaces...", nil)
 
 	//Restart network services
 	cmd := exec.Command("wpa_cli", "-i", w.wan_interface_name, "reconfigure")
@@ -464,7 +465,7 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		//Maybe the user forgot to set the flag. Try auto detect.
 		autoDetectedWIface, err := w.GetWirelessInterfaces()
 		if err != nil || len(autoDetectedWIface) == 0 {
-			wifiLogger.PrintAndLog("Wifi", "failed to restart network: "+string(out), nil)
+			logger.PrintAndLog("Wifi", "failed to restart network: "+string(out), nil)
 			return &WiFiConnectionResult{Success: false}, err
 		}
 
@@ -473,22 +474,22 @@ func (w *WiFiManager) ConnectWiFi(ssid string, password string, connType string,
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			//Really failed.
-			wifiLogger.PrintAndLog("Wifi", "failed to restart network: "+string(out), nil)
+			logger.PrintAndLog("Wifi", "failed to restart network: "+string(out), nil)
 			return &WiFiConnectionResult{Success: false}, err
 		}
 
 	}
 
-	wifiLogger.PrintAndLog("Wifi", "*WiFi* Trying to connect new AP", nil)
+	logger.PrintAndLog("Wifi", "*WiFi* Trying to connect new AP", nil)
 	//Wait until the WiFi is conencted
 	rescanCount := 0
 	connectedSSID, _, _ := w.GetConnectedWiFi()
 	//Wait for 30 seconds
 	for rescanCount < 10 && connectedSSID == "" {
 		connectedSSID, _, _ = w.GetConnectedWiFi()
-		wifiLogger.PrintAndLog("Wifi", fmt.Sprint(connectedSSID), nil)
+		logger.PrintAndLog("Wifi", fmt.Sprint(connectedSSID), nil)
 		rescanCount = rescanCount + 1
-		wifiLogger.PrintAndLog("Wifi", "*WiFi* Waiting WiFi Connection (Retry "+strconv.Itoa(rescanCount)+"/10)", nil)
+		logger.PrintAndLog("Wifi", "*WiFi* Waiting WiFi Connection (Retry "+strconv.Itoa(rescanCount)+"/10)", nil)
 		time.Sleep(3 * time.Second)
 	}
 

--- a/src/mod/network/wifi/wifi_windows.go
+++ b/src/mod/network/wifi/wifi_windows.go
@@ -14,6 +14,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 // Toggle WiFi On Off. Only allow on sudo mode
@@ -30,7 +32,7 @@ func (w *WiFiManager) ScanNearbyWiFi(interfaceName string) ([]WiFiInfo, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		//No interface found on the system
-		wifiLogger.PrintAndLog("Wifi", string(out), nil)
+		logger.PrintAndLog("Wifi", string(out), nil)
 		return []WiFiInfo{}, errors.New(string(out))
 	}
 
@@ -131,7 +133,7 @@ func (w *WiFiManager) GetWirelessInterfaces() ([]string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		//No interface found on the system
-		wifiLogger.PrintAndLog("Wifi", string(out), nil)
+		logger.PrintAndLog("Wifi", string(out), nil)
 		return []string{}, err
 	}
 	output := string(out)
@@ -163,7 +165,7 @@ func (w *WiFiManager) GetConnectedWiFi() (string, string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		//No interface found on the system
-		wifiLogger.PrintAndLog("Wifi", string(out), nil)
+		logger.PrintAndLog("Wifi", string(out), nil)
 		return "", "", nil
 	}
 	output := string(out)

--- a/src/mod/network/wifi/zz_logger.go
+++ b/src/mod/network/wifi/zz_logger.go
@@ -1,5 +1,0 @@
-package wifi
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var wifiLogger, _ = logger.NewTmpLogger()

--- a/src/mod/network/zz_logger.go
+++ b/src/mod/network/zz_logger.go
@@ -1,5 +1,0 @@
-package network
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var networkLogger, _ = logger.NewTmpLogger()

--- a/src/mod/notification/agents/smtpn/smtpn.go
+++ b/src/mod/notification/agents/smtpn/smtpn.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"time"
 
+	"imuslab.com/arozos/mod/info/logger"
 	notification "imuslab.com/arozos/mod/notification"
 	"imuslab.com/arozos/mod/utils"
 )
@@ -94,7 +95,7 @@ func (a Agent) ConsumerNotification(incomingNotification *notification.Notificat
 		if err == nil {
 			userEmails = append(userEmails, []string{username, userEmail})
 		} else {
-			smtpnLogger.PrintAndLog("Smtpn", "[SMTP Notification] Unable to notify "+username+": Email not set", nil)
+			logger.PrintAndLog("Smtpn", "[SMTP Notification] Unable to notify "+username+": Email not set", nil)
 		}
 	}
 
@@ -112,7 +113,7 @@ func (a Agent) ConsumerNotification(incomingNotification *notification.Notificat
 			"timestamp": time.Now().Format("2006-01-02 3:4:5 PM"),
 		})
 		if err != nil {
-			smtpnLogger.PrintAndLog("Smtpn", "[SMTP] Template load failed: "+err.Error(), nil)
+			logger.PrintAndLog("Smtpn", "[SMTP] Template load failed: "+err.Error(), nil)
 		}
 
 		msg := []byte("To: " + thisEmail + "\n" +
@@ -125,7 +126,7 @@ func (a Agent) ConsumerNotification(incomingNotification *notification.Notificat
 		auth := smtp.PlainAuth("", a.SMTPSender, a.SMTPPassword, a.SMTPDomain)
 		err = smtp.SendMail(a.SMTPDomain+":"+strconv.Itoa(a.SMTPPort), auth, a.SMTPSender, []string{thisEmail}, msg)
 		if err != nil {
-			smtpnLogger.PrintAndLog("Smtpn", fmt.Sprint("[SMTPN] Email sent failed: ", err.Error()), nil)
+			logger.PrintAndLog("Smtpn", fmt.Sprint("[SMTPN] Email sent failed: ", err.Error()), nil)
 			return err
 		}
 	}

--- a/src/mod/notification/agents/smtpn/zz_logger.go
+++ b/src/mod/notification/agents/smtpn/zz_logger.go
@@ -1,5 +1,0 @@
-package smtpn
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var smtpnLogger, _ = logger.NewTmpLogger()

--- a/src/mod/notification/notification.go
+++ b/src/mod/notification/notification.go
@@ -2,6 +2,8 @@ package notification
 
 import (
 	"container/list"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -72,11 +74,11 @@ func (q *NotificationQueue) BroadcastNotification(message *NotificationPayload) 
 		//Send this notification via this agent
 		err := thisAgent.ConsumerNotification(message)
 		if err != nil {
-			notificationLogger.PrintAndLog("Notification", "[Notification] Unable to send message via notification agent: "+thisAgent.Name(), nil)
+			logger.PrintAndLog("Notification", "[Notification] Unable to send message via notification agent: "+thisAgent.Name(), nil)
 		}
 
 	}
 
-	notificationLogger.PrintAndLog("Notification", "[Notification] Message titled: "+message.Title+" (ID: "+message.ID+") broadcasted", nil)
+	logger.PrintAndLog("Notification", "[Notification] Message titled: "+message.Title+" (ID: "+message.ID+") broadcasted", nil)
 	return nil
 }

--- a/src/mod/notification/notification_test.go
+++ b/src/mod/notification/notification_test.go
@@ -14,8 +14,8 @@ type mockAgent struct {
 	returnErr    error
 }
 
-func (m *mockAgent) Name() string  { return m.name }
-func (m *mockAgent) Desc() string  { return "mock agent" }
+func (m *mockAgent) Name() string     { return m.name }
+func (m *mockAgent) Desc() string     { return "mock agent" }
 func (m *mockAgent) IsConsumer() bool { return m.isConsumer }
 func (m *mockAgent) IsProducer() bool { return m.isProducer }
 

--- a/src/mod/notification/zz_logger.go
+++ b/src/mod/notification/zz_logger.go
@@ -1,5 +1,0 @@
-package notification
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var notificationLogger, _ = logger.NewTmpLogger()

--- a/src/mod/permission/group.go
+++ b/src/mod/permission/group.go
@@ -44,7 +44,7 @@ func (gp *PermissionGroup) SetCronJobPermission(allow bool) {
 	gp.parent.database.Write("permission", "canCreateCronJob/"+gp.Name, allowStr)
 }
 
-//Remove this permission group
+// Remove this permission group
 func (gp *PermissionGroup) Remove() {
 	db := gp.parent.database
 

--- a/src/mod/permission/permission.go
+++ b/src/mod/permission/permission.go
@@ -8,6 +8,7 @@ import (
 
 	db "imuslab.com/arozos/mod/database"
 	fs "imuslab.com/arozos/mod/filesystem"
+	"imuslab.com/arozos/mod/info/logger"
 	storage "imuslab.com/arozos/mod/storage"
 	"imuslab.com/arozos/mod/utils"
 )
@@ -72,7 +73,7 @@ func (h *PermissionHandler) LoadPermissionGroupsFromDatabase() error {
 			json.Unmarshal(keypairs[1], &originalJSONString)
 			err := json.Unmarshal([]byte(originalJSONString), &groupPermission)
 			if err != nil {
-				permissionLogger.PrintAndLog("Permission", fmt.Sprint(err), nil)
+				logger.PrintAndLog("Permission", fmt.Sprint(err), nil)
 			}
 			//IsAdmin
 			isAdmin := "false"

--- a/src/mod/permission/request.go
+++ b/src/mod/permission/request.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -185,7 +186,7 @@ func (h *PermissionHandler) HandleGroupCreate(w http.ResponseWriter, r *http.Req
 	h.NewPermissionGroup(groupname, isAdmin == "true", int64(quotaInt), permissionSlice, interfaceModule)
 
 	utils.SendOK(w)
-	permissionLogger.PrintAndLog("Permission", fmt.Sprint("Creating New Permission Group:", groupname, permission, isAdmin, quota), nil)
+	logger.PrintAndLog("Permission", fmt.Sprint("Creating New Permission Group:", groupname, permission, isAdmin, quota), nil)
 }
 
 func (h *PermissionHandler) HandleGroupRemove(w http.ResponseWriter, r *http.Request) {

--- a/src/mod/permission/static.go
+++ b/src/mod/permission/static.go
@@ -1,6 +1,6 @@
 package permission
 
-//Get the largest storage quota from all the given groups. Return int64
+// Get the largest storage quota from all the given groups. Return int64
 func GetLargestStorageQuotaFromGroups(groups []*PermissionGroup) int64 {
 	maxQuota := int64(0)
 	for _, group := range groups {

--- a/src/mod/permission/zz_logger.go
+++ b/src/mod/permission/zz_logger.go
@@ -1,5 +1,0 @@
-package permission
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var permissionLogger, _ = logger.NewTmpLogger()

--- a/src/mod/prouter/prouter.go
+++ b/src/mod/prouter/prouter.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"net/http"
 
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/security/csrf"
 	user "imuslab.com/arozos/mod/user"
 )
@@ -51,7 +52,7 @@ func NewModuleRouter(option RouterOption) *RouterDef {
 func (router *RouterDef) HandleFunc(endpoint string, handler func(http.ResponseWriter, *http.Request)) error {
 	//Check if the endpoint already registered
 	if _, exist := router.endpoints[endpoint]; exist {
-		prouterLogger.PrintAndLog("Prouter", "WARNING! Duplicated registering of web endpoint: "+endpoint, nil)
+		logger.PrintAndLog("Prouter", "WARNING! Duplicated registering of web endpoint: "+endpoint, nil)
 		return errors.New("Endpoint register duplicated")
 	}
 

--- a/src/mod/prouter/zz_logger.go
+++ b/src/mod/prouter/zz_logger.go
@@ -1,5 +1,0 @@
-package prouter
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var prouterLogger, _ = logger.NewTmpLogger()

--- a/src/mod/quota/quota.go
+++ b/src/mod/quota/quota.go
@@ -17,7 +17,7 @@ import (
 	fs "imuslab.com/arozos/mod/filesystem"
 )
 
-//QuotaHandler Object
+// QuotaHandler Object
 type QuotaHandler struct {
 	database          *db.Database //System database for storing data
 	username          string       //The current username for this handler
@@ -26,7 +26,7 @@ type QuotaHandler struct {
 	UsedStorageQuota  int64
 }
 
-//Create a storage quotation handler for this user
+// Create a storage quotation handler for this user
 func NewUserQuotaHandler(database *db.Database, username string, fsh []*fs.FileSystemHandler, defaultQuota int64) *QuotaHandler {
 	//Create the quota table if not exists
 	totalQuota := defaultQuota //Use defalt quota if init first time
@@ -61,7 +61,7 @@ func NewUserQuotaHandler(database *db.Database, username string, fsh []*fs.FileS
 	return &thisUserQuotaManager
 }
 
-//Set and Get the user storage quota
+// Set and Get the user storage quota
 func (q *QuotaHandler) SetUserStorageQuota(quota int64) {
 	q.database.Write("quota", q.username+"/quota", quota)
 	q.TotalStorageQuota = quota
@@ -76,7 +76,7 @@ func (q *QuotaHandler) GetUserStorageQuota() int64 {
 	return quota
 }
 
-//Check if the user's quota has been initialized
+// Check if the user's quota has been initialized
 func (q *QuotaHandler) IsQuotaInitialized() bool {
 	if q.GetUserStorageQuota() == int64(-2) {
 		return false
@@ -101,18 +101,18 @@ func (q *QuotaHandler) HaveSpace(size int64) bool {
 	}
 }
 
-//Update the user's storage pool to new one
+// Update the user's storage pool to new one
 func (q *QuotaHandler) UpdateUserStoragePool(fsh []*fs.FileSystemHandler) {
 	q.fspool = fsh
 }
 
-//Claim a space for the given file and set the file ownership to this user
+// Claim a space for the given file and set the file ownership to this user
 func (q *QuotaHandler) AllocateSpace(filesize int64) error {
 	q.UsedStorageQuota += filesize
 	return nil
 }
 
-//Reclaim file occupied space (Call this before removing it)
+// Reclaim file occupied space (Call this before removing it)
 func (q *QuotaHandler) ReclaimSpace(filesize int64) error {
 	q.UsedStorageQuota -= filesize
 	if q.UsedStorageQuota < 0 {
@@ -121,7 +121,7 @@ func (q *QuotaHandler) ReclaimSpace(filesize int64) error {
 	return nil
 }
 
-//Recalculate the user storage quota. This takes a lot of time and CPUs
+// Recalculate the user storage quota. This takes a lot of time and CPUs
 func (q *QuotaHandler) CalculateQuotaUsage() {
 	totalUsedVolume := int64(0)
 	for _, thisfs := range q.fspool {

--- a/src/mod/security/csrf/csrf.go
+++ b/src/mod/security/csrf/csrf.go
@@ -28,7 +28,7 @@ type Token struct {
 	Timeout      int64  //The timeout for this token in seconds
 }
 
-//Create a new CSRF Token Manager
+// Create a new CSRF Token Manager
 func NewTokenManager(uh *user.UserHandler, tokenExpireTime int64) *TokenManager {
 	tm := TokenManager{
 		UserHandler:            uh,
@@ -38,7 +38,7 @@ func NewTokenManager(uh *user.UserHandler, tokenExpireTime int64) *TokenManager 
 	return &tm
 }
 
-//Generate a new token
+// Generate a new token
 func (m *TokenManager) GenerateNewToken(username string) string {
 	//Generate a new uuid as the token
 	newUUID := uuid.NewV4().String()
@@ -72,7 +72,7 @@ func (m *TokenManager) GetUserTokenMap(username string) *sync.Map {
 	}
 }
 
-//Check if a given token is valud
+// Check if a given token is valud
 func (m *TokenManager) CheckTokenValidation(username string, token string) bool {
 	userSyncMap := m.GetUserTokenMap(username)
 	tokenObject, ok := userSyncMap.Load(token)

--- a/src/mod/security/csrf/handlers.go
+++ b/src/mod/security/csrf/handlers.go
@@ -19,7 +19,7 @@ func (m *TokenManager) HandleNewToken(w http.ResponseWriter, r *http.Request) {
 	utils.SendJSONResponse(w, string(js))
 }
 
-//validate the token validation from request
+// validate the token validation from request
 func (m *TokenManager) HandleTokenValidation(w http.ResponseWriter, r *http.Request) bool {
 	userinfo, err := m.UserHandler.GetUserInfoFromRequest(w, r)
 	if err != nil {

--- a/src/mod/share/share.go
+++ b/src/mod/share/share.go
@@ -37,6 +37,7 @@ import (
 	filesystem "imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
 	"imuslab.com/arozos/mod/filesystem/metadata"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/share/shareEntry"
 	"imuslab.com/arozos/mod/user"
 	"imuslab.com/arozos/mod/utils"
@@ -605,17 +606,17 @@ func (s *Manager) HandleShareAccess(w http.ResponseWriter, r *http.Request) {
 							} else {
 								f, err := targetFshAbs.ReadStream(path)
 								if err != nil {
-									shareLogger.PrintAndLog("Share", fmt.Sprint("[Share] Buffer and zip download operation failed: ", err), nil)
+									logger.PrintAndLog("Share", fmt.Sprint("[Share] Buffer and zip download operation failed: ", err), nil)
 								}
 								defer f.Close()
 								dest, err := os.OpenFile(localPath, os.O_CREATE|os.O_WRONLY, 0775)
 								if err != nil {
-									shareLogger.PrintAndLog("Share", fmt.Sprint("[Share] Buffer and zip download operation failed: ", err), nil)
+									logger.PrintAndLog("Share", fmt.Sprint("[Share] Buffer and zip download operation failed: ", err), nil)
 								}
 								defer dest.Close()
 								_, err = io.Copy(dest, f)
 								if err != nil {
-									shareLogger.PrintAndLog("Share", fmt.Sprint("[Share] Buffer and zip download operation failed: ", err), nil)
+									logger.PrintAndLog("Share", fmt.Sprint("[Share] Buffer and zip download operation failed: ", err), nil)
 								}
 
 							}
@@ -632,7 +633,7 @@ func (s *Manager) HandleShareAccess(w http.ResponseWriter, r *http.Request) {
 						//Failed to create zip file
 						w.WriteHeader(http.StatusInternalServerError)
 						w.Write([]byte("500 - Internal Server Error: Zip file creation failed"))
-						shareLogger.PrintAndLog("Share", "Failed to create zip file for share download: "+err.Error(), nil)
+						logger.PrintAndLog("Share", "Failed to create zip file for share download: "+err.Error(), nil)
 						return
 					}
 
@@ -1321,9 +1322,9 @@ func (s *Manager) ValidateAndClearShares() {
 			//This share source file don't exists anymore. Remove it
 			err = s.options.ShareEntryTable.RemoveShareByPathHash(pathHash)
 			if err != nil {
-				shareLogger.PrintAndLog("Share", fmt.Sprint("[Share] Failed to remove share", err), nil)
+				logger.PrintAndLog("Share", fmt.Sprint("[Share] Failed to remove share", err), nil)
 			}
-			shareLogger.PrintAndLog("Share", "[Share] Removing share to file: "+thisShareOption.FileRealPath+" as it no longer exists", nil)
+			logger.PrintAndLog("Share", "[Share] Removing share to file: "+thisShareOption.FileRealPath+" as it no longer exists", nil)
 		}
 		return true
 	})

--- a/src/mod/share/shareEntry/shareEntry.go
+++ b/src/mod/share/shareEntry/shareEntry.go
@@ -116,7 +116,7 @@ func (s *ShareEntryTable) CreateNewShare(srcFsh *filesystem.FileSystemHandler, v
 	}
 }
 
-//Delete the share on this vpath
+// Delete the share on this vpath
 func (s *ShareEntryTable) DeleteShareByPathHash(pathhash string) error {
 	//Check if the share already exists. If yes, use the previous link
 	val, ok := s.FileToUrlMap.Load(pathhash)

--- a/src/mod/share/zz_logger.go
+++ b/src/mod/share/zz_logger.go
@@ -1,5 +1,0 @@
-package share
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var shareLogger, _ = logger.NewTmpLogger()

--- a/src/mod/storage/bridge/bridge.go
+++ b/src/mod/storage/bridge/bridge.go
@@ -106,7 +106,7 @@ func (r *Record) IsBridgedFSH(FSHUUID string, groupOwner string) (bool, error) {
 	return false, nil
 }
 
-//Get a list of group owners that have this fsh uuid as "bridged" fs
+// Get a list of group owners that have this fsh uuid as "bridged" fs
 func (r *Record) GetBridgedGroups(FSHUUID string) []string {
 	results := []string{}
 	currentConfigs, err := r.ReadConfig()

--- a/src/mod/storage/du/diskusage.go
+++ b/src/mod/storage/du/diskusage.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package du

--- a/src/mod/storage/ftp/drivers.go
+++ b/src/mod/storage/ftp/drivers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	ftp "github.com/fclairamb/ftpserverlib"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 func (m mainDriver) GetSettings() (*ftp.Settings, error) {
@@ -32,7 +33,7 @@ func (m mainDriver) ClientDisconnected(cc ftp.ClientContext) {
 				if err == nil {
 					//Update the user storage quota
 					userinfo.StorageQuota.CalculateQuotaUsage()
-					ftpLogger.PrintAndLog("Ftp", fmt.Sprint("FTP storage quota updated: ", val.(string)), nil)
+					logger.PrintAndLog("Ftp", fmt.Sprint("FTP storage quota updated: ", val.(string)), nil)
 				}
 			} else {
 				//This user is being delete during his connection to FTP???
@@ -71,7 +72,7 @@ func (m mainDriver) AuthUser(cc ftp.ClientContext, user string, pass string) (ft
 			//log the signin request
 			m.userHandler.GetAuthAgent().Logger.LogAuthByRequestInfo(user, cc.RemoteAddr().String(), time.Now().Unix(), false, "ftp")
 			//Disconnect this user as he is not in the group that is allowed to access ftp
-			ftpLogger.PrintAndLog("Ftp", userinfo.Username+" tries to access FTP endpoint with invalid permission settings.", nil)
+			logger.PrintAndLog("Ftp", userinfo.Username+" tries to access FTP endpoint with invalid permission settings.", nil)
 			return nil, errors.New("User " + userinfo.Username + " has no permission to access FTP endpoint")
 		}
 

--- a/src/mod/storage/ftp/ftp.go
+++ b/src/mod/storage/ftp/ftp.go
@@ -8,6 +8,7 @@ import (
 
 	ftp "github.com/fclairamb/ftpserverlib"
 	"imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/user"
 )
 
@@ -62,7 +63,7 @@ func NewFTPHandler(userHandler *user.UserHandler, ServerName string, Port int, t
 func UpdateAccessableGroups(database *database.Database, groups []string) {
 	database.Write("ftp", "groups", groups)
 	if len(groups) == 0 {
-		ftpLogger.PrintAndLog("Ftp", "Setting no group access to ftp server!", nil)
+		logger.PrintAndLog("Ftp", "Setting no group access to ftp server!", nil)
 	}
 }
 
@@ -70,7 +71,7 @@ func UpdateAccessableGroups(database *database.Database, groups []string) {
 func (f *Handler) Start() error {
 	if f.server != nil {
 		go func(f *Handler) {
-			ftpLogger.PrintAndLog("Ftp", "FTP Server Started, listening at: "+strconv.Itoa(f.Port), nil)
+			logger.PrintAndLog("Ftp", "FTP Server Started, listening at: "+strconv.Itoa(f.Port), nil)
 			f.server.ListenAndServe()
 		}(f)
 		f.ServerRunning = true

--- a/src/mod/storage/ftp/zz_logger.go
+++ b/src/mod/storage/ftp/zz_logger.go
@@ -1,5 +1,0 @@
-package ftp
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var ftpLogger, _ = logger.NewTmpLogger()

--- a/src/mod/storage/sftpserver/sftpserver.go
+++ b/src/mod/storage/sftpserver/sftpserver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/sftp"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/crypto/ssh"
+	"imuslab.com/arozos/mod/info/logger"
 	user "imuslab.com/arozos/mod/user"
 )
 
@@ -62,7 +63,7 @@ func NewSFTPServer(sftpConfig *SFTPConfig) (*Instance, error) {
 	if err != nil {
 		return nil, err
 	}
-	sftpserverLogger.PrintAndLog("Sftpserver", fmt.Sprintf("[SFTP] Listening on %v\n", listener.Addr()), nil)
+	logger.PrintAndLog("Sftpserver", fmt.Sprintf("[SFTP] Listening on %v\n", listener.Addr()), nil)
 
 	//Setup a closer handler for this instance
 	closeChan := make(chan bool)
@@ -99,7 +100,7 @@ func NewSFTPServer(sftpConfig *SFTPConfig) (*Instance, error) {
 				if err != nil {
 					return err
 				}
-				sftpserverLogger.PrintAndLog("Sftpserver", fmt.Sprint("[SFTP] User Connected: ", cx.User()), nil)
+				logger.PrintAndLog("Sftpserver", fmt.Sprint("[SFTP] User Connected: ", cx.User()), nil)
 
 				userinfo, err := sftpConfig.UserManager.GetUserInfoFromUsername(cx.User())
 				if err != nil {
@@ -167,10 +168,10 @@ func NewSFTPServer(sftpConfig *SFTPConfig) (*Instance, error) {
 					if err := server.Serve(); err == io.EOF {
 						kickChan <- true
 						//server.Close()
-						sftpserverLogger.PrintAndLog("Sftpserver", "sftp client exited session.", nil)
+						logger.PrintAndLog("Sftpserver", "sftp client exited session.", nil)
 					} else if err != nil {
 						kickChan <- false
-						sftpserverLogger.PrintAndLog("Sftpserver", fmt.Sprint("sftp server completed with error:", err), nil)
+						logger.PrintAndLog("Sftpserver", fmt.Sprint("sftp server completed with error:", err), nil)
 					}
 
 				}
@@ -186,5 +187,5 @@ func NewSFTPServer(sftpConfig *SFTPConfig) (*Instance, error) {
 func (i *Instance) Close() {
 	i.closer <- true
 	i.Closed = true
-	sftpserverLogger.PrintAndLog("Sftpserver", "[SFTP] SFTP Server Closed", nil)
+	logger.PrintAndLog("Sftpserver", "[SFTP] SFTP Server Closed", nil)
 }

--- a/src/mod/storage/sftpserver/vroot.go
+++ b/src/mod/storage/sftpserver/vroot.go
@@ -17,7 +17,7 @@ import (
 	"imuslab.com/arozos/mod/filesystem/arozfs"
 )
 
-//Root of the serving tree
+// Root of the serving tree
 type root struct {
 	username       string
 	rootFile       *rootFolder
@@ -32,7 +32,7 @@ type rootFolder struct {
 	content []byte
 }
 
-//Fake folders in root for vroot redirections
+// Fake folders in root for vroot redirections
 type rootEntry struct {
 	thisFsh *filesystem.FileSystemHandler
 }
@@ -73,7 +73,7 @@ type sftpFileInterface interface {
 	WriteAt([]byte, int64) (int, error)
 }
 
-//Wrapper for the arozfs File to provide missing functions
+// Wrapper for the arozfs File to provide missing functions
 type wrappedArozFile struct {
 	file arozfs.File
 }
@@ -414,7 +414,7 @@ func (fs *root) Realpath(p string) string {
 	return cleanPathWithBase(fs.startDirectory, p)
 }
 
-//Convert sftp raw path into fsh, subpath and realpath. return err if any
+// Convert sftp raw path into fsh, subpath and realpath. return err if any
 func (fs *root) getFshAndSubpathFromSFTPPathname(pathname string) (*filesystem.FileSystemHandler, string, string, error) {
 	pathname = strings.TrimSpace(pathname)
 	if pathname[0:1] != "/" {

--- a/src/mod/storage/sftpserver/zz_logger.go
+++ b/src/mod/storage/sftpserver/zz_logger.go
@@ -1,5 +1,0 @@
-package sftpserver
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var sftpserverLogger, _ = logger.NewTmpLogger()

--- a/src/mod/storage/tftp/tftp.go
+++ b/src/mod/storage/tftp/tftp.go
@@ -10,6 +10,7 @@ import (
 
 	tftplib "github.com/pin/tftp/v3"
 	"imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/user"
 )
 
@@ -65,12 +66,12 @@ func NewTFTPHandler(userHandler *user.UserHandler, ServerName string, Port int, 
 func (h *Handler) Start() error {
 	if h.server != nil {
 		addr := ":" + strconv.Itoa(h.Port)
-		tftpLogger.PrintAndLog("Tftp", "[TFTP] Server Started, listening at: "+strconv.Itoa(h.Port), nil)
+		logger.PrintAndLog("Tftp", "[TFTP] Server Started, listening at: "+strconv.Itoa(h.Port), nil)
 
 		go func() {
 			err := h.server.ListenAndServe(addr)
 			if err != nil {
-				tftpLogger.PrintAndLog("Tftp", fmt.Sprint("[TFTP] Server error:", err), nil)
+				logger.PrintAndLog("Tftp", fmt.Sprint("[TFTP] Server error:", err), nil)
 			}
 		}()
 
@@ -117,7 +118,7 @@ func (d *tftpDriver) readHandler(filename string, rf io.ReaderFrom) error {
 	// Open file for reading
 	file, err := afs.Open(filename)
 	if err != nil {
-		tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] READ: Failed to open %s: %v", filename, err), nil)
+		logger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] READ: Failed to open %s: %v", filename, err), nil)
 		return err
 	}
 	defer file.Close()
@@ -136,11 +137,11 @@ func (d *tftpDriver) readHandler(filename string, rf io.ReaderFrom) error {
 
 	n, err := rf.ReadFrom(file)
 	if err != nil {
-		tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] READ: Transfer error for %s: %v", filename, err), nil)
+		logger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] READ: Transfer error for %s: %v", filename, err), nil)
 		return err
 	}
 
-	tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] READ: Sent %s (%d bytes)", filename, n), nil)
+	logger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] READ: Sent %s (%d bytes)", filename, n), nil)
 	return nil
 }
 
@@ -171,17 +172,17 @@ func (d *tftpDriver) writeHandler(filename string, wt io.WriterTo) error {
 	// Check if user can write
 	file, err := afs.Create(filename)
 	if err != nil {
-		tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] WRITE: Failed to create %s: %v", filename, err), nil)
+		logger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] WRITE: Failed to create %s: %v", filename, err), nil)
 		return err
 	}
 	defer file.Close()
 
 	n, err := wt.WriteTo(file)
 	if err != nil {
-		tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] WRITE: Transfer error for %s: %v", filename, err), nil)
+		logger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] WRITE: Transfer error for %s: %v", filename, err), nil)
 		return err
 	}
 
-	tftpLogger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] WRITE: Received %s (%d bytes)", filename, n), nil)
+	logger.PrintAndLog("Tftp", fmt.Sprintf("[TFTP] WRITE: Received %s (%d bytes)", filename, n), nil)
 	return nil
 }

--- a/src/mod/storage/tftp/zz_logger.go
+++ b/src/mod/storage/tftp/zz_logger.go
@@ -1,5 +1,0 @@
-package tftp
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var tftpLogger, _ = logger.NewTmpLogger()

--- a/src/mod/storage/webdav/common.go
+++ b/src/mod/storage/webdav/common.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -107,7 +109,7 @@ func isDir(path string) bool {
 	}
 	fi, err := os.Stat(path)
 	if err != nil {
-		webdavLogger.PrintAndLog("Webdav", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Webdav", fmt.Sprint(err), nil)
 		os.Exit(1)
 		return false
 	}

--- a/src/mod/storage/webdav/fshAdapter.go
+++ b/src/mod/storage/webdav/fshAdapter.go
@@ -10,6 +10,7 @@ import (
 
 	"imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/network/webdav"
 )
 
@@ -145,7 +146,7 @@ func (a *FshWebDAVAdapter) OpenFile(ctx context.Context, name string, flag int, 
 	//Merge it into a proper vpath and perform abstraction path translation
 	realRequestPath, err := a.requestPathToRealPath(name)
 	if err != nil {
-		webdavLogger.PrintAndLog("Webdav", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Webdav", fmt.Sprint(err), nil)
 		return nil, err
 	}
 

--- a/src/mod/storage/webdav/webdav.go
+++ b/src/mod/storage/webdav/webdav.go
@@ -22,6 +22,7 @@ import (
 	"imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/hidden"
 	"imuslab.com/arozos/mod/filesystem/metadata"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/network/webdav"
 	"imuslab.com/arozos/mod/user"
 	"imuslab.com/arozos/mod/utils"
@@ -224,7 +225,7 @@ func (s *Server) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	//Windows File Explorer. Handle with special case
 	/*
 		if r.Header["User-Agent"] != nil && strings.Contains(r.Header["User-Agent"][0], "Microsoft-WebDAV-MiniRedir") && r.TLS == nil {
-			webdavLogger.PrintAndLog("Webdav", "Windows File Explorer Connection. Routing using alternative handler", nil)
+			logger.PrintAndLog("Webdav", "Windows File Explorer Connection. Routing using alternative handler", nil)
 			s.HandleWindowClientAccess(w, r, reqRoot)
 			return
 		}
@@ -245,14 +246,14 @@ func (s *Server) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	//Validate request origin
 	allowAccess, err := authAgent.ValidateLoginRequest(w, r)
 	if !allowAccess {
-		webdavLogger.PrintAndLog("Webdav", "Someone from "+r.RemoteAddr+" try to log into "+username+" WebDAV endpoint but got rejected: "+err.Error(), nil)
+		logger.PrintAndLog("Webdav", "Someone from "+r.RemoteAddr+" try to log into "+username+" WebDAV endpoint but got rejected: "+err.Error(), nil)
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
 	passwordValid, rejectionReason := authAgent.ValidateUsernameAndPasswordWithReason(username, password)
 	if !passwordValid {
 		authAgent.Logger.LogAuthByRequestInfo(username, r.RemoteAddr, time.Now().Unix(), false, "webdav")
-		webdavLogger.PrintAndLog("Webdav", "Someone from "+r.RemoteAddr+" try to log into "+username+" WebDAV endpoint but got rejected: "+rejectionReason, nil)
+		logger.PrintAndLog("Webdav", "Someone from "+r.RemoteAddr+" try to log into "+username+" WebDAV endpoint but got rejected: "+rejectionReason, nil)
 		http.Error(w, rejectionReason, http.StatusUnauthorized)
 		return
 	}
@@ -260,14 +261,14 @@ func (s *Server) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	//Resolve the vroot to realpath
 	userinfo, err := s.userHandler.GetUserInfoFromUsername(username)
 	if err != nil {
-		webdavLogger.PrintAndLog("Webdav", err.Error(), nil)
+		logger.PrintAndLog("Webdav", err.Error(), nil)
 		http.Error(w, "Invalid username or password", http.StatusUnauthorized)
 		return
 	}
 
 	fsh, err := userinfo.GetFileSystemHandlerFromVirtualPath(reqRoot + ":/")
 	if err != nil {
-		webdavLogger.PrintAndLog("Webdav", fmt.Sprint("[WebDAV] Failed to load File System Handler from request root: ", reqRoot+":/", err.Error()), nil)
+		logger.PrintAndLog("Webdav", fmt.Sprint("[WebDAV] Failed to load File System Handler from request root: ", reqRoot+":/", err.Error()), nil)
 		http.Error(w, "Invalid ", http.StatusInternalServerError)
 		return
 	}
@@ -276,7 +277,7 @@ func (s *Server) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	/*
 		realRoot, err := userinfo.VirtualPathToRealPath(reqRoot + ":/")
 		if err != nil {
-			webdavLogger.PrintAndLog("Webdav", err.Error(), nil)
+			logger.PrintAndLog("Webdav", err.Error(), nil)
 			http.Error(w, "Invalid ", http.StatusUnauthorized)
 			return
 		}

--- a/src/mod/storage/webdav/webdavWindowHandler.go
+++ b/src/mod/storage/webdav/webdavWindowHandler.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	uuid "github.com/satori/go.uuid"
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 // Handle request from Windows File Explorer
@@ -43,7 +44,7 @@ func (s *Server) HandleWindowClientAccess(w http.ResponseWriter, r *http.Request
 			ip = "localhost"
 		}
 
-		webdavLogger.PrintAndLog("Webdav", fmt.Sprint("New Window WebDAV Client Connected! Assinging UUID:", thisWebDAVClientID), nil)
+		logger.PrintAndLog("Webdav", fmt.Sprint("New Window WebDAV Client Connected! Assinging UUID:", thisWebDAVClientID), nil)
 		//Store this UUID with the connection
 		s.windowsClientNotLoggedIn.Store(thisWebDAVClientID, &WindowClientInfo{
 			Agent:                   r.Header["User-Agent"][0],
@@ -122,7 +123,7 @@ func (s *Server) HandleWindowClientAccess(w http.ResponseWriter, r *http.Request
 
 			fsh, err := userinfo.GetFileSystemHandlerFromVirtualPath(vroot + ":/")
 			if err != nil {
-				webdavLogger.PrintAndLog("Webdav", fmt.Sprint("[WebDAV] Failed to load File System Handler from request root: ", err.Error()), nil)
+				logger.PrintAndLog("Webdav", fmt.Sprint("[WebDAV] Failed to load File System Handler from request root: ", err.Error()), nil)
 				http.Error(w, "Invalid ", http.StatusUnauthorized)
 				return
 			}

--- a/src/mod/storage/webdav/zz_logger.go
+++ b/src/mod/storage/webdav/zz_logger.go
@@ -1,5 +1,0 @@
-package webdav
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var webdavLogger, _ = logger.NewTmpLogger()

--- a/src/mod/subservice/common.go
+++ b/src/mod/subservice/common.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -108,7 +110,7 @@ func isDir(path string) bool {
 	}
 	fi, err := os.Stat(path)
 	if err != nil {
-		subserviceLogger.PrintAndLog("Subservice", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Subservice", fmt.Sprint(err), nil)
 		os.Exit(1)
 		return false
 	}

--- a/src/mod/subservice/subservice.go
+++ b/src/mod/subservice/subservice.go
@@ -155,7 +155,7 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 		launchConfig, err := os.ReadFile(servicePath + "/moduleInfo.json")
 		if err != nil {
 			if startupMode {
-				subserviceLogger.PrintAndLog("Subservice", fmt.Sprint("Failed to read moduleInfo.json: "+binaryname, err), nil)
+				logger.PrintAndLog("Subservice", fmt.Sprint("Failed to read moduleInfo.json: "+binaryname, err), nil)
 				os.Exit(1)
 			} else {
 				return errors.New("Failed to read moduleInfo.json: " + binaryname)
@@ -169,7 +169,7 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 		if err != nil {
 			sr.logger.PrintAndLog("Subservice", "Missing module startup info for "+servicePath, errors.New("Startup flag -info return no JSON string and moduleInfo.json does not exists for "+servicePath))
 			if startupMode {
-				subserviceLogger.PrintAndLog("Subservice", fmt.Sprint("Unable to start service: "+binaryname, err), nil)
+				logger.PrintAndLog("Subservice", fmt.Sprint("Unable to start service: "+binaryname, err), nil)
 				os.Exit(1)
 			} else {
 				return errors.New("Unable to start service: " + binaryname)
@@ -186,7 +186,7 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 	err := json.Unmarshal([]byte(serviceLaunchInfo), &thisModuleInfo)
 	if err != nil {
 		if startupMode {
-			subserviceLogger.PrintAndLog("Subservice", fmt.Sprint("Failed to load subservice: "+serviceRoot+"\n", err.Error()), nil)
+			logger.PrintAndLog("Subservice", fmt.Sprint("Failed to load subservice: "+serviceRoot+"\n", err.Error()), nil)
 			os.Exit(1)
 
 		} else {
@@ -207,7 +207,7 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 
 			if !fileExists(initPath) {
 				if startupMode {
-					subserviceLogger.PrintAndLog("Subservice", "start.sh not found. Unable to startup service "+serviceRoot, nil)
+					logger.PrintAndLog("Subservice", "start.sh not found. Unable to startup service "+serviceRoot, nil)
 					os.Exit(1)
 				} else {
 					return errors.New("start.sh not found. Unable to startup service " + serviceRoot)
@@ -243,7 +243,7 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 		//Check if this path is reversed
 		if stringInSlice(rProxyEndpoint, sr.ReservePaths) || rProxyEndpoint == "" {
 			if startupMode {
-				subserviceLogger.PrintAndLog("Subservice", serviceRoot+" service try to request system reserve path as Reverse Proxy endpoint.", nil)
+				logger.PrintAndLog("Subservice", serviceRoot+" service try to request system reserve path as Reverse Proxy endpoint.", nil)
 				os.Exit(1)
 			} else {
 				return errors.New(serviceRoot + " service try to request system reserve path as Reverse Proxy endpoint.")
@@ -264,7 +264,7 @@ func (sr *SubServiceRouter) Launch(servicePath string, startupMode bool) error {
 
 			if !fileExists(initPath) {
 				if startupMode {
-					subserviceLogger.PrintAndLog("Subservice", "start.sh not found. Unable to startup service "+serviceRoot, nil)
+					logger.PrintAndLog("Subservice", "start.sh not found. Unable to startup service "+serviceRoot, nil)
 					os.Exit(1)
 				} else {
 					return errors.New(serviceRoot + "start.sh not found. Unable to startup service " + serviceRoot)

--- a/src/mod/subservice/zz_logger.go
+++ b/src/mod/subservice/zz_logger.go
@@ -1,5 +1,0 @@
-package subservice
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var subserviceLogger, _ = logger.NewTmpLogger()

--- a/src/mod/time/scheduler/scheduler.go
+++ b/src/mod/time/scheduler/scheduler.go
@@ -105,7 +105,7 @@ func (a *Scheduler) createTicker(duration time.Duration) chan bool {
 	stop := make(chan bool, 1)
 
 	go func() {
-		defer schedulerLogger.PrintAndLog("Scheduler", "Scheduler Stopped", nil)
+		defer logger.PrintAndLog("Scheduler", "Scheduler Stopped", nil)
 		for {
 			select {
 			case <-ticker.C:
@@ -392,11 +392,11 @@ func cronlog(message string) {
 	f, err := os.OpenFile(currentLogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		//Unable to write to file. Log to STDOUT instead
-		schedulerLogger.PrintAndLog("Scheduler", fmt.Sprint(message), nil)
+		logger.PrintAndLog("Scheduler", fmt.Sprint(message), nil)
 		return
 	}
 	if _, err := f.WriteString(message + "\n"); err != nil {
-		schedulerLogger.PrintAndLog("Scheduler", fmt.Sprint(message), nil)
+		logger.PrintAndLog("Scheduler", fmt.Sprint(message), nil)
 		return
 	}
 	defer f.Close()

--- a/src/mod/time/scheduler/scheduler_test.go
+++ b/src/mod/time/scheduler/scheduler_test.go
@@ -701,11 +701,11 @@ func TestClose_WithTicker(t *testing.T) {
 
 // testEnv holds everything needed for authenticated HTTP handler tests.
 type testEnv struct {
-	scheduler  *Scheduler
-	authAgent  *auth.AuthAgent
+	scheduler   *Scheduler
+	authAgent   *auth.AuthAgent
 	userHandler *user.UserHandler
-	db         interface{ Close() }
-	cleanup    func()
+	db          interface{ Close() }
+	cleanup     func()
 }
 
 // newAuthTestEnv sets up a fully functional scheduler with a real UserHandler

--- a/src/mod/time/scheduler/zz_logger.go
+++ b/src/mod/time/scheduler/zz_logger.go
@@ -1,5 +1,0 @@
-package scheduler
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var schedulerLogger, _ = logger.NewTmpLogger()

--- a/src/mod/updates/handler.go
+++ b/src/mod/updates/handler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -155,7 +156,7 @@ func HandleGetUpdatePlatformInfo(w http.ResponseWriter, r *http.Request) {
 	vendorUpdateConfig := UpdateConfig{}
 	err = json.Unmarshal(updateFileContent, &vendorUpdateConfig)
 	if err != nil {
-		updatesLogger.PrintAndLog("Updates", fmt.Sprint("[Updates] Failed to parse update config file: ", err.Error()), nil)
+		logger.PrintAndLog("Updates", fmt.Sprint("[Updates] Failed to parse update config file: ", err.Error()), nil)
 		utils.SendErrorResponse(w, "Invalid or corrupted update config")
 		return
 	}

--- a/src/mod/updates/zz_logger.go
+++ b/src/mod/updates/zz_logger.go
@@ -1,5 +1,0 @@
-package updates
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var updatesLogger, _ = logger.NewTmpLogger()

--- a/src/mod/user/directoryHandler.go
+++ b/src/mod/user/directoryHandler.go
@@ -21,12 +21,12 @@ func (u *User) GetHomeDirectory() (string, error) {
 }
 */
 
-//Get the user home file system handler, aka user:/
+// Get the user home file system handler, aka user:/
 func (u *User) GetHomeFileSystemHandler() (*fs.FileSystemHandler, error) {
 	return getHandlerFromID(u.HomeDirectories.Storages, "user")
 }
 
-//Get all user Acessible file system handlers (ignore special fsh like backups)
+// Get all user Acessible file system handlers (ignore special fsh like backups)
 func (u *User) GetAllAccessibleFileSystemHandler() []*fs.FileSystemHandler {
 	results := []*fs.FileSystemHandler{}
 	fshs := u.GetAllFileSystemHandler()
@@ -39,7 +39,7 @@ func (u *User) GetAllAccessibleFileSystemHandler() []*fs.FileSystemHandler {
 	return results
 }
 
-//Try to get the root file system handler from vpath where the root file system handler must be in user scope of permission
+// Try to get the root file system handler from vpath where the root file system handler must be in user scope of permission
 func (u *User) GetRootFSHFromVpathInUserScope(vpath string) *fs.FileSystemHandler {
 	allFsh := u.GetAllAccessibleFileSystemHandler()
 	var vpathSourceFsh *fs.FileSystemHandler
@@ -238,7 +238,7 @@ func (u *User) RealPathToVirtualPath(rpath string) (string, error) {
 }
 */
 
-//Get a file system handler from a virtual path, this file system handler might not be the highest prioity one
+// Get a file system handler from a virtual path, this file system handler might not be the highest prioity one
 func (u *User) GetFileSystemHandlerFromVirtualPath(vpath string) (*fs.FileSystemHandler, error) {
 	fsHandlers := u.GetAllFileSystemHandler()
 	handler, err := getHandlerFromVirtualPath(fsHandlers, vpath)

--- a/src/mod/user/permissionHandler.go
+++ b/src/mod/user/permissionHandler.go
@@ -12,7 +12,7 @@ import (
 	"imuslab.com/arozos/mod/utils"
 )
 
-//Permissions related to modules
+// Permissions related to modules
 func (u *User) GetModuleAccessPermission(moduleName string) bool {
 	//Check if this module permission is within user's permission group access
 	moduleName = strings.ToLower(moduleName)
@@ -73,7 +73,7 @@ func (u *User) IsAdmin() bool {
 	return isAdmin
 }
 
-//Get the (or a list of ) Interface Module (aka booting module) for this user, returning module uuids
+// Get the (or a list of ) Interface Module (aka booting module) for this user, returning module uuids
 func (u *User) GetInterfaceModules() []string {
 	results := []string{}
 	for _, pg := range u.PermissionGroup {
@@ -91,7 +91,7 @@ func (u *User) GetInterfaceModules() []string {
 	return results
 }
 
-//Check if the user has access to this virthal filepath
+// Check if the user has access to this virthal filepath
 func (u *User) GetPathAccessPermission(vpath string) string {
 	fsid, _, err := getIDFromVirtualPath(filepath.ToSlash(vpath))
 	if err != nil {
@@ -125,7 +125,7 @@ func (u *User) GetPathAccessPermission(vpath string) string {
 	}
 }
 
-//Helper function for checking permission
+// Helper function for checking permission
 func (u *User) CanRead(vpath string) bool {
 	rwp := u.GetPathAccessPermission(vpath)
 	if rwp == arozfs.FsReadOnly || rwp == arozfs.FsReadWrite {
@@ -144,7 +144,7 @@ func (u *User) CanWrite(vpath string) bool {
 	}
 }
 
-//Get the highest access right to the given fs uuid
+// Get the highest access right to the given fs uuid
 func (u *User) GetHighestAccessRightStoragePool(fsUUID string) (*storage.StoragePool, error) {
 	//List all storage pool that have access to this fsUUID
 	matchingStoragePool := []*storage.StoragePool{}
@@ -202,7 +202,7 @@ func (u *User) GetUserPermissionGroupNames() []string {
 	return userPermissionGroups
 }
 
-//Check if the user is in one of the permission groups, require groupname
+// Check if the user is in one of the permission groups, require groupname
 func (u *User) UserIsInOneOfTheGroupOf(groupnames []string) bool {
 	userpg := u.GetUserPermissionGroup()
 	for _, thispg := range userpg {

--- a/src/mod/user/user.go
+++ b/src/mod/user/user.go
@@ -9,6 +9,7 @@ import (
 
 	auth "imuslab.com/arozos/mod/auth"
 	db "imuslab.com/arozos/mod/database"
+	"imuslab.com/arozos/mod/info/logger"
 	permission "imuslab.com/arozos/mod/permission"
 	quota "imuslab.com/arozos/mod/quota"
 	"imuslab.com/arozos/mod/share/shareEntry"
@@ -89,7 +90,7 @@ func (u *UserHandler) GetUserInfoFromUsername(username string) (*User, error) {
 	//Create user directories in the Home Directories
 	if u.basePool.Storages == nil {
 		//This userhandler do not have a basepool?
-		userLogger.PrintAndLog("User", "USER HANDLER DO NOT HAVE BASEPOOL", nil)
+		logger.PrintAndLog("User", "USER HANDLER DO NOT HAVE BASEPOOL", nil)
 	} else {
 		for _, store := range u.basePool.Storages {
 			if store.Hierarchy == "user" {

--- a/src/mod/user/useropr.go
+++ b/src/mod/user/useropr.go
@@ -1,6 +1,10 @@
 package user
 
-import "fmt"
+import (
+	"fmt"
+
+	"imuslab.com/arozos/mod/info/logger"
+)
 
 // Get the user's handler
 func (u *User) Parent() *UserHandler {
@@ -10,7 +14,7 @@ func (u *User) Parent() *UserHandler {
 // Remove the current user
 func (u *User) RemoveUser() {
 	//Remove the user storage quota settings
-	userLogger.PrintAndLog("User", fmt.Sprint("Removing User Quota: ", u.Username), nil)
+	logger.PrintAndLog("User", fmt.Sprint("Removing User Quota: ", u.Username), nil)
 	u.StorageQuota.RemoveUserQuota()
 
 	//Remove the user authentication register

--- a/src/mod/user/zz_logger.go
+++ b/src/mod/user/zz_logger.go
@@ -1,5 +1,0 @@
-package user
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var userLogger, _ = logger.NewTmpLogger()

--- a/src/mod/utils/utils.go
+++ b/src/mod/utils/utils.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"imuslab.com/arozos/mod/info/logger"
 )
 
 /*
@@ -142,7 +144,7 @@ func IsDir(path string) bool {
 	}
 	fi, err := os.Stat(path)
 	if err != nil {
-		utilsLogger.PrintAndLog("Utils", fmt.Sprint(err), nil)
+		logger.PrintAndLog("Utils", fmt.Sprint(err), nil)
 		os.Exit(1)
 		return false
 	}

--- a/src/mod/utils/zz_logger.go
+++ b/src/mod/utils/zz_logger.go
@@ -1,5 +1,0 @@
-package utils
-
-import logger "imuslab.com/arozos/mod/info/logger"
-
-var utilsLogger, _ = logger.NewTmpLogger()

--- a/src/network.go
+++ b/src/network.go
@@ -342,7 +342,7 @@ func FileServerInit() {
 	SambaShareManager, err = samba.NewSambaShareManager(userHandler)
 	if err != nil {
 		//Disable samba if not installed or platform not supported
-		systemWideLogger.PrintAndLog("System", "[INFO] Samba Share Manager Disabled: " + err.Error(), nil)
+		systemWideLogger.PrintAndLog("System", "[INFO] Samba Share Manager Disabled: "+err.Error(), nil)
 	}
 
 	//Register Endpoints

--- a/src/quota.go
+++ b/src/quota.go
@@ -33,7 +33,7 @@ func DiskQuotaInit() {
 	nightlyManager.RegisterNightlyTask(system_disk_quota_updateAllUserQuotaEstimation)
 }
 
-//Register the handler for automatically updating all user storage quota
+// Register the handler for automatically updating all user storage quota
 func system_disk_quota_updateAllUserQuotaEstimation() {
 	registeredUsers := authAgent.ListUsers()
 	for _, username := range registeredUsers {
@@ -43,7 +43,7 @@ func system_disk_quota_updateAllUserQuotaEstimation() {
 	}
 }
 
-//Set the storage quota of the particular user
+// Set the storage quota of the particular user
 func system_disk_quota_setQuota(w http.ResponseWriter, r *http.Request) {
 	userinfo, err := userHandler.GetUserInfoFromRequest(w, r)
 	if err != nil {
@@ -132,7 +132,7 @@ var fileExtensions = map[string][]string{
 	"Scripts":       {"pl", "lua", "r", "matlab", "ps1", "psm1", "bash", "zsh", "fish", "awk", "sed", "tcl"},
 }
 
-//Get all the users files and return size + count per category
+// Get all the users files and return size + count per category
 func system_disk_quota_handleFileDistributionView(w http.ResponseWriter, r *http.Request) {
 	userinfo, err := userHandler.GetUserInfoFromRequest(w, r)
 	if err != nil {

--- a/src/security.go
+++ b/src/security.go
@@ -23,7 +23,7 @@ var (
 	tokenCleaningTime int   = int(tokenExpireTime) * 12 //Tokens are cleared every 12 x tokenExpireTime
 )
 
-//Initiation function
+// Initiation function
 func security_init() {
 	//Create a default permission router accessable by everyone
 	router := prout.NewModuleRouter(prout.RouterOption{

--- a/src/startup.go
+++ b/src/startup.go
@@ -17,6 +17,7 @@ import (
 
 func RunStartup() {
 	systemWideLogger, _ = logger.NewLogger("system", "system/logs/system/", true)
+	systemWideLogger.PrintJSON = (*log_format == "json")
 	//1. Initiate the main system database
 
 	//Check if system or web both not exists and web.tar.gz exists. Unzip it for the user

--- a/src/startup.go
+++ b/src/startup.go
@@ -17,6 +17,7 @@ import (
 
 func RunStartup() {
 	systemWideLogger, _ = logger.NewLogger("system", "system/logs/system/", true)
+	logger.SetDefaultLogger(systemWideLogger)
 	//1. Initiate the main system database
 
 	//Check if system or web both not exists and web.tar.gz exists. Unzip it for the user

--- a/src/startup.go
+++ b/src/startup.go
@@ -17,7 +17,6 @@ import (
 
 func RunStartup() {
 	systemWideLogger, _ = logger.NewLogger("system", "system/logs/system/", true)
-	systemWideLogger.PrintJSON = (*log_format == "json")
 	//1. Initiate the main system database
 
 	//Check if system or web both not exists and web.tar.gz exists. Unzip it for the user

--- a/src/storage.bridge.go
+++ b/src/storage.bridge.go
@@ -11,7 +11,7 @@ import (
 	Storage functions related to bridged FSH
 */
 
-//Initiate bridged storage pool configs
+// Initiate bridged storage pool configs
 func BridgeStoragePoolInit() {
 	bridgeRecords, err := bridgeManager.ReadConfig()
 	if err != nil {
@@ -70,7 +70,7 @@ func BridgeStoragePoolForGroup(group string) {
 	}
 }
 
-//Debridge all bridged FSH from this group, origin (i.e. not bridged) fsh will be skipped
+// Debridge all bridged FSH from this group, origin (i.e. not bridged) fsh will be skipped
 func DebridgeAllFSHandlerFromGroup(group string) error {
 	targetSp, err := GetStoragePoolByOwner(group)
 	if err != nil {
@@ -106,7 +106,7 @@ func DebridgeAllFSHandlerFromGroup(group string) error {
 	return nil
 }
 
-//Bridge a FSH to a given Storage Pool
+// Bridge a FSH to a given Storage Pool
 func BridgeFSHandlerToGroup(fsh *fs.FileSystemHandler, sp *storage.StoragePool) error {
 	//Check if the fsh already exists in the basepool
 	for _, thisFSH := range sp.Storages {
@@ -118,7 +118,7 @@ func BridgeFSHandlerToGroup(fsh *fs.FileSystemHandler, sp *storage.StoragePool) 
 	return nil
 }
 
-//Debridge a fsh from a given group by fsh ID
+// Debridge a fsh from a given group by fsh ID
 func DebridgeFSHandlerFromGroup(fshUUID string, sp *storage.StoragePool) error {
 	isBridged, err := bridgeManager.IsBridgedFSH(fshUUID, sp.Owner)
 	if err != nil || !isBridged {

--- a/src/storage.go
+++ b/src/storage.go
@@ -147,7 +147,7 @@ func StoragePerformFileSystemAbstractionConnectionHeartbeat() {
 	for _, thisFsh := range allFsh {
 		err := thisFsh.FileSystemAbstraction.Heartbeat()
 		if err != nil {
-			systemWideLogger.PrintAndLog("System", "[Storage] File System Abstraction from " + thisFsh.Name + " report an error: " + err.Error(), nil)
+			systemWideLogger.PrintAndLog("System", "[Storage] File System Abstraction from "+thisFsh.Name+" report an error: "+err.Error(), nil)
 			//Retreive the old startup config and close the pool
 			originalStartOption := filesystem.FileSystemOption{}
 			js, _ := json.Marshal(thisFsh.StartOptions)
@@ -158,7 +158,7 @@ func StoragePerformFileSystemAbstractionConnectionHeartbeat() {
 				LocalBufferPath: *tmp_directory,
 			})
 			if err != nil {
-				systemWideLogger.PrintAndLog("System", "[Storage] Unable to reconnect " + thisFsh.Name + ": " + err.Error(), nil)
+				systemWideLogger.PrintAndLog("System", "[Storage] Unable to reconnect "+thisFsh.Name+": "+err.Error(), nil)
 				continue
 			} else {
 				//New fsh created. Close the old one
@@ -179,7 +179,7 @@ func StoragePerformFileSystemAbstractionConnectionHeartbeat() {
 			for _, pool := range parentsp {
 				err := pool.AttachFsHandler(newfsh)
 				if err != nil {
-					systemWideLogger.PrintAndLog("System", "[Storage] Attach fsh to pool failed: " + err.Error(), nil)
+					systemWideLogger.PrintAndLog("System", "[Storage] Attach fsh to pool failed: "+err.Error(), nil)
 				}
 			}
 		}

--- a/src/subservice.go
+++ b/src/subservice.go
@@ -75,7 +75,7 @@ func SubserviceInit() {
 	}
 }
 
-//Stop all the subprocess correctly
+// Stop all the subprocess correctly
 func SubserviceHandleShutdown() {
 	if ssRouter != nil {
 		ssRouter.Close()

--- a/src/test.go
+++ b/src/test.go
@@ -1,12 +1,12 @@
 package main
 
 /*
-	Development test playground
+Development test playground
 
-	To developers: If you have anything you want to try before
-	merging into other modules, test it here. This will execute
-	after all the startup process is ready and you can access
-	all global objects from the Run_Test() function below.
+To developers: If you have anything you want to try before
+merging into other modules, test it here. This will execute
+after all the startup process is ready and you can access
+all global objects from the Run_Test() function below.
 */
 func Run_Test() {
 


### PR DESCRIPTION
## Summary

- Adds a `--log_format` flag (`text` | `json`, default `text`) that switches all console output to newline-delimited JSON
- Eliminates all 56 per-package `zz_logger.go` files and their identical `NewTmpLogger()` instances, replacing them with a single default logger in the logger package
- Every module's `xxxLogger.PrintAndLog(...)` call is rewritten to `logger.PrintAndLog(...)` — one call path, one place to change behaviour

## Motivation

The system had 56 package-level logger variables, all created with `NewTmpLogger()` at package init time before flag parsing. This meant:

- Structured logging flags set after startup had no effect on module loggers
- Adding any new logging behaviour (JSON, sampling, redirection) required touching 56 files
- The instances were otherwise identical — no per-module configuration was ever used

## Changes

### `--log_format` flag
Pass `--log_format=json` at startup to get newline-delimited JSON on stdout:
```
{"time":"2026-06-05T01:15:48.677665+09:00","level":"info","title":"Scheduler","message":"[uuid] CronDemo_Schedule executed: ok"}
```
`level` is `"info"` or `"error"` depending on whether an error is attached. Text format (`log.Println`) is unchanged by default.

### Single default logger
The `logger` package now owns:
```go
var defaultLogger, _ = NewTmpLogger()          // safe before main() runs
func SetDefaultLogger(l *Logger)               // called from main() / RunStartup()
func PrintAndLog(title, message string, err error) // all modules call this
```

`main()` calls `SetDefaultLogger` twice: once with the temp logger (before `RunStartup`), and again with the persistent file-backed logger inside `RunStartup`. All intermediate log output is captured correctly.

### Deleted files
All 56 `zz_logger.go` files removed.

### Updated files
221 Go files updated — `xxxLogger.PrintAndLog(` → `logger.PrintAndLog(`; `goimports` regenerated all affected import blocks.

## Test plan
- [ ] Start with `--log_format=text` (default) — output unchanged from before
- [ ] Start with `--log_format=json` — all `PrintAndLog` output (including module loggers like AGI, Smart, SSDP) appears as JSON
- [ ] Scheduler cron log lines appear in JSON: `{"level":"info","title":"Scheduler","message":"[uuid] JobName executed: ok"}`
- [ ] File log (`system/logs/system/`) still written in the existing pipe-delimited format regardless of `--log_format`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvkmdBDMMeaz3qu5FGDapg)_