### PR TITLE
Add download button to photo viewer toolbar

### DIFF
--- a/src/web/Photo/index.html
+++ b/src/web/Photo/index.html
@@ -567,7 +567,8 @@
         /* Inside the toolbar, layout is handled by flex, not per-button offsets */
         .viewer-toolbar .close-btn,
         .viewer-toolbar .show-info-btn,
-        .viewer-toolbar .cast-photo-btn {
+        .viewer-toolbar .cast-photo-btn,
+        .viewer-toolbar .download-photo-btn {
             position: static;
             top: auto;
             right: auto;
@@ -644,6 +645,21 @@
 
         .cast-photo-btn svg { width: 18px; height: 18px; }
         .cast-photo-btn.casting { background: #c0392b; }
+
+        .download-photo-btn {
+            background: #222222;
+            color: white;
+            border: none;
+            width: 30px;
+            height: 30px;
+            border-radius: 50%;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .download-photo-btn svg { width: 18px; height: 18px; }
 
         /* Cast modal */
         #cast-photo-modal {
@@ -1027,6 +1043,9 @@
                     <button class="show-info-btn" onclick="showInfoPanel()">ℹ</button>
                     <button class="cast-photo-btn" id="cast-photo-btn" onclick="openPhotoCastDialog()" title="Cast to Arozcast">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#F3F3F3"><path d="M480-480Zm320 320H600q0-20-1.5-40t-4.5-40h206v-480H160v46q-20-3-40-4.5T80-680v-40q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160Zm-720 0v-120q50 0 85 35t35 85H80Zm200 0q0-83-58.5-141.5T80-360v-80q117 0 198.5 81.5T360-160h-80Zm160 0q0-75-28.5-140.5t-77-114q-48.5-48.5-114-77T80-520v-80q91 0 171 34.5T391-471q60 60 94.5 140T520-160h-80Z"/></svg>
+                    </button>
+                    <button class="download-photo-btn" id="download-photo-btn" onclick="downloadCurrentPhoto()" title="Download">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#F3F3F3"><path d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z"/></svg>
                     </button>
                 </div>
                 

--- a/src/web/Photo/index.html
+++ b/src/web/Photo/index.html
@@ -552,6 +552,27 @@
             word-break: break-all;
         }
 
+        /* Top-right toolbar: keeps close / info / cast evenly spaced */
+        .viewer-toolbar {
+            position: absolute;
+            top: 1em;
+            right: 1em;
+            z-index: 500;
+            display: flex;
+            flex-direction: row-reverse;
+            align-items: center;
+            gap: 0.6em;
+        }
+
+        /* Inside the toolbar, layout is handled by flex, not per-button offsets */
+        .viewer-toolbar .close-btn,
+        .viewer-toolbar .show-info-btn,
+        .viewer-toolbar .cast-photo-btn {
+            position: static;
+            top: auto;
+            right: auto;
+        }
+
         .close-btn {
             position: absolute;
             top: 1em;
@@ -1001,11 +1022,13 @@
             <div class="viewer-left">
                 <img id="compressedImage" src="" style="display: none;" />
                 <img id="fullImage" src="img/loading.png" />
-                <button class="close-btn" onclick="closeViewer()">×</button>
-                <button class="show-info-btn" onclick="showInfoPanel()">ℹ</button>
-                <button class="cast-photo-btn" id="cast-photo-btn" onclick="openPhotoCastDialog()" title="Cast to Arozcast">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#F3F3F3"><path d="M480-480Zm320 320H600q0-20-1.5-40t-4.5-40h206v-480H160v46q-20-3-40-4.5T80-680v-40q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160Zm-720 0v-120q50 0 85 35t35 85H80Zm200 0q0-83-58.5-141.5T80-360v-80q117 0 198.5 81.5T360-160h-80Zm160 0q0-75-28.5-140.5t-77-114q-48.5-48.5-114-77T80-520v-80q91 0 171 34.5T391-471q60 60 94.5 140T520-160h-80Z"/></svg>
-                </button>
+                <div class="viewer-toolbar">
+                    <button class="close-btn" onclick="closeViewer()">×</button>
+                    <button class="show-info-btn" onclick="showInfoPanel()">ℹ</button>
+                    <button class="cast-photo-btn" id="cast-photo-btn" onclick="openPhotoCastDialog()" title="Cast to Arozcast">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#F3F3F3"><path d="M480-480Zm320 320H600q0-20-1.5-40t-4.5-40h206v-480H160v46q-20-3-40-4.5T80-680v-40q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160Zm-720 0v-120q50 0 85 35t35 85H80Zm200 0q0-83-58.5-141.5T80-360v-80q117 0 198.5 81.5T360-160h-80Zm160 0q0-75-28.5-140.5t-77-114q-48.5-48.5-114-77T80-520v-80q91 0 171 34.5T391-471q60 60 94.5 140T520-160h-80Z"/></svg>
+                    </button>
+                </div>
                 
                 <!-- Loading Progress -->
                 <div id="loading-progress" class="loading-progress"><i class="loading spinner icon"></i> Loading</div>

--- a/src/web/Photo/photo.js
+++ b/src/web/Photo/photo.js
@@ -14,6 +14,8 @@ let prePhoto = "";
 let nextPhoto = "";
 let currentModel = "";
 let currentPhotoAllIndex = -1; // index of current photo in allImages (full server list)
+let currentViewerFilepath = null; // filepath of the photo currently open in the viewer
+let currentViewerFilename = null; // filename of the photo currently open in the viewer
 let isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
 // Check if image should use compression (only JPG/PNG)
@@ -518,6 +520,22 @@ function closeViewer(){
     }, 300);
 }
 
+// Download the photo currently open in the viewer to the user's device
+function downloadCurrentPhoto(){
+    if (currentViewerFilepath == null || currentViewerFilepath === ""){
+        return;
+    }
+    var url = ao_root + "media?file=" + encodeURIComponent(currentViewerFilepath) + "&download=true";
+    var a = document.createElement("a");
+    a.href = url;
+    if (currentViewerFilename){
+        a.download = currentViewerFilename;
+    }
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+}
+
 let compressedImageLoaded = false;
 let fullsizeImageLoaded = false;
 
@@ -538,6 +556,8 @@ function showImage(object){
     
     var fd = JSON.parse(decodeURIComponent($(object).attr("filedata")));
     _currentCastFilepath = fd.filepath;
+    currentViewerFilepath = fd.filepath;
+    currentViewerFilename = fd.filename;
     if (_photoCastConnected()) _photoCastSendPhoto(fd.filepath);
     $("#info-dimensions").text("Calculating...");
     // Check if we should use compression (only for JPG/PNG > 5MB)


### PR DESCRIPTION
## Summary
This PR adds a download button to the photo viewer interface, allowing users to download the currently displayed photo to their device. The button is integrated into a new unified toolbar layout in the top-right corner alongside the existing close, info, and cast buttons.

## Key Changes
- **New toolbar container**: Created a `.viewer-toolbar` flex container that groups the close, info, cast, and download buttons with consistent spacing and alignment
- **Download button UI**: Added a circular download button styled to match existing toolbar buttons (dark background, white icon, 30px diameter)
- **Download functionality**: Implemented `downloadCurrentPhoto()` function that:
  - Retrieves the filepath and filename of the currently displayed photo
  - Constructs a download URL with proper encoding
  - Triggers a browser download using a temporary anchor element
- **State tracking**: Added `currentViewerFilepath` and `currentViewerFilename` variables to track the photo currently open in the viewer
- **Layout refactoring**: Converted individual absolute-positioned buttons to flex-based layout, improving maintainability and consistency

## Implementation Details
- The download button uses the same styling pattern as the cast button (circular, 30px, centered SVG icon)
- The toolbar uses `flex-direction: row-reverse` to maintain the original button order (close, info, cast, download from left to right)
- Download URL includes `&download=true` parameter to force browser download behavior
- The filename is preserved when downloading to maintain the original photo name on the user's device

https://claude.ai/code/session_01XtS5jbhwpzNBs1HgU7uy9f