### PR TITLE
Add RAW to JPEG conversion support to imagelib

### DIFF
--- a/src/agi-doc.md
+++ b/src/agi-doc.md
@@ -599,8 +599,23 @@ imagelib.getImageDimension("user:/Desktop/test.jpg");                           
 imagelib.resizeImage("user:/Desktop/input.png", "user:/Desktop/output.png", 500, 300);     //Resize input.png to 500 x 300 pixal and write to output.png
 imagelib.loadThumbString("user:/Desktop/test.jpg"); //Load the given file's thumbnail as base64 string, return false if failed
 imagelib.cropImage("user:/Desktop/test.jpg", "user:/Desktop/out.jpg",100,100,200,200)); 
+//Convert a RAW photo to a normal JPEG, return true on success and false on failure
+imagelib.rawToJPEG("user:/Desktop/photo.ARW", "user:/Desktop/photo.jpg");
 //Classify an image using neural network, since v1.119
 imagelib.classify("tmp:/classify.jpg", "yolo3"); 
+```
+
+#### Convert RAW to JPEG
+
+```
+Convert a camera RAW photo into a standard JPEG by extracting its embedded
+full-size preview. Supported RAW formats: .arw, .cr2, .dng, .nef, .raf, .orf
+
+1) Input file (virtual path to the RAW photo)
+2) Output file (virtual path, must end in .jpg or .jpeg, overwritten if exists)
+
+return true if success, false if failed (e.g. input is not a supported RAW
+format, or no embedded preview could be extracted)
 ```
 
 #### Crop Image Options

--- a/src/mod/agi/agi.image.go
+++ b/src/mod/agi/agi.image.go
@@ -22,7 +22,9 @@ import (
 	"github.com/rwcarlsen/goexif/exif"
 
 	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/filesystem"
 	"imuslab.com/arozos/mod/filesystem/arozfs"
+	metadata "imuslab.com/arozos/mod/filesystem/metadata"
 	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/utils"
 )
@@ -599,6 +601,46 @@ func (g *Gateway) injectImageLibFunctions(payload *static.AgiLibInjectionPayload
 		return result
 	})
 
+	//Convert a RAW photo (ARW/CR2/DNG/NEF/RAF/ORF) to a normal JPEG, require (input, output)
+	vm.Set("_imagelib_rawToJPEG", func(call otto.FunctionCall) otto.Value {
+		vsrc, err := call.Argument(0).ToString()
+		if err != nil {
+			g.RaiseError(err)
+			return otto.FalseValue()
+		}
+
+		vdest, err := call.Argument(1).ToString()
+		if err != nil {
+			g.RaiseError(err)
+			return otto.FalseValue()
+		}
+
+		//Convert the virtual paths to real paths
+		srcfsh, rsrc, err := static.VirtualPathToRealPath(vsrc, u)
+		if err != nil {
+			g.RaiseError(err)
+			return otto.FalseValue()
+		}
+		destfsh, rdest, err := static.VirtualPathToRealPath(vdest, u)
+		if err != nil {
+			g.RaiseError(err)
+			return otto.FalseValue()
+		}
+
+		if !srcfsh.FileSystemAbstraction.FileExists(rsrc) {
+			g.RaiseError(errors.New("File not exists! Given " + rsrc))
+			return otto.FalseValue()
+		}
+
+		err = convertRawToJPEG(srcfsh, rsrc, destfsh, rdest)
+		if err != nil {
+			g.RaiseError(err)
+			return otto.FalseValue()
+		}
+
+		return otto.TrueValue()
+	})
+
 	//Wrap all the native code function into an imagelib class
 	vm.Run(`
 		var imagelib = {};
@@ -609,5 +651,30 @@ func (g *Gateway) injectImageLibFunctions(payload *static.AgiLibInjectionPayload
 		imagelib.loadThumbString = _imagelib_loadThumbString;
 		imagelib.hasExif = _imagelib_hasExif;
 		imagelib.getExif = _imagelib_getExif;
+		imagelib.rawToJPEG = _imagelib_rawToJPEG;
 	`)
+}
+
+// convertRawToJPEG renders a RAW photo (ARW, CR2, DNG, NEF, RAF, ORF) into a
+// standard JPEG by extracting its embedded full-size preview, then writes the
+// result to destRpath on destFsh. It returns an error when the source is not a
+// supported RAW format, when the output is not a .jpg/.jpeg file, or when any
+// read / render / write step fails. WriteFile is used for the output so this
+// works on every filesystem abstraction, including buffered ones (S3, FTP, WebDAV).
+func convertRawToJPEG(srcFsh *filesystem.FileSystemHandler, srcRpath string, destFsh *filesystem.FileSystemHandler, destRpath string) error {
+	if !metadata.IsRawImageFile(srcRpath) {
+		return errors.New("source is not a supported RAW image: " + filepath.Base(srcRpath))
+	}
+
+	destExt := strings.ToLower(filepath.Ext(destRpath))
+	if destExt != ".jpg" && destExt != ".jpeg" {
+		return errors.New("output file must have a .jpg or .jpeg extension")
+	}
+
+	jpegData, err := metadata.RenderRAWImage(srcFsh, srcRpath)
+	if err != nil {
+		return err
+	}
+
+	return destFsh.FileSystemAbstraction.WriteFile(destRpath, jpegData, 0775)
 }

--- a/src/mod/agi/agi.image_test.go
+++ b/src/mod/agi/agi.image_test.go
@@ -1,0 +1,111 @@
+package agi
+
+import (
+	"bytes"
+	"image"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"imuslab.com/arozos/mod/filesystem"
+	"imuslab.com/arozos/mod/filesystem/abstractions/localfs"
+)
+
+// newImageTestFSH creates a FileSystemHandler backed by a temporary local
+// directory for exercising the imagelib helpers.
+func newImageTestFSH(t *testing.T) (*filesystem.FileSystemHandler, string) {
+	t.Helper()
+	dir := t.TempDir()
+	abs := localfs.NewLocalFileSystemAbstraction("TEST", dir+"/", "public", false)
+	fsh := &filesystem.FileSystemHandler{
+		Name:                  "test",
+		UUID:                  "TEST",
+		Path:                  dir + "/",
+		ReadOnly:              false,
+		Hierarchy:             "public",
+		InitiationTime:        time.Now().Unix(),
+		FileSystemAbstraction: abs,
+		Filesystem:            "ext4",
+	}
+	return fsh, dir
+}
+
+// smallJPEGBytes returns a small solid image encoded as JPEG. Written into a
+// RAW-extension file it stands in for the embedded preview that real RAW photos
+// carry, which is what convertRawToJPEG extracts.
+func smallJPEGBytes(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 32, 24))
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatalf("jpeg encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestConvertRawToJPEG(t *testing.T) {
+	jpegBytes := smallJPEGBytes(t)
+
+	t.Run("RAW with embedded JPEG is converted", func(t *testing.T) {
+		fsh, dir := newImageTestFSH(t)
+		src := filepath.Join(dir, "photo.arw")
+		if err := os.WriteFile(src, jpegBytes, 0644); err != nil {
+			t.Fatalf("write src: %v", err)
+		}
+		dst := filepath.Join(dir, "photo.jpg")
+
+		if err := convertRawToJPEG(fsh, src, fsh, dst); err != nil {
+			t.Fatalf("convertRawToJPEG returned error: %v", err)
+		}
+
+		out, err := os.ReadFile(dst)
+		if err != nil {
+			t.Fatalf("output not written: %v", err)
+		}
+		img, format, err := image.Decode(bytes.NewReader(out))
+		if err != nil {
+			t.Fatalf("output is not a decodable image: %v", err)
+		}
+		if format != "jpeg" {
+			t.Errorf("expected jpeg output, got %q", format)
+		}
+		if b := img.Bounds(); b.Dx() != 32 || b.Dy() != 24 {
+			t.Errorf("unexpected output dimensions: %dx%d", b.Dx(), b.Dy())
+		}
+	})
+
+	t.Run("non-RAW source is rejected", func(t *testing.T) {
+		fsh, dir := newImageTestFSH(t)
+		src := filepath.Join(dir, "photo.png")
+		if err := os.WriteFile(src, jpegBytes, 0644); err != nil {
+			t.Fatalf("write src: %v", err)
+		}
+		if err := convertRawToJPEG(fsh, src, fsh, filepath.Join(dir, "out.jpg")); err == nil {
+			t.Errorf("expected error for non-RAW source, got nil")
+		}
+	})
+
+	t.Run("non-JPEG output extension is rejected", func(t *testing.T) {
+		fsh, dir := newImageTestFSH(t)
+		src := filepath.Join(dir, "photo.arw")
+		if err := os.WriteFile(src, jpegBytes, 0644); err != nil {
+			t.Fatalf("write src: %v", err)
+		}
+		if err := convertRawToJPEG(fsh, src, fsh, filepath.Join(dir, "out.png")); err == nil {
+			t.Errorf("expected error for non-JPEG output, got nil")
+		}
+	})
+
+	t.Run("RAW without embedded JPEG fails cleanly", func(t *testing.T) {
+		fsh, dir := newImageTestFSH(t)
+		src := filepath.Join(dir, "garbage.cr2")
+		if err := os.WriteFile(src, []byte("not a real raw file"), 0644); err != nil {
+			t.Fatalf("write src: %v", err)
+		}
+		if err := convertRawToJPEG(fsh, src, fsh, filepath.Join(dir, "out.jpg")); err == nil {
+			t.Errorf("expected error for RAW without embedded JPEG, got nil")
+		}
+	})
+}

--- a/src/web/UnitTest/backend/imagelib.rawToJPEG.js
+++ b/src/web/UnitTest/backend/imagelib.rawToJPEG.js
@@ -1,0 +1,24 @@
+console.log("RAW to JPEG Conversion Test");
+//To test this, put a RAW photo (e.g. test.ARW / test.CR2 / test.DNG) on your desktop
+var srcPath = "user:/Desktop/test.ARW";
+var destPath = "user:/Desktop/test.jpg";
+
+//Check if the file exists
+requirelib("filelib");
+if (!filelib.fileExists(srcPath)){
+	sendResp("File not exists!")
+}else{
+	//Require the image library
+	var loaded = requirelib("imagelib");
+	if (loaded) {
+		//Library loaded. Call to the functions
+		var success = imagelib.rawToJPEG(srcPath, destPath);
+		if (success){
+			sendResp("OK")
+		}else{
+			sendResp("Failed to convert RAW to JPEG");
+		}
+	} else {
+		console.log("Failed to load lib: imagelib");
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds support for converting camera RAW photos to standard JPEG format through the imagelib library. The implementation extracts embedded full-size previews from RAW files, providing a convenient way to process RAW images in AGI scripts.

## Key Changes
- **New `convertRawToJPEG()` function**: Core implementation that validates input/output formats, extracts embedded previews from RAW files, and writes JPEG output to the destination filesystem
- **JavaScript API**: Added `imagelib.rawToJPEG(srcPath, destPath)` function exposed to AGI scripts for RAW to JPEG conversion
- **Supported formats**: ARW, CR2, DNG, NEF, RAF, ORF (validated via `metadata.IsRawImageFile()`)
- **Comprehensive test suite**: Added `agi.image_test.go` with test cases covering:
  - Successful RAW to JPEG conversion
  - Rejection of non-RAW source files
  - Rejection of non-JPEG output extensions
  - Graceful handling of malformed RAW files
- **Documentation**: Updated `agi-doc.md` with usage examples and API documentation

## Implementation Details
- Uses existing `metadata.RenderRAWImage()` to extract embedded previews from RAW files
- Validates source file extension against supported RAW formats
- Enforces `.jpg` or `.jpeg` output extension
- Works with all filesystem abstractions (local, S3, FTP, WebDAV, etc.) via `WriteFile()`
- Returns boolean success/failure to JavaScript caller with error details logged
- Includes test helper functions for creating temporary filesystems and test images

https://claude.ai/code/session_016apSCY3cfCMT2fGRf8XaBw

<img width="1166" height="454" alt="image" src="https://github.com/user-attachments/assets/6144a1a3-d7f6-4dbc-8c98-f786605fde5b" />
