### PR TITLE
Add execution ID to AGI script error log messages

### DIFF
--- a/src/mod/agi/agi.go
+++ b/src/mod/agi/agi.go
@@ -357,7 +357,7 @@ func (g *Gateway) ExecuteAGIScript(scriptContent string, fsh *filesystem.FileSys
 		if thisuser != nil {
 			username = thisuser.Username
 		}
-		logger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Script error in %s (user: %s): %s", scriptFile, username, err.Error()), nil)
+		logger.PrintAndLog("Agi", fmt.Sprintf("[AGI][%s] Script error in %s (user: %s): %s", execID, scriptFile, username, err.Error()), nil)
 
 		if devMode {
 			// Return a detailed JSON error payload for developer inspection
@@ -496,7 +496,7 @@ func (g *Gateway) ExecuteAGIScriptAsUser(fsh *filesystem.FileSystemHandler, scri
 
 	_, err = vm.Run(scriptContent)
 	if err != nil {
-		logger.PrintAndLog("Agi", fmt.Sprintf("[AGI] Script error in %s (user: %s): %s", scriptFile, targetUser.Username, err.Error()), nil)
+		logger.PrintAndLog("Agi", fmt.Sprintf("[AGI][%s] Script error in %s (user: %s): %s", execID, scriptFile, targetUser.Username, err.Error()), nil)
 		return execID, "", err
 	}
 

--- a/src/mod/agi/externalReqHandler.go
+++ b/src/mod/agi/externalReqHandler.go
@@ -228,7 +228,7 @@ func (g *Gateway) ExtAPIHandler(w http.ResponseWriter, r *http.Request) {
 	g.recordExecution(endpointUUID, pathFromDb, execID, r.Method, durationMs, execErr)
 
 	if execErr != nil {
-		logger.PrintAndLog("Agi", fmt.Sprint("[Remote AGI] ", pathFromDb, " failed to execute", execErr.Error()), nil)
+		logger.PrintAndLog("Agi", fmt.Sprintf("[Remote AGI][%s] %s failed to execute: %s", execID, pathFromDb, execErr.Error()), nil)
 		utils.SendErrorResponse(w, execErr.Error())
 		return
 	}


### PR DESCRIPTION
## Summary
Enhanced AGI script error logging by including the execution ID in error messages across multiple logging points. This improves traceability and debugging by allowing operators to correlate error logs with specific script executions.

## Key Changes
- Added `execID` to error log messages in `ExecuteAGIScript()` method
- Added `execID` to error log messages in `ExecuteAGIScriptAsUser()` method
- Added `execID` to error log messages in `ExtAPIHandler()` for remote AGI execution failures
- Standardized log message format to `[AGI][{execID}]` for consistency across all three logging points
- Improved remote AGI error message formatting by using `fmt.Sprintf()` instead of `fmt.Sprint()` for better readability

## Implementation Details
The execution ID (`execID`) is now included in the log format as `[AGI][{execID}]` prefix, making it easier to trace specific script executions in logs. This is particularly useful for debugging issues in production environments where multiple scripts may be executing concurrently.

https://claude.ai/code/session_01FHPkX8pCYWbGvh2pL47J8y