### PR TITLE
Add extended request logging with request ID tracking

### DIFF
--- a/src/main.flags.go
+++ b/src/main.flags.go
@@ -99,6 +99,7 @@ var enable_beta_scanning_support = flag.Bool("beta_scan", false, "Allow compatib
 var enable_console = flag.Bool("console", false, "Enable the debugging console.")
 var enable_logging = flag.Bool("logging", true, "Enable logging to file for debug purpose")
 var log_format = flag.String("log_format", "text", "Console log output format: text or json")
+var extended_log = flag.Bool("extended_log", false, "Enable extended request logging: attach X-Arozos-RequestId UUID header to every response and log method, path, headers, status code, duration, and handling component for each request")
 
 // Flags related to running on Cloud Environment or public domain
 var allow_public_registry = flag.Bool("public_reg", false, "Enable public register interface for account creation")

--- a/src/main.go
+++ b/src/main.go
@@ -13,6 +13,7 @@ import (
 
 	console "imuslab.com/arozos/mod/console"
 	"imuslab.com/arozos/mod/info/logger"
+	"imuslab.com/arozos/mod/requestlog"
 )
 
 /*
@@ -114,6 +115,18 @@ func main() {
 	//Updates 2022-09-06: Gzip handler moved inside the master router
 	http.Handle("/", mrouter(fs))
 
+	// Enable extended request logging when the --extended_log flag is set.
+	// The middleware wraps the entire default mux so every request (including
+	// those registered directly via http.HandleFunc) is covered.
+	if *extended_log {
+		requestlog.Enabled = true
+		systemWideLogger.PrintAndLog("System", "Extended request logging enabled (X-Arozos-RequestId)", nil)
+	}
+	var serverHandler http.Handler = http.DefaultServeMux
+	if *extended_log {
+		serverHandler = requestlog.Middleware(http.DefaultServeMux)
+	}
+
 	//Setup handler for Ctrl +C
 	SetupCloseHandler()
 
@@ -124,16 +137,16 @@ func main() {
 				go func() {
 					address := fmt.Sprintf("%s:%d", *listen_host, *listen_port)
 					systemWideLogger.PrintAndLog("System", fmt.Sprint("Standard (HTTP) Web server listening at", address), nil)
-					http.ListenAndServe(address, nil)
+					http.ListenAndServe(address, serverHandler)
 				}()
 			}
 			address := fmt.Sprintf("%s:%d", *listen_host, *tls_listen_port)
 			systemWideLogger.PrintAndLog("System", fmt.Sprint("Secure (HTTPS) Web server listening at", address), nil)
-			http.ListenAndServeTLS(address, *tls_cert, *tls_key, nil)
+			http.ListenAndServeTLS(address, *tls_cert, *tls_key, serverHandler)
 		} else {
 			address := fmt.Sprintf("%s:%d", *listen_host, *listen_port)
 			systemWideLogger.PrintAndLog("System", fmt.Sprint("Web server listening at", address), nil)
-			http.ListenAndServe(address, nil)
+			http.ListenAndServe(address, serverHandler)
 		}
 	}()
 

--- a/src/mod/prouter/prouter.go
+++ b/src/mod/prouter/prouter.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 
 	"imuslab.com/arozos/mod/info/logger"
+	"imuslab.com/arozos/mod/requestlog"
 	"imuslab.com/arozos/mod/security/csrf"
 	user "imuslab.com/arozos/mod/user"
 )
@@ -81,6 +82,7 @@ func (router *RouterDef) HandleFunc(endpoint string, handler func(http.ResponseW
 				if router.adminOnly && !userinfo.IsAdmin() {
 					router.permissionDeniedHandler(w, r)
 				} else {
+					requestlog.LogComponent(r, "(system)", endpoint)
 					handler(w, r)
 				}
 				return
@@ -91,6 +93,7 @@ func (router *RouterDef) HandleFunc(endpoint string, handler func(http.ResponseW
 				if router.adminOnly == true {
 					//This module require admin. Check user is admin
 					if userinfo.IsAdmin() == true {
+						requestlog.LogComponent(r, router.moduleUUID, endpoint)
 						handler(w, r)
 					} else {
 						router.permissionDeniedHandler(w, r)
@@ -98,6 +101,7 @@ func (router *RouterDef) HandleFunc(endpoint string, handler func(http.ResponseW
 					}
 				} else {
 					//This module do not require admin. Allow serving
+					requestlog.LogComponent(r, router.moduleUUID, endpoint)
 					handler(w, r)
 				}
 			} else {

--- a/src/mod/requestlog/requestlog.go
+++ b/src/mod/requestlog/requestlog.go
@@ -17,8 +17,10 @@ package requestlog
 */
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"sort"
 	"strings"
@@ -62,6 +64,17 @@ func (rr *responseRecorder) status() int {
 		return http.StatusOK
 	}
 	return rr.statusCode
+}
+
+// Hijack implements http.Hijacker so that WebSocket upgrades work through the
+// middleware. Without this, the gorilla/websocket upgrader cannot take over the
+// underlying TCP connection and returns "response does not implement http.Hijacker".
+func (rr *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := rr.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("requestlog: underlying ResponseWriter does not implement http.Hijacker")
+	}
+	return hijacker.Hijack()
 }
 
 // GetRequestID retrieves the request ID injected by Middleware from the

--- a/src/mod/requestlog/requestlog.go
+++ b/src/mod/requestlog/requestlog.go
@@ -9,7 +9,8 @@ package requestlog
 	  - returned to the client as the X-Arozos-RequestId response header
 
 	The middleware logs two lines per request:
-	  RECV  – method, path, remote address, and all request headers
+	  RECV  – method, path, remote address, and all request headers (sensitive
+	          headers such as Cookie and Authorization are redacted)
 	  DONE  – method, path, status code, and elapsed time
 
 	Downstream components (e.g. prouter) call LogComponent to append a
@@ -37,22 +38,62 @@ const requestIDKey contextKey = "x-arozos-requestId"
 // Enabled is set once at startup by main() when --extended_log is passed.
 var Enabled bool
 
+// sensitiveHeaders lists canonical header names whose full values are redacted.
+var sensitiveHeaders = map[string]bool{
+	"Authorization": true,
+	"Set-Cookie":    true,
+	"X-Auth-Token":  true,
+	"X-Api-Key":     true,
+}
+
+// sanitizeHeader returns the header value safe for logging. Cookie headers show
+// cookie names with redacted values; other sensitive headers are fully redacted.
+func sanitizeHeader(name, value string) string {
+	canonical := http.CanonicalHeaderKey(name)
+	if canonical == "Cookie" {
+		var parts []string
+		for _, pair := range strings.Split(value, ";") {
+			pair = strings.TrimSpace(pair)
+			if idx := strings.IndexByte(pair, '='); idx >= 0 {
+				parts = append(parts, pair[:idx+1]+"[REDACTED]")
+			} else {
+				parts = append(parts, pair)
+			}
+		}
+		return strings.Join(parts, "; ")
+	}
+	if sensitiveHeaders[canonical] {
+		return "[REDACTED]"
+	}
+	return value
+}
+
 // responseRecorder wraps http.ResponseWriter to capture the written status code.
+// It also tracks whether the connection was hijacked (e.g. for WebSocket
+// upgrades) so that post-hijack calls to WriteHeader/Write are silently
+// dropped rather than producing "WriteHeader on hijacked connection" warnings.
 type responseRecorder struct {
 	http.ResponseWriter
 	statusCode  int
 	wroteHeader bool
+	hijacked    bool
 }
 
 func (rr *responseRecorder) WriteHeader(code int) {
-	if !rr.wroteHeader {
-		rr.statusCode = code
-		rr.wroteHeader = true
-		rr.ResponseWriter.WriteHeader(code)
+	if rr.hijacked || rr.wroteHeader {
+		return
 	}
+	rr.statusCode = code
+	rr.wroteHeader = true
+	rr.ResponseWriter.WriteHeader(code)
 }
 
 func (rr *responseRecorder) Write(b []byte) (int, error) {
+	if rr.hijacked {
+		// The raw connection is owned by the WebSocket handler; writes must go
+		// there directly, not through the http.ResponseWriter.
+		return len(b), nil
+	}
 	if !rr.wroteHeader {
 		rr.WriteHeader(http.StatusOK)
 	}
@@ -67,14 +108,20 @@ func (rr *responseRecorder) status() int {
 }
 
 // Hijack implements http.Hijacker so that WebSocket upgrades work through the
-// middleware. Without this, the gorilla/websocket upgrader cannot take over the
-// underlying TCP connection and returns "response does not implement http.Hijacker".
+// middleware. Sets hijacked=true so subsequent WriteHeader/Write calls are
+// suppressed to avoid "WriteHeader on hijacked connection" log noise.
 func (rr *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijacker, ok := rr.ResponseWriter.(http.Hijacker)
 	if !ok {
 		return nil, nil, fmt.Errorf("requestlog: underlying ResponseWriter does not implement http.Hijacker")
 	}
-	return hijacker.Hijack()
+	conn, brw, err := hijacker.Hijack()
+	if err == nil {
+		rr.hijacked = true
+		rr.wroteHeader = true
+		rr.statusCode = http.StatusSwitchingProtocols
+	}
+	return conn, brw, err
 }
 
 // GetRequestID retrieves the request ID injected by Middleware from the
@@ -117,10 +164,11 @@ func Middleware(next http.Handler) http.Handler {
 		// Expose request ID to the client
 		w.Header().Set("X-Arozos-RequestId", requestID)
 
-		// Collect and sort headers for a deterministic log line
+		// Collect, sanitize, and sort headers for a deterministic log line
 		var headerParts []string
 		for name, values := range r.Header {
-			headerParts = append(headerParts, fmt.Sprintf("%s: %s", name, strings.Join(values, ", ")))
+			sanitized := sanitizeHeader(name, strings.Join(values, ", "))
+			headerParts = append(headerParts, fmt.Sprintf("%s: %s", name, sanitized))
 		}
 		sort.Strings(headerParts)
 

--- a/src/mod/requestlog/requestlog.go
+++ b/src/mod/requestlog/requestlog.go
@@ -1,0 +1,137 @@
+package requestlog
+
+/*
+	ArozOS Extended Request Logger
+
+	When enabled via the --extended_log flag, every HTTP request is assigned a
+	UUID that is:
+	  - injected into the request context (for downstream components to read)
+	  - returned to the client as the X-Arozos-RequestId response header
+
+	The middleware logs two lines per request:
+	  RECV  – method, path, remote address, and all request headers
+	  DONE  – method, path, status code, and elapsed time
+
+	Downstream components (e.g. prouter) call LogComponent to append a
+	third line that records which module handled the request.
+*/
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"imuslab.com/arozos/mod/info/logger"
+)
+
+type contextKey string
+
+const requestIDKey contextKey = "x-arozos-requestId"
+
+// Enabled is set once at startup by main() when --extended_log is passed.
+var Enabled bool
+
+// responseRecorder wraps http.ResponseWriter to capture the written status code.
+type responseRecorder struct {
+	http.ResponseWriter
+	statusCode  int
+	wroteHeader bool
+}
+
+func (rr *responseRecorder) WriteHeader(code int) {
+	if !rr.wroteHeader {
+		rr.statusCode = code
+		rr.wroteHeader = true
+		rr.ResponseWriter.WriteHeader(code)
+	}
+}
+
+func (rr *responseRecorder) Write(b []byte) (int, error) {
+	if !rr.wroteHeader {
+		rr.WriteHeader(http.StatusOK)
+	}
+	return rr.ResponseWriter.Write(b)
+}
+
+func (rr *responseRecorder) status() int {
+	if !rr.wroteHeader {
+		return http.StatusOK
+	}
+	return rr.statusCode
+}
+
+// GetRequestID retrieves the request ID injected by Middleware from the
+// request context. Returns an empty string if extended logging is disabled.
+func GetRequestID(r *http.Request) string {
+	if id, ok := r.Context().Value(requestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// LogComponent records which module/component accepted a request. Call this
+// from prouter or any other handler that knows its own module name.
+func LogComponent(r *http.Request, component, endpoint string) {
+	if !Enabled {
+		return
+	}
+	requestID := GetRequestID(r)
+	logger.PrintAndLog("RequestLog", fmt.Sprintf(
+		"HDLR requestId=%s component=%s endpoint=%s",
+		requestID, component, endpoint,
+	), nil)
+}
+
+// Middleware wraps next and performs extended request logging when Enabled.
+// When disabled it is a transparent pass-through with zero overhead.
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !Enabled {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		requestID := uuid.NewV4().String()
+
+		// Propagate the request ID through context
+		ctx := context.WithValue(r.Context(), requestIDKey, requestID)
+		r = r.WithContext(ctx)
+
+		// Expose request ID to the client
+		w.Header().Set("X-Arozos-RequestId", requestID)
+
+		// Collect and sort headers for a deterministic log line
+		var headerParts []string
+		for name, values := range r.Header {
+			headerParts = append(headerParts, fmt.Sprintf("%s: %s", name, strings.Join(values, ", ")))
+		}
+		sort.Strings(headerParts)
+
+		logger.PrintAndLog("RequestLog", fmt.Sprintf(
+			"RECV requestId=%s method=%s path=%s remoteAddr=%s headers=[%s]",
+			requestID,
+			r.Method,
+			r.URL.RequestURI(),
+			r.RemoteAddr,
+			strings.Join(headerParts, " | "),
+		), nil)
+
+		rec := &responseRecorder{ResponseWriter: w}
+		start := time.Now()
+
+		next.ServeHTTP(rec, r)
+
+		logger.PrintAndLog("RequestLog", fmt.Sprintf(
+			"DONE requestId=%s method=%s path=%s status=%d duration=%s",
+			requestID,
+			r.Method,
+			r.URL.RequestURI(),
+			rec.status(),
+			time.Since(start).Round(time.Millisecond),
+		), nil)
+	})
+}


### PR DESCRIPTION
## Summary
Implements comprehensive HTTP request logging for ArozOS with per-request UUID tracking. When enabled via the `--extended_log` flag, the system logs request lifecycle events (received, handled, completed) with sensitive header redaction and request ID propagation through context and response headers.

## Key Changes

- **New `requestlog` module** (`src/mod/requestlog/requestlog.go`):
  - Middleware that wraps HTTP handlers to log request lifecycle (RECV, HDLR, DONE)
  - Generates unique UUID for each request and injects into request context
  - Returns request ID to clients via `X-Arozos-RequestId` response header
  - Sanitizes sensitive headers (Authorization, Set-Cookie, X-Auth-Token, X-Api-Key) with redaction
  - Special handling for Cookie headers (shows names, redacts values)
  - Custom `responseRecorder` wrapper to capture HTTP status codes and handle WebSocket hijacking
  - `LogComponent()` function for downstream handlers to record which module processed the request

- **Integration in `main.go`**:
  - Added `--extended_log` flag support
  - Wraps `http.DefaultServeMux` with request logging middleware when flag is enabled
  - Applies middleware to both HTTP and HTTPS listeners
  - Logs system message when extended logging is activated

- **Integration in `prouter.go`**:
  - Calls `requestlog.LogComponent()` when routing requests to modules
  - Records both system endpoints and module-specific endpoints with their UUIDs
  - Logs component information for admin-only and user-authenticated routes

## Notable Implementation Details

- Middleware is a transparent pass-through when disabled (zero overhead)
- Headers are sorted deterministically in logs for consistent output
- Proper handling of hijacked connections (WebSocket upgrades) to avoid spurious warnings
- Request ID available to all downstream components via `GetRequestID(r *http.Request)`
- Elapsed time logged with millisecond precision

https://claude.ai/code/session_0195pobUvqxCCJKnwUFL728T

<img width="1169" height="623" alt="image" src="https://github.com/user-attachments/assets/ff585525-0f01-4470-92b4-1cad28c63724" />
