### PR TITLE
Refactor AGI logger initialization and remove duplicate import

### DIFF
--- a/src/mod/agi/agi.go
+++ b/src/mod/agi/agi.go
@@ -21,7 +21,6 @@ import (
 	"imuslab.com/arozos/mod/filesystem/arozfs"
 	"imuslab.com/arozos/mod/info/logger"
 	metadata "imuslab.com/arozos/mod/filesystem/metadata"
-	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/iot"
 	"imuslab.com/arozos/mod/share"
 	"imuslab.com/arozos/mod/time/nightly"

--- a/src/mod/agi/agi.system.go
+++ b/src/mod/agi/agi.system.go
@@ -42,10 +42,10 @@ func (g *Gateway) injectStandardLibs(vm *otto.Otto, scriptFile string, scriptSco
 	// Override otto's built-in console.log (which maps to fmt.Println) so that
 	// script output goes through the structured logger and carries the execID.
 	// Use the system-wide logger (with file output) when available; fall back to
-	// agiLogger (stdout only) if the Gateway was created without one.
-	scriptLogger := agiLogger
-	if g.Option.Logger != nil {
-		scriptLogger = g.Option.Logger
+	// a tmp stdout-only logger if the Gateway was created without one.
+	scriptLogger := g.Option.Logger
+	if scriptLogger == nil {
+		scriptLogger, _ = logger.NewTmpLogger()
 	}
 	vm.Set("_agi_console_log", func(call otto.FunctionCall) otto.Value {
 		parts := make([]string, 0, len(call.ArgumentList))


### PR DESCRIPTION
## Summary
This PR improves the AGI module's logger handling by refactoring the initialization logic and cleaning up a duplicate import statement.

## Key Changes
- **Logger initialization refactoring**: Changed the logic in `injectStandardLibs()` to check if `g.Option.Logger` is nil and create a temporary stdout-only logger using `logger.NewTmpLogger()` instead of relying on a global `agiLogger` variable
- **Removed duplicate import**: Eliminated the duplicate `"imuslab.com/arozos/mod/info/logger"` import in `agi.go`

## Implementation Details
- The logger initialization now follows a clearer pattern: use the configured logger if available, otherwise create a temporary logger on-demand
- This change removes the dependency on a global `agiLogger` variable, making the code more self-contained and testable
- The temporary logger is created only when needed (when no system-wide logger is configured)

https://claude.ai/code/session_01TPKX7ABMZtSMQyj7UQUANU