### PR TITLE
Add SharedSpace collaboration areas and MeetRoom integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,11 @@ ffmpeg helpers, SQLite, WebSockets, an LLM/`aimodel` chat library, and more).
   registered in `LoadAllFunctionalModules`
   ([`src/mod/agi/moduleManager.go`](src/mod/agi/moduleManager.go)): `filelib`,
   `imagelib`, `http`, `share`, `iot`, `appdata`, `sysinfo`, `ziplib` (incl. 7z),
-  `sqlite`, `aimodel`, and `ffmpeg` (only when ffmpeg is on the host), plus
-  `websocket` and `scheduler` which are injected only in an HTTP request context.
+  `sqlite`, `aimodel`, `sharedspace` (multi-user text/image/file sharing areas,
+  [`src/mod/sharedspace/`](src/mod/sharedspace/)), `meetroom` (MeetRoom room
+  creation/control, gated by MeetRoom module permission), and `ffmpeg` (only
+  when ffmpeg is on the host), plus `websocket` and `scheduler` which are
+  injected only in an HTTP request context.
 - **Execution entry points:**
   - **`init.agi`** — a web app's startup/registration script, scanned at boot
     from `./web/*/init.agi` (`InitiateAllWebAppModules`) and run with **system

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,14 @@ ffmpeg helpers, SQLite, WebSockets, an LLM/`aimodel` chat library, and more).
   registered in `LoadAllFunctionalModules`
   ([`src/mod/agi/moduleManager.go`](src/mod/agi/moduleManager.go)): `filelib`,
   `imagelib`, `http`, `share`, `iot`, `appdata`, `sysinfo`, `ziplib` (incl. 7z),
-  `sqlite`, `aimodel`, `sharedspace` (multi-user text/image/file sharing areas,
-  [`src/mod/sharedspace/`](src/mod/sharedspace/)), `meetroom` (MeetRoom room
-  creation/control, gated by MeetRoom module permission), and `ffmpeg` (only
-  when ffmpeg is on the host), plus `websocket` and `scheduler` which are
-  injected only in an HTTP request context.
+  `sqlite`, `aimodel`, `sharedspace` (multi-user collaboration spaces with
+  texts/images/files, revision-synced documents, open/public/private ACLs and
+  optional persistence, [`src/mod/sharedspace/`](src/mod/sharedspace/); web
+  clients reach the same spaces via `/system/sharedspace/*` + WebSocket),
+  `meetroom` (MeetRoom room creation/control, gated by MeetRoom module
+  permission), and `ffmpeg` (only when ffmpeg is on the host), plus
+  `websocket` and `scheduler` which are injected only in an HTTP request
+  context.
 - **Execution entry points:**
   - **`init.agi`** — a web app's startup/registration script, scanned at boot
     from `./web/*/init.agi` (`InitiateAllWebAppModules`) and run with **system

--- a/src/agi.go
+++ b/src/agi.go
@@ -15,22 +15,24 @@ var (
 func AGIInit() {
 	//Create new AGI Gateway object
 	gw, err := agi.NewGateway(agi.AgiSysInfo{
-		BuildVersion:         build_version,
-		InternalVersion:      internal_version,
-		LoadedModule:         moduleHandler.GetModuleNameList(),
-		ReservedTables:       []string{"auth", "permisson", "register", "desktop"},
+		BuildVersion:          build_version,
+		InternalVersion:       internal_version,
+		LoadedModule:          moduleHandler.GetModuleNameList(),
+		ReservedTables:        []string{"auth", "permisson", "register", "desktop"},
 		ModuleRegisterParser:  moduleHandler.RegisterModuleFromAGI,
 		ExtIconRegisterParser: moduleHandler.RegisterExtIcon,
-		ModuleListProvider:   moduleHandler.GetModuleListJSONForUser,
-		PackageManager:       packageManager,
-		Logger:               systemWideLogger,
-		UserHandler:          userHandler,
-		StartupRoot:          "./web",
-		ActivateScope:        []string{"./web", "./subservice"},
-		FileSystemRender:     thumbRenderHandler,
-		ShareManager:         shareManager,
-		NightlyManager:       nightlyManager,
-		TempFolderPath:       *tmp_directory,
+		ModuleListProvider:    moduleHandler.GetModuleListJSONForUser,
+		PackageManager:        packageManager,
+		Logger:                systemWideLogger,
+		UserHandler:           userHandler,
+		StartupRoot:           "./web",
+		ActivateScope:         []string{"./web", "./subservice"},
+		FileSystemRender:      thumbRenderHandler,
+		ShareManager:          shareManager,
+		NightlyManager:        nightlyManager,
+		MeetRoomManager:       meetRoomManager,
+		SharedSpaceManager:    sharedSpaceManager,
+		TempFolderPath:        *tmp_directory,
 	})
 	if err != nil {
 		systemWideLogger.PrintAndLog("AGI", "AGI Gateway Initialization Failed", err)

--- a/src/meetroom.go
+++ b/src/meetroom.go
@@ -12,7 +12,7 @@ package main
 	  GET  /system/meetroom/info?roomid=XXXXXXXXX             --> {"exists":..,"protected":..}
 	  GET  /system/meetroom/ws?roomid=&password=              --> WebSocket signaling upgrade
 	  POST /system/meetroom/upload      multipart (file)      --> {"fileid":...}
-	  GET  /system/meetroom/download?roomid=&password=&fileid=
+	  GET  /system/meetroom/download?roomid=&password=&fileid=[&inline=1]
 	  GET  /system/meetroom/end?roomid=                       --> host ends the meeting
 	  GET  /system/meetroom/iceservers                        --> WebRTC ICE config
 
@@ -21,13 +21,20 @@ package main
 	                    {"type":"chat","text":"..."}
 	                    {"type":"file","fileid":"..."}               announce uploaded file
 	                    {"type":"state","audio":b,"video":b,"screen":b}
+	                    {"type":"attendance"}                        request the join/leave log
 	                    {"type":"ping"}                              app-level heartbeat
 	                    {"type":"end"}                               host only
 	  server -> client: {"type":"welcome",...}, {"type":"peer-join",...},
 	                    {"type":"peer-leave",...}, {"type":"signal","from":..},
 	                    {"type":"chat",...}, {"type":"file",...},
-	                    {"type":"state",...}, {"type":"pong"},
-	                    {"type":"room-closed"}
+	                    {"type":"state",...}, {"type":"attendance",...},
+	                    {"type":"pong"}, {"type":"room-closed"}
+
+	Shared space integration: every room owns a mod/sharedspace space (its ID
+	travels with the room). Chat and uploads mirror into the space with
+	origin meetroom.OriginMeetRoom; items posted into the space by AGI
+	scripts flow back through mrSpaceItemBroadcast as chat / file frames
+	with peer ID 0 (a reserved ID no real participant ever gets).
 
 	Liveness: the server sends a WebSocket protocol ping every
 	mrPingInterval and enforces mrReadTimeout as a read deadline (refreshed
@@ -53,6 +60,7 @@ import (
 	"github.com/gorilla/websocket"
 	"imuslab.com/arozos/mod/meetroom"
 	prout "imuslab.com/arozos/mod/prouter"
+	"imuslab.com/arozos/mod/sharedspace"
 	"imuslab.com/arozos/mod/utils"
 )
 
@@ -120,9 +128,62 @@ func mrEndMeeting(roomID string) {
 	meetRoomManager.CloseRoom(roomID)
 }
 
+// mrAttendanceList renders a room's join/leave log for the client. leftat is
+// 0 while the participant is still connected.
+func mrAttendanceList(room *meetroom.Room) []map[string]interface{} {
+	records := room.Attendance()
+	list := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		entry := map[string]interface{}{
+			"username": record.Username,
+			"joinedat": record.JoinedAt.Unix(),
+			"present":  record.Present(),
+			"leftat":   int64(0),
+		}
+		if !record.Present() {
+			entry["leftat"] = record.LeftAt.Unix()
+		}
+		list = append(list, entry)
+	}
+	return list
+}
+
+// mrSpaceItemBroadcast pushes items posted into a room's shared space from
+// outside the room (e.g. by AGI scripts) into the meeting as live chat /
+// file frames. Peer ID 0 marks server-side senders: real participants are
+// numbered from 1.
+func mrSpaceItemBroadcast(room *meetroom.Room, item *sharedspace.Item) {
+	if item.Type == sharedspace.ItemTypeText {
+		room.Broadcast(mrMarshalOrDrop(map[string]interface{}{
+			"type":     "chat",
+			"from":     0,
+			"username": item.Uploader,
+			"text":     item.Text,
+			"time":     item.CreatedAt.Unix(),
+		}), -1)
+		return
+	}
+	room.Broadcast(mrMarshalOrDrop(map[string]interface{}{
+		"type":     "file",
+		"from":     0,
+		"username": item.Uploader,
+		"fileid":   item.ID,
+		"name":     item.Name,
+		"size":     item.Size,
+		"time":     item.CreatedAt.Unix(),
+	}), -1)
+}
+
 // MeetRoomInit wires up the MeetRoom video conferencing endpoints.
 func MeetRoomInit() {
 	meetRoomManager = meetroom.NewManager("")
+
+	//Give every room a shared space (chat + files mirror into it, AGI
+	//scripts post into it) and bridge external posts back into the meeting.
+	if sharedSpaceManager != nil {
+		meetRoomManager.BindSpaceManager(sharedSpaceManager)
+		meetRoomManager.SetSpaceItemHandler(mrSpaceItemBroadcast)
+	}
 
 	//Sweep abandoned rooms so forgotten meetings do not accumulate
 	go func() {
@@ -316,7 +377,16 @@ func MeetRoomInit() {
 			}
 			return c
 		}, attachment.Name)
-		w.Header().Set("Content-Disposition", "attachment; filename=\""+fallback+"\"; filename*=UTF-8''"+url.PathEscape(attachment.Name))
+
+		//inline=1 lets the chat render images directly in the browser. Only
+		//raster images may be served inline: anything else (notably SVG,
+		//which can carry scripts) keeps the attachment disposition.
+		disposition := "attachment"
+		if r.URL.Query().Get("inline") == "1" && sharedspace.IsImageName(attachment.Name) {
+			disposition = "inline"
+		}
+		w.Header().Set("Content-Disposition", disposition+"; filename=\""+fallback+"\"; filename*=UTF-8''"+url.PathEscape(attachment.Name))
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 		if ctype := mime.TypeByExtension(strings.ToLower(filepathExt(attachment.Name))); ctype != "" {
 			w.Header().Set("Content-Type", ctype)
 		} else {
@@ -467,6 +537,9 @@ func MeetRoomInit() {
 					"text":     text,
 					"time":     time.Now().Unix(),
 				}), -1)
+				//Mirror into the room's shared space so AGI scripts can
+				//read the conversation
+				meetRoomManager.LogChat(room.ID, participant.Username, text)
 			case "file":
 				attachment, ok := meetRoomManager.GetAttachment(room.ID, frame.FileID)
 				if !ok {
@@ -490,6 +563,14 @@ func MeetRoomInit() {
 					"video":  frame.Video,
 					"screen": frame.Screen,
 				}), participant.PeerID)
+			case "attendance":
+				//Send the requester the room's join/leave log (the
+				//participants side panel polls this on open and on
+				//peer-join / peer-leave)
+				room.SendTo(participant.PeerID, mrMarshalOrDrop(map[string]interface{}{
+					"type":    "attendance",
+					"records": mrAttendanceList(room),
+				}))
 			case "ping":
 				//App-level heartbeat: lets the client detect a half-dead
 				//connection and trigger its auto-reconnect logic.

--- a/src/mod/agi/README.md
+++ b/src/mod/agi/README.md
@@ -15,7 +15,7 @@ This document is updated to match the current AGI implementation in `mod/agi/agi
 
 ## AGI Version
 
-- Runtime version: `3.0` (`AgiVersion` in `agi.go`)
+- Runtime version: `3.3` (`AgiVersion` in `agi.go`)
 
 ## Quick Start
 
@@ -1508,6 +1508,160 @@ The cron script must reside inside the webapp's own web folder, **not** in user 
 ```
 
 The scheduler calls `cron.agi` with the permissions of the user who approved it, so all file-system and database operations are scoped to that user.
+
+---
+
+## sharedspace API
+
+Load:
+
+```javascript
+requirelib("sharedspace");
+```
+
+A **shared space** is an in-memory area where multiple different users can
+share texts, images and files together. The random space ID acts as the
+access capability: any user whose script knows the ID can read and post
+items. Blob items (images / files) are stored in temporary server storage
+and, like the spaces themselves, do not survive a server restart. MeetRoom
+binds one space to every meeting room (see the meetroom API), so this
+library is also how scripts read a live meeting's chat and post messages or
+files into it.
+
+### `sharedspace.createSpace(name)` → object
+
+Create a new space owned by the calling user. Returns
+`{ spaceid, name, owner, items, createdat }`.
+
+```javascript
+requirelib("sharedspace");
+var space = sharedspace.createSpace("Design sync");
+sendJSONResp(space);
+```
+
+### `sharedspace.listMySpaces()` → array
+
+List the spaces owned by the calling user (same fields as `createSpace`).
+
+### `sharedspace.getSpaceInfo(spaceid)` → object
+
+Describe a space by ID. Returns `{ exists: false }` for unknown IDs.
+
+### `sharedspace.addText(spaceid, text)` → string | null
+
+Post a text snippet (clipped to 4000 characters) into the space. Returns the
+new item ID, or `null` on failure.
+
+### `sharedspace.addFile(spaceid, vpath)` → string | null
+
+Copy a file from the calling user's storage into the space. Files with a
+raster-image extension (png / jpg / jpeg / gif / webp / bmp) are stored as
+`image` items, everything else as `file`. Returns the new item ID.
+
+```javascript
+requirelib("sharedspace");
+var itemid = sharedspace.addFile(spaceid, "user:/Photo/cat.png");
+```
+
+### `sharedspace.listItems(spaceid)` → array | null
+
+Chronological list of items:
+`{ itemid, type, name, text, size, uploader, origin, time }`. `type` is
+`"text"`, `"image"` or `"file"`; `text` is only filled for text items.
+
+### `sharedspace.getText(spaceid, itemid)` → string | null
+
+Read the content of a text item.
+
+### `sharedspace.saveFileTo(spaceid, itemid, destVpath)` → bool
+
+Copy an image / file item into the calling user's storage.
+
+### `sharedspace.removeItem(spaceid, itemid)` → bool
+
+Remove an item. Only the item's uploader or the space owner may remove it.
+
+### `sharedspace.deleteSpace(spaceid)` → bool
+
+Delete a space and all its items. Space owner only.
+
+---
+
+## meetroom API
+
+Load:
+
+```javascript
+requirelib("meetroom");
+```
+
+Control interface for the MeetRoom video conferencing WebApp. The library is
+only injected for users who have access permission to the **MeetRoom**
+module (the same gate as the `/system/meetroom/*` endpoints). Every meeting
+room owns a shared space where the room's chat and file attachments are
+mirrored; posting into that space with the sharedspace API delivers the item
+into the live meeting chat.
+
+### `meetroom.createRoom(title, password)` → object
+
+Create a meeting room hosted by the calling user. Both arguments are
+optional (`""` for an untitled / open room). Returns
+`{ roomid, displayid, title, host, protected, participants, createdat, spaceid }`
+where `spaceid` is the room's shared space.
+
+```javascript
+requirelib("meetroom");
+var room = meetroom.createRoom("Weekly standup", "");
+sendJSONResp({ invite: room.displayid, space: room.spaceid });
+```
+
+### `meetroom.getRoomInfo(roomid)` → object | null
+
+Describe a room. Returns `{ exists: false }` for unknown IDs. `spaceid` is
+included only when the calling user is the room's host.
+
+### `meetroom.getRoomSpace(roomid, password)` → string | null
+
+Return the room's shared space ID after passing the same password check the
+join endpoint applies. Use this to chat with a meeting you were invited to:
+
+```javascript
+requirelib("meetroom");
+requirelib("sharedspace");
+var spaceid = meetroom.getRoomSpace("123456789", "roomPassword");
+if (spaceid !== null) {
+    sharedspace.addText(spaceid, "Reminder: meeting notes are due today");
+}
+```
+
+### `meetroom.listMyRooms()` → array
+
+List the live rooms hosted by the calling user (same fields as `createRoom`).
+
+### `meetroom.endRoom(roomid)` → bool
+
+End the meeting for everyone. Host only.
+
+### `meetroom.getAttendance(roomid)` → array | null
+
+Export the room's attendance log:
+`{ username, joinedat, leftat, present }` per join (`leftat` is `0` while the
+participant is still connected). Only the host or a currently connected
+participant may read it.
+
+```javascript
+requirelib("meetroom");
+var log = meetroom.getAttendance("123456789");
+if (log !== null) {
+    var report = "";
+    for (var i = 0; i < log.length; i++) {
+        report += log[i].username + "," + log[i].joinedat + "," + log[i].leftat + "\n";
+    }
+    if (requirelib("filelib")) {
+        filelib.writeFile("user:/Desktop/attendance.csv", report);
+    }
+}
+```
 
 ---
 

--- a/src/mod/agi/README.md
+++ b/src/mod/agi/README.md
@@ -15,7 +15,7 @@ This document is updated to match the current AGI implementation in `mod/agi/agi
 
 ## AGI Version
 
-- Runtime version: `3.3` (`AgiVersion` in `agi.go`)
+- Runtime version: `3.4` (`AgiVersion` in `agi.go`)
 
 ## Quick Start
 
@@ -273,6 +273,8 @@ Registered library IDs:
 - `sqlite` (SQLite database access — not available on linux/mipsle or windows/arm/386)
 - `llm` (OpenAI / Anthropic LLM chat: text & file based, with pricing & quota)
 - `cnn` (CXNNAIO vision inference: classification, detection, segmentation, pose, oriented detection, face analysis)
+- `sharedspace` (multi-user collaboration spaces: texts / images / files / documents, ACLs, persistence)
+- `meetroom` (MeetRoom control: create / end meetings, attendance - requires MeetRoom module access)
 - `ffmpeg` (only when ffmpeg exists on host)
 
 Special case:
@@ -1519,14 +1521,27 @@ Load:
 requirelib("sharedspace");
 ```
 
-A **shared space** is an in-memory area where multiple different users can
-share texts, images and files together. The random space ID acts as the
-access capability: any user whose script knows the ID can read and post
-items. Blob items (images / files) are stored in temporary server storage
-and, like the spaces themselves, do not survive a server restart. MeetRoom
-binds one space to every meeting room (see the meetroom API), so this
-library is also how scripts read a live meeting's chat and post messages or
-files into it.
+A **shared space** is an area where multiple different users can share
+texts, images, files and collaboratively edited documents together - the
+collaboration backbone behind chat-style apps, document collaboration and
+MeetRoom meetings. Every space carries:
+
+- an **access mode**: `"open"` (default - the random space ID acts as the
+  capability, anyone who knows it can read and post), `"public"`
+  (discoverable via `listPublicSpaces`, any logged-in user can self-join)
+  or `"private"` (members only, invited by the owner or a space admin);
+- a **member list** with roles `owner` / `admin` / `member`;
+- a **metadata** key-value store (managers only, capped);
+- a **persistent** flag: persistent spaces (and their items, files and
+  documents) survive server restarts; ephemeral spaces (the default, and
+  what MeetRoom uses) are gone after a restart.
+
+Web clients get the same feature set over `/system/sharedspace/*` and a
+realtime WebSocket channel (`/system/sharedspace/ws`), so items and
+document patches posted from AGI appear live in connected clients.
+MeetRoom binds one space to every meeting room (see the meetroom API), so
+this library is also how scripts read a live meeting's chat and post
+messages or files into it.
 
 ### `sharedspace.createSpace(name)` → object
 
@@ -1579,11 +1594,100 @@ Copy an image / file item into the calling user's storage.
 
 ### `sharedspace.removeItem(spaceid, itemid)` → bool
 
-Remove an item. Only the item's uploader or the space owner may remove it.
+Remove an item. Only the item's uploader, a space admin or the space owner
+may remove it.
 
 ### `sharedspace.deleteSpace(spaceid)` → bool
 
-Delete a space and all its items. Space owner only.
+Delete a space and all its items. Space owner or a space admin only.
+
+### `sharedspace.createSpaceAdvanced(name, options)` → object | null
+
+Create a space with options: `{ access, persistent, metadata }`. Returns the
+space descriptor (`{ spaceid, name, owner, access, persistent, items, docs,
+members, metadata, createdat }` - the same shape every listing below uses),
+or `null` when e.g. persistence is disabled by the administrator.
+
+```javascript
+requirelib("sharedspace");
+var space = sharedspace.createSpaceAdvanced("Team chat", {
+    access: "private",
+    persistent: true,
+    metadata: { purpose: "chat" }
+});
+```
+
+### `sharedspace.listPublicSpaces()` → array
+
+The public space directory (descriptors of every `"public"` space).
+
+### `sharedspace.listJoinedSpaces()` → array
+
+Descriptors of every space the calling user belongs to (owner, admin or
+member). `listMySpaces()` remains the owned-only subset.
+
+### `sharedspace.joinSpace(spaceid)` / `sharedspace.leaveSpace(spaceid)` → bool
+
+Self-join a public (or open) space as a member / leave a space. Private
+spaces are invite-only, so `joinSpace` fails on them.
+
+### `sharedspace.setAccess(spaceid, access)` → bool
+
+Change the access mode (`"open"`, `"public"` or `"private"`). Managers only.
+
+### `sharedspace.setMeta(spaceid, key, value)` / `sharedspace.getMeta(spaceid)` → bool / object
+
+Set (empty value deletes) or read the space metadata. Writing requires
+manager rights; reading requires read access.
+
+### `sharedspace.addMember(spaceid, username, role)` → bool
+
+Invite a user with role `"admin"` or `"member"` (default). Managers only.
+
+### `sharedspace.removeMember(spaceid, username)` → bool
+
+Remove a member (managers) or leave (self). The owner cannot be removed.
+
+### `sharedspace.listMembers(spaceid)` → object | null
+
+Member map `{ username: role, ... }`. Members and managers only.
+
+### `sharedspace.createDoc(spaceid, name)` → object | null
+
+Create a collaborative document. Returns the document snapshot
+`{ docid, name, creator, revision, content, createdat, updatedat, updatedby }`.
+
+### `sharedspace.listDocs(spaceid)` → array | null
+
+Document snapshots without their `content`.
+
+### `sharedspace.getDoc(spaceid, docid)` → object | null
+
+One document with its full content - also the recovery path after an update
+conflict.
+
+### `sharedspace.updateDoc(spaceid, docid, baserev, content)` → object | null
+
+Compare-and-swap update: the new `content` replaces the document body only
+when `baserev` matches the document's current revision. Returns
+`{ ok: true, revision }` on success or
+`{ ok: false, conflict: true, revision }` when someone else updated the
+document first - re-fetch with `getDoc`, merge your change and retry.
+Debounce saves (~500ms): every accepted revision is one database write, and
+live WebSocket clients receive each revision as a patch frame.
+
+```javascript
+requirelib("sharedspace");
+var doc = sharedspace.getDoc(spaceid, docid);
+var result = sharedspace.updateDoc(spaceid, docid, doc.revision, doc.content + "\nAppended by AGI");
+if (result !== null && result.conflict) {
+    // someone got there first: re-fetch, rebase, retry
+}
+```
+
+### `sharedspace.deleteDoc(spaceid, docid)` → bool
+
+Delete a document. Creator or space managers only.
 
 ---
 

--- a/src/mod/agi/agi.go
+++ b/src/mod/agi/agi.go
@@ -39,7 +39,7 @@ import (
 */
 
 var (
-	AgiVersion string = "3.3" //Defination of the agi runtime version. Update this when new function is added
+	AgiVersion string = "3.4" //Defination of the agi runtime version. Update this when new function is added
 
 	//AGI Internal Error Standard
 	errExitcall = errors.New("errExit")

--- a/src/mod/agi/agi.go
+++ b/src/mod/agi/agi.go
@@ -22,7 +22,9 @@ import (
 	metadata "imuslab.com/arozos/mod/filesystem/metadata"
 	"imuslab.com/arozos/mod/info/logger"
 	"imuslab.com/arozos/mod/iot"
+	"imuslab.com/arozos/mod/meetroom"
 	"imuslab.com/arozos/mod/share"
+	"imuslab.com/arozos/mod/sharedspace"
 	"imuslab.com/arozos/mod/time/nightly"
 	user "imuslab.com/arozos/mod/user"
 	"imuslab.com/arozos/mod/utils"
@@ -37,7 +39,7 @@ import (
 */
 
 var (
-	AgiVersion string = "3.2" //Defination of the agi runtime version. Update this when new function is added
+	AgiVersion string = "3.3" //Defination of the agi runtime version. Update this when new function is added
 
 	//AGI Internal Error Standard
 	errExitcall = errors.New("errExit")
@@ -59,17 +61,19 @@ type AgiSysInfo struct {
 	LoadedModule    []string
 
 	//System Handlers
-	Logger               *logger.Logger
-	UserHandler          *user.UserHandler
-	ReservedTables       []string
-	PackageManager       *apt.AptPackageManager
+	Logger                *logger.Logger
+	UserHandler           *user.UserHandler
+	ReservedTables        []string
+	PackageManager        *apt.AptPackageManager
 	ModuleRegisterParser  func(string) error
 	ModuleListProvider    func(username string) string //Returns JSON of accessible modules for a user
 	ExtIconRegisterParser func(ext, iconPath string)   //Called when registerExtensionIcon() fires in an init.agi
-	FileSystemRender     *metadata.RenderHandler
-	IotManager           *iot.Manager
-	ShareManager         *share.Manager
-	NightlyManager       *nightly.TaskManager
+	FileSystemRender      *metadata.RenderHandler
+	IotManager            *iot.Manager
+	ShareManager          *share.Manager
+	NightlyManager        *nightly.TaskManager
+	MeetRoomManager       *meetroom.Manager    //MeetRoom rooms for the meetroom lib (nil disables the lib)
+	SharedSpaceManager    *sharedspace.Manager //Shared collaboration spaces for the sharedspace lib (nil disables the lib)
 
 	//Scanning Roots
 	StartupRoot    string

--- a/src/mod/agi/agi.meetroom.go
+++ b/src/mod/agi/agi.meetroom.go
@@ -1,0 +1,206 @@
+package agi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/robertkrimen/otto"
+	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/info/logger"
+	"imuslab.com/arozos/mod/meetroom"
+)
+
+/*
+	AGI MeetRoom Library
+
+	Exposes the MeetRoom video conferencing room manager to AGI scripts so
+	scripts can create meeting rooms, inspect and end rooms they host, and
+	export the attendance log. Loaded with requirelib("meetroom") and gated
+	by the caller's access permission to the MeetRoom module, mirroring the
+	/system/meetroom/* HTTP endpoints.
+
+	Every room owns a shared space (see agi.sharedspace.go): the space ID
+	returned by createRoom / getRoomSpace is where the meeting's chat and
+	shared files live, so scripts can read the conversation and post texts,
+	images and files into a live meeting through the sharedspace library.
+*/
+
+// meetRoomModuleName is the module permission gate shared with the
+// /system/meetroom/* HTTP endpoints (see prouter setup in src/meetroom.go).
+const meetRoomModuleName = "MeetRoom"
+
+func (g *Gateway) MeetRoomLibRegister() {
+	err := g.RegisterLib("meetroom", g.injectMeetRoomFunctions)
+	if err != nil {
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
+	}
+}
+
+// agiDescribeRoom renders the room fields shared with AGI scripts.
+// includeSpace controls whether the room's shared space ID is revealed;
+// the space ID is a capability, so it is only shared with the host or a
+// caller who passed the room password check.
+func agiDescribeRoom(room *meetroom.Room, includeSpace bool) map[string]interface{} {
+	desc := map[string]interface{}{
+		"roomid":       room.ID,
+		"displayid":    meetroom.FormatRoomID(room.ID),
+		"title":        room.Title,
+		"host":         room.Host,
+		"protected":    room.HasPassword(),
+		"participants": room.ParticipantCount(),
+		"createdat":    room.CreatedAt.Unix(),
+	}
+	if includeSpace {
+		desc["spaceid"] = room.SpaceID
+	}
+	return desc
+}
+
+// agiAttendanceList renders a room's attendance log for AGI scripts.
+func agiAttendanceList(records []meetroom.AttendanceRecord) []map[string]interface{} {
+	list := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		entry := map[string]interface{}{
+			"username": record.Username,
+			"joinedat": record.JoinedAt.Unix(),
+			"present":  record.Present(),
+			"leftat":   int64(0),
+		}
+		if !record.Present() {
+			entry["leftat"] = record.LeftAt.Unix()
+		}
+		list = append(list, entry)
+	}
+	return list
+}
+
+func (g *Gateway) injectMeetRoomFunctions(payload *static.AgiLibInjectionPayload) {
+	vm := payload.VM
+	u := payload.User
+	manager := g.Option.MeetRoomManager
+	if manager == nil || u == nil {
+		return
+	}
+
+	//The caller needs the same module permission the HTTP endpoints require
+	if !u.GetModuleAccessPermission(meetRoomModuleName) {
+		return
+	}
+
+	//jsonReply marshals v and hands it to the VM as a JSON string; the JS
+	//wrapper below parses it back into an object.
+	jsonReply := func(v interface{}) otto.Value {
+		js, err := json.Marshal(v)
+		if err != nil {
+			return otto.NullValue()
+		}
+		val, _ := vm.ToValue(string(js))
+		return val
+	}
+
+	//optionalString reads an argument that may be omitted in the script.
+	optionalString := func(call otto.FunctionCall, idx int) string {
+		arg := call.Argument(idx)
+		if !arg.IsDefined() {
+			return ""
+		}
+		s, _ := arg.ToString()
+		return s
+	}
+
+	//Create a meeting room hosted by the calling user
+	vm.Set("_meetroom_createRoom", func(call otto.FunctionCall) otto.Value {
+		title := optionalString(call, 0)
+		password := optionalString(call, 1)
+		room := manager.CreateRoom(u.Username, title, password)
+		return jsonReply(agiDescribeRoom(room, true))
+	})
+
+	//Public probe: does the room exist and is it protected
+	vm.Set("_meetroom_getRoomInfo", func(call otto.FunctionCall) otto.Value {
+		roomID, err := call.Argument(0).ToString()
+		if err != nil {
+			return otto.NullValue()
+		}
+		room, ok := manager.GetRoom(meetroom.NormalizeRoomID(roomID))
+		if !ok {
+			return jsonReply(map[string]interface{}{"exists": false})
+		}
+		desc := agiDescribeRoom(room, room.Host == u.Username)
+		desc["exists"] = true
+		return jsonReply(desc)
+	})
+
+	//Reveal the room's shared space ID to callers who pass the password
+	//check (the same gate the join endpoint applies)
+	vm.Set("_meetroom_getRoomSpace", func(call otto.FunctionCall) otto.Value {
+		roomID, err := call.Argument(0).ToString()
+		if err != nil {
+			return otto.NullValue()
+		}
+		password := optionalString(call, 1)
+		room, err := manager.ValidateJoin(meetroom.NormalizeRoomID(roomID), password)
+		if err != nil {
+			return otto.NullValue()
+		}
+		if room.SpaceID == "" {
+			return otto.NullValue()
+		}
+		val, _ := vm.ToValue(room.SpaceID)
+		return val
+	})
+
+	//List the live rooms hosted by the calling user
+	vm.Set("_meetroom_listMyRooms", func(call otto.FunctionCall) otto.Value {
+		hosted := manager.ListRoomsByHost(u.Username)
+		list := make([]map[string]interface{}, 0, len(hosted))
+		for _, room := range hosted {
+			list = append(list, agiDescribeRoom(room, true))
+		}
+		return jsonReply(list)
+	})
+
+	//End a meeting for everyone; host only
+	vm.Set("_meetroom_endRoom", func(call otto.FunctionCall) otto.Value {
+		roomID, err := call.Argument(0).ToString()
+		if err != nil {
+			return otto.FalseValue()
+		}
+		room, ok := manager.GetRoom(meetroom.NormalizeRoomID(roomID))
+		if !ok || room.Host != u.Username {
+			return otto.FalseValue()
+		}
+		room.Broadcast([]byte(`{"type":"room-closed"}`), -1)
+		manager.CloseRoom(room.ID)
+		return otto.TrueValue()
+	})
+
+	//Export the attendance log; host or a connected participant only
+	vm.Set("_meetroom_getAttendance", func(call otto.FunctionCall) otto.Value {
+		roomID, err := call.Argument(0).ToString()
+		if err != nil {
+			return otto.NullValue()
+		}
+		room, ok := manager.GetRoom(meetroom.NormalizeRoomID(roomID))
+		if !ok {
+			return otto.NullValue()
+		}
+		if room.Host != u.Username && !room.HasParticipantUsername(u.Username) {
+			return otto.NullValue()
+		}
+		return jsonReply(agiAttendanceList(room.Attendance()))
+	})
+
+	//Wrap the native functions into a meetroom class
+	vm.Run(`
+		var meetroom = {};
+		meetroom.createRoom = function(title, password){ return JSON.parse(_meetroom_createRoom(title, password)); };
+		meetroom.getRoomInfo = function(roomid){ var r = _meetroom_getRoomInfo(roomid); return r === null ? null : JSON.parse(r); };
+		meetroom.getRoomSpace = _meetroom_getRoomSpace;
+		meetroom.listMyRooms = function(){ return JSON.parse(_meetroom_listMyRooms()); };
+		meetroom.endRoom = _meetroom_endRoom;
+		meetroom.getAttendance = function(roomid){ var r = _meetroom_getAttendance(roomid); return r === null ? null : JSON.parse(r); };
+	`)
+}

--- a/src/mod/agi/agi.meetroom_test.go
+++ b/src/mod/agi/agi.meetroom_test.go
@@ -1,0 +1,131 @@
+package agi
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"imuslab.com/arozos/mod/meetroom"
+	"imuslab.com/arozos/mod/sharedspace"
+)
+
+// spaceBoundRoomManager builds the meetroom + sharedspace manager pair the
+// way MeetRoomInit wires them in production.
+func spaceBoundRoomManager(t *testing.T) (*meetroom.Manager, *sharedspace.Manager) {
+	t.Helper()
+	rm := meetroom.NewManager(filepath.Join(t.TempDir(), "attachments"))
+	sm := sharedspace.NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	rm.BindSpaceManager(sm)
+	return rm, sm
+}
+
+func TestAgiDescribeRoom(t *testing.T) {
+	rm, _ := spaceBoundRoomManager(t)
+	room := rm.CreateRoom("alice", "Standup", "hunter2")
+
+	tests := []struct {
+		name         string
+		includeSpace bool
+	}{
+		{"with space capability", true},
+		{"without space capability", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc := agiDescribeRoom(room, tt.includeSpace)
+			if desc["roomid"] != room.ID {
+				t.Errorf("roomid = %v, want %v", desc["roomid"], room.ID)
+			}
+			if desc["displayid"] != meetroom.FormatRoomID(room.ID) {
+				t.Errorf("displayid = %v, want formatted ID", desc["displayid"])
+			}
+			if desc["title"] != "Standup" || desc["host"] != "alice" {
+				t.Errorf("title/host = %v/%v", desc["title"], desc["host"])
+			}
+			if desc["protected"] != true {
+				t.Errorf("protected = %v, want true", desc["protected"])
+			}
+			spaceID, revealed := desc["spaceid"]
+			if tt.includeSpace && (!revealed || spaceID != room.SpaceID) {
+				t.Errorf("spaceid not revealed to authorized caller")
+			}
+			if !tt.includeSpace && revealed {
+				t.Errorf("spaceid leaked to unauthorized caller")
+			}
+		})
+	}
+}
+
+func TestAgiAttendanceList(t *testing.T) {
+	rm, _ := spaceBoundRoomManager(t)
+	room := rm.CreateRoom("alice", "", "")
+	host, _ := room.AddParticipant("alice")
+	guest, _ := room.AddParticipant("bob")
+	room.RemoveParticipant(guest.PeerID)
+	_ = host
+
+	list := agiAttendanceList(room.Attendance())
+	if len(list) != 2 {
+		t.Fatalf("attendance list length = %d, want 2", len(list))
+	}
+	if list[0]["username"] != "alice" || list[0]["present"] != true {
+		t.Errorf("host entry = %+v, want present alice", list[0])
+	}
+	if list[0]["leftat"] != int64(0) {
+		t.Errorf("present entry leftat = %v, want 0", list[0]["leftat"])
+	}
+	if list[1]["username"] != "bob" || list[1]["present"] != false {
+		t.Errorf("guest entry = %+v, want departed bob", list[1])
+	}
+	if list[1]["leftat"] == int64(0) {
+		t.Errorf("departed entry has zero leftat")
+	}
+}
+
+func TestAgiDescribeSpaceAndItem(t *testing.T) {
+	sm := sharedspace.NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	space := sm.CreateSpace("alice", "Notes")
+	textItem, err := space.AddText("alice", "hello", "agi")
+	if err != nil {
+		t.Fatalf("AddText() error = %v", err)
+	}
+	blobItem, err := space.SaveBlob(sharedspace.ItemTypeImage, "pic.png", "bob", "agi", strings.NewReader("img"), 1024)
+	if err != nil {
+		t.Fatalf("SaveBlob() error = %v", err)
+	}
+
+	desc := agiDescribeSpace(space)
+	if desc["spaceid"] != space.ID || desc["name"] != "Notes" || desc["owner"] != "alice" {
+		t.Errorf("space description = %+v", desc)
+	}
+	if desc["items"] != 2 {
+		t.Errorf("space item count = %v, want 2", desc["items"])
+	}
+
+	textDesc := agiDescribeItem(textItem)
+	if textDesc["type"] != sharedspace.ItemTypeText || textDesc["text"] != "hello" {
+		t.Errorf("text item description = %+v", textDesc)
+	}
+	blobDesc := agiDescribeItem(blobItem)
+	if blobDesc["type"] != sharedspace.ItemTypeImage || blobDesc["name"] != "pic.png" {
+		t.Errorf("blob item description = %+v", blobDesc)
+	}
+	if blobDesc["size"] != int64(3) || blobDesc["uploader"] != "bob" {
+		t.Errorf("blob size/uploader = %v/%v", blobDesc["size"], blobDesc["uploader"])
+	}
+}
+
+func TestMeetRoomLibRegistration(t *testing.T) {
+	rm, sm := spaceBoundRoomManager(t)
+	wired := minimalGateway()
+	wired.Option.MeetRoomManager = rm
+	wired.Option.SharedSpaceManager = sm
+	wired.MeetRoomLibRegister()
+	wired.SharedSpaceLibRegister()
+	if _, ok := wired.LoadedAGILibrary["meetroom"]; !ok {
+		t.Errorf("meetroom lib not registered")
+	}
+	if _, ok := wired.LoadedAGILibrary["sharedspace"]; !ok {
+		t.Errorf("sharedspace lib not registered")
+	}
+}

--- a/src/mod/agi/agi.sharedspace.go
+++ b/src/mod/agi/agi.sharedspace.go
@@ -1,0 +1,295 @@
+package agi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/robertkrimen/otto"
+	"imuslab.com/arozos/mod/agi/static"
+	"imuslab.com/arozos/mod/info/logger"
+	"imuslab.com/arozos/mod/sharedspace"
+)
+
+/*
+	AGI SharedSpace Library
+
+	Exposes the shared collaboration space manager to AGI scripts. A shared
+	space is an area where multiple different users can share texts, images
+	and files together: the random space ID acts as the access capability,
+	so any user whose script knows the ID can read and post items. Loaded
+	with requirelib("sharedspace").
+
+	MeetRoom binds one space to every meeting room (see agi.meetroom.go),
+	so this library is also how scripts read a live meeting's chat and post
+	messages / files into it.
+*/
+
+// agiOriginTag marks items posted through this library so consumers (e.g.
+// the MeetRoom space item bridge) can tell them apart from their own posts.
+const agiOriginTag = "agi"
+
+func (g *Gateway) SharedSpaceLibRegister() {
+	err := g.RegisterLib("sharedspace", g.injectSharedSpaceFunctions)
+	if err != nil {
+		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
+		os.Exit(1)
+	}
+}
+
+// agiDescribeSpace renders the space fields shared with AGI scripts.
+func agiDescribeSpace(space *sharedspace.Space) map[string]interface{} {
+	return map[string]interface{}{
+		"spaceid":   space.ID,
+		"name":      space.Name,
+		"owner":     space.Owner,
+		"items":     space.ItemCount(),
+		"createdat": space.CreatedAt.Unix(),
+	}
+}
+
+// agiDescribeItem renders a space item for AGI scripts. Text content is
+// included inline for text items; blobs report their display name and size.
+func agiDescribeItem(item *sharedspace.Item) map[string]interface{} {
+	return map[string]interface{}{
+		"itemid":   item.ID,
+		"type":     item.Type,
+		"name":     item.Name,
+		"text":     item.Text,
+		"size":     item.Size,
+		"uploader": item.Uploader,
+		"origin":   item.Origin,
+		"time":     item.CreatedAt.Unix(),
+	}
+}
+
+func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayload) {
+	vm := payload.VM
+	u := payload.User
+	scriptFsh := payload.ScriptFsh
+	manager := g.Option.SharedSpaceManager
+	if manager == nil || u == nil {
+		return
+	}
+
+	jsonReply := func(v interface{}) otto.Value {
+		js, err := json.Marshal(v)
+		if err != nil {
+			return otto.NullValue()
+		}
+		val, _ := vm.ToValue(string(js))
+		return val
+	}
+
+	getSpace := func(call otto.FunctionCall) (*sharedspace.Space, bool) {
+		spaceID, err := call.Argument(0).ToString()
+		if err != nil {
+			return nil, false
+		}
+		return manager.GetSpace(spaceID)
+	}
+
+	//Create a new shared space owned by the calling user
+	vm.Set("_sharedspace_createSpace", func(call otto.FunctionCall) otto.Value {
+		name := ""
+		if call.Argument(0).IsDefined() {
+			name, _ = call.Argument(0).ToString()
+		}
+		space := manager.CreateSpace(u.Username, name)
+		return jsonReply(agiDescribeSpace(space))
+	})
+
+	//Delete a space; owner only
+	vm.Set("_sharedspace_deleteSpace", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok || space.Owner != u.Username {
+			return otto.FalseValue()
+		}
+		manager.DeleteSpace(space.ID)
+		return otto.TrueValue()
+	})
+
+	//List the spaces owned by the calling user
+	vm.Set("_sharedspace_listMySpaces", func(call otto.FunctionCall) otto.Value {
+		owned := manager.ListSpacesByOwner(u.Username)
+		list := make([]map[string]interface{}, 0, len(owned))
+		for _, space := range owned {
+			list = append(list, agiDescribeSpace(space))
+		}
+		return jsonReply(list)
+	})
+
+	//Describe a space by ID
+	vm.Set("_sharedspace_getSpaceInfo", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return jsonReply(map[string]interface{}{"exists": false})
+		}
+		desc := agiDescribeSpace(space)
+		desc["exists"] = true
+		return jsonReply(desc)
+	})
+
+	//Post a text snippet into a space
+	vm.Set("_sharedspace_addText", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		text, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.NullValue()
+		}
+		item, err := space.AddText(u.Username, text, agiOriginTag)
+		if err != nil {
+			return otto.NullValue()
+		}
+		val, _ := vm.ToValue(item.ID)
+		return val
+	})
+
+	//Share a file from the calling user's storage into a space
+	vm.Set("_sharedspace_addFile", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		vpath, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.NullValue()
+		}
+		vpath = static.RelativeVpathRewrite(scriptFsh, vpath, vm, u)
+		if !u.CanRead(vpath) {
+			panic(vm.MakeCustomError("PermissionDenied", "Path access denied: "+vpath))
+		}
+		fsh, rpath, err := static.VirtualPathToRealPath(vpath, u)
+		if err != nil {
+			g.RaiseError(err)
+			return otto.NullValue()
+		}
+		src, err := fsh.FileSystemAbstraction.ReadStream(rpath)
+		if err != nil {
+			g.RaiseError(err)
+			return otto.NullValue()
+		}
+		defer src.Close()
+
+		name := filepath.Base(vpath)
+		itemType := sharedspace.ItemTypeFile
+		if sharedspace.IsImageName(name) {
+			itemType = sharedspace.ItemTypeImage
+		}
+		item, err := space.SaveBlob(itemType, name, u.Username, agiOriginTag, src, g.Option.SharedSpaceManager.MaxUpload())
+		if err != nil {
+			g.RaiseError(err)
+			return otto.NullValue()
+		}
+		val, _ := vm.ToValue(item.ID)
+		return val
+	})
+
+	//List the items in a space
+	vm.Set("_sharedspace_listItems", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		items := space.Items()
+		list := make([]map[string]interface{}, 0, len(items))
+		for _, item := range items {
+			list = append(list, agiDescribeItem(item))
+		}
+		return jsonReply(list)
+	})
+
+	//Read the content of a text item
+	vm.Set("_sharedspace_getText", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		itemID, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.NullValue()
+		}
+		item, ok := space.GetItem(itemID)
+		if !ok || item.Type != sharedspace.ItemTypeText {
+			return otto.NullValue()
+		}
+		val, _ := vm.ToValue(item.Text)
+		return val
+	})
+
+	//Copy an image / file item into the calling user's storage
+	vm.Set("_sharedspace_saveFileTo", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.FalseValue()
+		}
+		itemID, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.FalseValue()
+		}
+		item, ok := space.GetItem(itemID)
+		if !ok || item.DiskPath == "" {
+			return otto.FalseValue()
+		}
+		destVpath, err := call.Argument(2).ToString()
+		if err != nil {
+			return otto.FalseValue()
+		}
+		destVpath = static.RelativeVpathRewrite(scriptFsh, destVpath, vm, u)
+		if !u.CanWrite(destVpath) {
+			panic(vm.MakeCustomError("PermissionDenied", "Path access denied: "+destVpath))
+		}
+		fsh, rpath, err := static.VirtualPathToRealPath(destVpath, u)
+		if err != nil {
+			g.RaiseError(err)
+			return otto.FalseValue()
+		}
+		src, err := os.Open(item.DiskPath)
+		if err != nil {
+			g.RaiseError(err)
+			return otto.FalseValue()
+		}
+		defer src.Close()
+		err = fsh.FileSystemAbstraction.WriteStream(rpath, src, 0775)
+		if err != nil {
+			g.RaiseError(err)
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
+	//Remove an item; item uploader or space owner only
+	vm.Set("_sharedspace_removeItem", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.FalseValue()
+		}
+		itemID, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.FalseValue()
+		}
+		if err := space.RemoveItem(itemID, u.Username); err != nil {
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
+	//Wrap the native functions into a sharedspace class
+	vm.Run(`
+		var sharedspace = {};
+		sharedspace.createSpace = function(name){ return JSON.parse(_sharedspace_createSpace(name)); };
+		sharedspace.deleteSpace = _sharedspace_deleteSpace;
+		sharedspace.listMySpaces = function(){ return JSON.parse(_sharedspace_listMySpaces()); };
+		sharedspace.getSpaceInfo = function(spaceid){ return JSON.parse(_sharedspace_getSpaceInfo(spaceid)); };
+		sharedspace.addText = _sharedspace_addText;
+		sharedspace.addFile = _sharedspace_addFile;
+		sharedspace.listItems = function(spaceid){ var r = _sharedspace_listItems(spaceid); return r === null ? null : JSON.parse(r); };
+		sharedspace.getText = _sharedspace_getText;
+		sharedspace.saveFileTo = _sharedspace_saveFileTo;
+		sharedspace.removeItem = _sharedspace_removeItem;
+	`)
+}

--- a/src/mod/agi/agi.sharedspace.go
+++ b/src/mod/agi/agi.sharedspace.go
@@ -16,10 +16,13 @@ import (
 	AGI SharedSpace Library
 
 	Exposes the shared collaboration space manager to AGI scripts. A shared
-	space is an area where multiple different users can share texts, images
-	and files together: the random space ID acts as the access capability,
-	so any user whose script knows the ID can read and post items. Loaded
-	with requirelib("sharedspace").
+	space is an area where multiple different users can share texts, images,
+	files and collaboratively edited documents together. Spaces carry an
+	access mode - "open" (the random space ID acts as the capability),
+	"public" (discoverable, self-join) or "private" (members only) - plus
+	a member list with owner / admin / member roles, a metadata store and
+	an optional persistent flag (survives restarts). Loaded with
+	requirelib("sharedspace").
 
 	MeetRoom binds one space to every meeting room (see agi.meetroom.go),
 	so this library is also how scripts read a live meeting's chat and post
@@ -41,11 +44,16 @@ func (g *Gateway) SharedSpaceLibRegister() {
 // agiDescribeSpace renders the space fields shared with AGI scripts.
 func agiDescribeSpace(space *sharedspace.Space) map[string]interface{} {
 	return map[string]interface{}{
-		"spaceid":   space.ID,
-		"name":      space.Name,
-		"owner":     space.Owner,
-		"items":     space.ItemCount(),
-		"createdat": space.CreatedAt.Unix(),
+		"spaceid":    space.ID,
+		"name":       space.Name,
+		"owner":      space.Owner,
+		"access":     space.AccessMode(),
+		"persistent": space.Persistent,
+		"items":      space.ItemCount(),
+		"docs":       space.DocCount(),
+		"members":    space.MemberCount(),
+		"metadata":   space.Metadata(),
+		"createdat":  space.CreatedAt.Unix(),
 	}
 }
 
@@ -62,6 +70,23 @@ func agiDescribeItem(item *sharedspace.Item) map[string]interface{} {
 		"origin":   item.Origin,
 		"time":     item.CreatedAt.Unix(),
 	}
+}
+
+// agiDescribeDoc renders a document snapshot for AGI scripts.
+func agiDescribeDoc(doc *sharedspace.DocSnapshot, includeContent bool) map[string]interface{} {
+	desc := map[string]interface{}{
+		"docid":     doc.ID,
+		"name":      doc.Name,
+		"creator":   doc.Creator,
+		"revision":  doc.Revision,
+		"createdat": doc.CreatedAt.Unix(),
+		"updatedat": doc.UpdatedAt.Unix(),
+		"updatedby": doc.UpdatedBy,
+	}
+	if includeContent {
+		desc["content"] = doc.Content
+	}
+	return desc
 }
 
 func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayload) {
@@ -82,6 +107,8 @@ func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayl
 		return val
 	}
 
+	//getSpace resolves the first argument to a live space without any
+	//access check (used where the called method enforces its own ACL).
 	getSpace := func(call otto.FunctionCall) (*sharedspace.Space, bool) {
 		spaceID, err := call.Argument(0).ToString()
 		if err != nil {
@@ -90,22 +117,68 @@ func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayl
 		return manager.GetSpace(spaceID)
 	}
 
-	//Create a new shared space owned by the calling user
-	vm.Set("_sharedspace_createSpace", func(call otto.FunctionCall) otto.Value {
-		name := ""
-		if call.Argument(0).IsDefined() {
-			name, _ = call.Argument(0).ToString()
+	//getReadableSpace additionally requires read access for the calling
+	//user - private spaces stay invisible to outsiders.
+	getReadableSpace := func(call otto.FunctionCall) (*sharedspace.Space, bool) {
+		space, ok := getSpace(call)
+		if !ok || !space.CanRead(u.Username) {
+			return nil, false
 		}
+		return space, true
+	}
+
+	//optionalString reads an argument that may be omitted in the script.
+	optionalString := func(call otto.FunctionCall, idx int) string {
+		arg := call.Argument(idx)
+		if !arg.IsDefined() {
+			return ""
+		}
+		s, _ := arg.ToString()
+		if s == "undefined" || s == "null" {
+			return ""
+		}
+		return s
+	}
+
+	//Create a new open, ephemeral space owned by the calling user
+	vm.Set("_sharedspace_createSpace", func(call otto.FunctionCall) otto.Value {
+		name := optionalString(call, 0)
 		space := manager.CreateSpace(u.Username, name)
 		return jsonReply(agiDescribeSpace(space))
 	})
 
-	//Delete a space; owner only
+	//Create a space with options: {access, persistent, metadata}
+	vm.Set("_sharedspace_createSpaceAdvanced", func(call otto.FunctionCall) otto.Value {
+		name := optionalString(call, 0)
+		optionsJSON := optionalString(call, 1)
+		options := struct {
+			Access     string            `json:"access"`
+			Persistent bool              `json:"persistent"`
+			Metadata   map[string]string `json:"metadata"`
+		}{}
+		if optionsJSON != "" {
+			json.Unmarshal([]byte(optionsJSON), &options)
+		}
+		space, err := manager.CreateSpaceWithOptions(u.Username, name, sharedspace.SpaceOptions{
+			Access:     options.Access,
+			Persistent: options.Persistent,
+			Metadata:   options.Metadata,
+		})
+		if err != nil {
+			g.RaiseError(err)
+			return otto.NullValue()
+		}
+		return jsonReply(agiDescribeSpace(space))
+	})
+
+	//Delete a space; owner or space admin only
 	vm.Set("_sharedspace_deleteSpace", func(call otto.FunctionCall) otto.Value {
 		space, ok := getSpace(call)
-		if !ok || space.Owner != u.Username {
+		if !ok || !space.CanManage(u.Username) {
 			return otto.FalseValue()
 		}
+		//Give live channel subscribers the shutdown notice first
+		space.Channel().Broadcast([]byte(`{"type":"space-closed"}`), -1)
 		manager.DeleteSpace(space.ID)
 		return otto.TrueValue()
 	})
@@ -120,21 +193,158 @@ func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayl
 		return jsonReply(list)
 	})
 
+	//List the spaces the calling user has joined (owner, admin or member)
+	vm.Set("_sharedspace_listJoinedSpaces", func(call otto.FunctionCall) otto.Value {
+		joined := manager.ListSpacesByMember(u.Username)
+		list := make([]map[string]interface{}, 0, len(joined))
+		for _, space := range joined {
+			list = append(list, agiDescribeSpace(space))
+		}
+		return jsonReply(list)
+	})
+
+	//List every public space (the discovery directory)
+	vm.Set("_sharedspace_listPublicSpaces", func(call otto.FunctionCall) otto.Value {
+		public := manager.ListPublicSpaces()
+		list := make([]map[string]interface{}, 0, len(public))
+		for _, space := range public {
+			list = append(list, agiDescribeSpace(space))
+		}
+		return jsonReply(list)
+	})
+
 	//Describe a space by ID
 	vm.Set("_sharedspace_getSpaceInfo", func(call otto.FunctionCall) otto.Value {
-		space, ok := getSpace(call)
+		space, ok := getReadableSpace(call)
 		if !ok {
 			return jsonReply(map[string]interface{}{"exists": false})
 		}
 		desc := agiDescribeSpace(space)
 		desc["exists"] = true
+		role, isMember := space.Role(u.Username)
+		desc["myrole"] = role
+		desc["ismember"] = isMember
 		return jsonReply(desc)
+	})
+
+	//Self-join a public (or open) space
+	vm.Set("_sharedspace_joinSpace", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.FalseValue()
+		}
+		if err := space.JoinPublic(u.Username); err != nil {
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
+	//Leave a space
+	vm.Set("_sharedspace_leaveSpace", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.FalseValue()
+		}
+		if err := space.RemoveMember(u.Username, u.Username); err != nil {
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
+	//Change the access mode; space managers only
+	vm.Set("_sharedspace_setAccess", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.FalseValue()
+		}
+		access, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.FalseValue()
+		}
+		if err := space.SetAccess(u.Username, access); err != nil {
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
+	//Set (or with an empty value delete) a metadata entry; managers only
+	vm.Set("_sharedspace_setMeta", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.FalseValue()
+		}
+		key, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.FalseValue()
+		}
+		value := optionalString(call, 2)
+		if err := space.SetMeta(u.Username, key, value); err != nil {
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
+	//Read the metadata of a space
+	vm.Set("_sharedspace_getMeta", func(call otto.FunctionCall) otto.Value {
+		space, ok := getReadableSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		return jsonReply(space.Metadata())
+	})
+
+	//Invite a user; managers only
+	vm.Set("_sharedspace_addMember", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.FalseValue()
+		}
+		target, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.FalseValue()
+		}
+		role := optionalString(call, 2)
+		if role == "" {
+			role = sharedspace.RoleMember
+		}
+		if err := space.AddMember(u.Username, target, role); err != nil {
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
+	//Remove a member; managers (or the member themselves)
+	vm.Set("_sharedspace_removeMember", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.FalseValue()
+		}
+		target, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.FalseValue()
+		}
+		if err := space.RemoveMember(u.Username, target); err != nil {
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
+	//List the members of a space; members and managers only
+	vm.Set("_sharedspace_listMembers", func(call otto.FunctionCall) otto.Value {
+		space, ok := getReadableSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		if _, isMember := space.Role(u.Username); !isMember && !space.CanManage(u.Username) {
+			return otto.NullValue()
+		}
+		return jsonReply(space.Members())
 	})
 
 	//Post a text snippet into a space
 	vm.Set("_sharedspace_addText", func(call otto.FunctionCall) otto.Value {
 		space, ok := getSpace(call)
-		if !ok {
+		if !ok || !space.CanPost(u.Username) {
 			return otto.NullValue()
 		}
 		text, err := call.Argument(1).ToString()
@@ -152,7 +362,7 @@ func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayl
 	//Share a file from the calling user's storage into a space
 	vm.Set("_sharedspace_addFile", func(call otto.FunctionCall) otto.Value {
 		space, ok := getSpace(call)
-		if !ok {
+		if !ok || !space.CanPost(u.Username) {
 			return otto.NullValue()
 		}
 		vpath, err := call.Argument(1).ToString()
@@ -191,7 +401,7 @@ func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayl
 
 	//List the items in a space
 	vm.Set("_sharedspace_listItems", func(call otto.FunctionCall) otto.Value {
-		space, ok := getSpace(call)
+		space, ok := getReadableSpace(call)
 		if !ok {
 			return otto.NullValue()
 		}
@@ -205,7 +415,7 @@ func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayl
 
 	//Read the content of a text item
 	vm.Set("_sharedspace_getText", func(call otto.FunctionCall) otto.Value {
-		space, ok := getSpace(call)
+		space, ok := getReadableSpace(call)
 		if !ok {
 			return otto.NullValue()
 		}
@@ -223,7 +433,7 @@ func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayl
 
 	//Copy an image / file item into the calling user's storage
 	vm.Set("_sharedspace_saveFileTo", func(call otto.FunctionCall) otto.Value {
-		space, ok := getSpace(call)
+		space, ok := getReadableSpace(call)
 		if !ok {
 			return otto.FalseValue()
 		}
@@ -262,7 +472,7 @@ func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayl
 		return otto.TrueValue()
 	})
 
-	//Remove an item; item uploader or space owner only
+	//Remove an item; item uploader, space admin or owner only
 	vm.Set("_sharedspace_removeItem", func(call otto.FunctionCall) otto.Value {
 		space, ok := getSpace(call)
 		if !ok {
@@ -278,18 +488,133 @@ func (g *Gateway) injectSharedSpaceFunctions(payload *static.AgiLibInjectionPayl
 		return otto.TrueValue()
 	})
 
+	//Create a collaborative document
+	vm.Set("_sharedspace_createDoc", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		name := optionalString(call, 1)
+		doc, err := space.CreateDoc(u.Username, name)
+		if err != nil {
+			return otto.NullValue()
+		}
+		return jsonReply(agiDescribeDoc(doc, true))
+	})
+
+	//List documents (without contents)
+	vm.Set("_sharedspace_listDocs", func(call otto.FunctionCall) otto.Value {
+		space, ok := getReadableSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		docs := space.ListDocs()
+		list := make([]map[string]interface{}, 0, len(docs))
+		for _, doc := range docs {
+			list = append(list, agiDescribeDoc(doc, false))
+		}
+		return jsonReply(list)
+	})
+
+	//Fetch one document with content
+	vm.Set("_sharedspace_getDoc", func(call otto.FunctionCall) otto.Value {
+		space, ok := getReadableSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		docID, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.NullValue()
+		}
+		doc, ok := space.GetDoc(docID)
+		if !ok {
+			return otto.NullValue()
+		}
+		return jsonReply(agiDescribeDoc(doc, true))
+	})
+
+	//Compare-and-swap document update
+	vm.Set("_sharedspace_updateDoc", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.NullValue()
+		}
+		docID, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.NullValue()
+		}
+		baseRev, err := call.Argument(2).ToInteger()
+		if err != nil {
+			return otto.NullValue()
+		}
+		content, _ := call.Argument(3).ToString()
+
+		doc, err := space.UpdateDoc(u.Username, docID, baseRev, content)
+		if err == sharedspace.ErrRevisionConflict {
+			current, _ := space.GetDoc(docID)
+			revision := int64(0)
+			if current != nil {
+				revision = current.Revision
+			}
+			return jsonReply(map[string]interface{}{
+				"ok":       false,
+				"conflict": true,
+				"revision": revision,
+			})
+		}
+		if err != nil {
+			return otto.NullValue()
+		}
+		return jsonReply(map[string]interface{}{
+			"ok":       true,
+			"revision": doc.Revision,
+		})
+	})
+
+	//Delete a document; creator or space managers
+	vm.Set("_sharedspace_deleteDoc", func(call otto.FunctionCall) otto.Value {
+		space, ok := getSpace(call)
+		if !ok {
+			return otto.FalseValue()
+		}
+		docID, err := call.Argument(1).ToString()
+		if err != nil {
+			return otto.FalseValue()
+		}
+		if err := space.DeleteDoc(u.Username, docID); err != nil {
+			return otto.FalseValue()
+		}
+		return otto.TrueValue()
+	})
+
 	//Wrap the native functions into a sharedspace class
 	vm.Run(`
 		var sharedspace = {};
 		sharedspace.createSpace = function(name){ return JSON.parse(_sharedspace_createSpace(name)); };
+		sharedspace.createSpaceAdvanced = function(name, options){ var r = _sharedspace_createSpaceAdvanced(name, options === undefined ? "" : JSON.stringify(options)); return r === null ? null : JSON.parse(r); };
 		sharedspace.deleteSpace = _sharedspace_deleteSpace;
 		sharedspace.listMySpaces = function(){ return JSON.parse(_sharedspace_listMySpaces()); };
+		sharedspace.listJoinedSpaces = function(){ return JSON.parse(_sharedspace_listJoinedSpaces()); };
+		sharedspace.listPublicSpaces = function(){ return JSON.parse(_sharedspace_listPublicSpaces()); };
 		sharedspace.getSpaceInfo = function(spaceid){ return JSON.parse(_sharedspace_getSpaceInfo(spaceid)); };
+		sharedspace.joinSpace = _sharedspace_joinSpace;
+		sharedspace.leaveSpace = _sharedspace_leaveSpace;
+		sharedspace.setAccess = _sharedspace_setAccess;
+		sharedspace.setMeta = _sharedspace_setMeta;
+		sharedspace.getMeta = function(spaceid){ var r = _sharedspace_getMeta(spaceid); return r === null ? null : JSON.parse(r); };
+		sharedspace.addMember = _sharedspace_addMember;
+		sharedspace.removeMember = _sharedspace_removeMember;
+		sharedspace.listMembers = function(spaceid){ var r = _sharedspace_listMembers(spaceid); return r === null ? null : JSON.parse(r); };
 		sharedspace.addText = _sharedspace_addText;
 		sharedspace.addFile = _sharedspace_addFile;
 		sharedspace.listItems = function(spaceid){ var r = _sharedspace_listItems(spaceid); return r === null ? null : JSON.parse(r); };
 		sharedspace.getText = _sharedspace_getText;
 		sharedspace.saveFileTo = _sharedspace_saveFileTo;
 		sharedspace.removeItem = _sharedspace_removeItem;
+		sharedspace.createDoc = function(spaceid, name){ var r = _sharedspace_createDoc(spaceid, name); return r === null ? null : JSON.parse(r); };
+		sharedspace.listDocs = function(spaceid){ var r = _sharedspace_listDocs(spaceid); return r === null ? null : JSON.parse(r); };
+		sharedspace.getDoc = function(spaceid, docid){ var r = _sharedspace_getDoc(spaceid, docid); return r === null ? null : JSON.parse(r); };
+		sharedspace.updateDoc = function(spaceid, docid, baserev, content){ var r = _sharedspace_updateDoc(spaceid, docid, baserev, content); return r === null ? null : JSON.parse(r); };
+		sharedspace.deleteDoc = _sharedspace_deleteDoc;
 	`)
 }

--- a/src/mod/agi/agi.sharedspace_test.go
+++ b/src/mod/agi/agi.sharedspace_test.go
@@ -1,0 +1,63 @@
+package agi
+
+import (
+	"path/filepath"
+	"testing"
+
+	"imuslab.com/arozos/mod/sharedspace"
+)
+
+func TestAgiDescribeSpaceAdvancedFields(t *testing.T) {
+	sm := sharedspace.NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	space, err := sm.CreateSpaceWithOptions("alice", "Project room", sharedspace.SpaceOptions{
+		Access:   sharedspace.AccessPublic,
+		Metadata: map[string]string{"purpose": "planning"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSpaceWithOptions() error = %v", err)
+	}
+	space.AddMember("alice", "bob", sharedspace.RoleMember)
+	space.CreateDoc("alice", "spec")
+
+	desc := agiDescribeSpace(space)
+	if desc["access"] != sharedspace.AccessPublic {
+		t.Errorf("access = %v, want public", desc["access"])
+	}
+	if desc["persistent"] != false {
+		t.Errorf("persistent = %v, want false", desc["persistent"])
+	}
+	if desc["members"] != 2 {
+		t.Errorf("members = %v, want 2", desc["members"])
+	}
+	if desc["docs"] != 1 {
+		t.Errorf("docs = %v, want 1", desc["docs"])
+	}
+	metadata, ok := desc["metadata"].(map[string]string)
+	if !ok || metadata["purpose"] != "planning" {
+		t.Errorf("metadata = %v", desc["metadata"])
+	}
+}
+
+func TestAgiDescribeDoc(t *testing.T) {
+	sm := sharedspace.NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	space := sm.CreateSpace("alice", "")
+	doc, err := space.CreateDoc("alice", "notes")
+	if err != nil {
+		t.Fatalf("CreateDoc() error = %v", err)
+	}
+	space.UpdateDoc("bob", doc.ID, 1, "content body")
+	snapshot, _ := space.GetDoc(doc.ID)
+
+	withContent := agiDescribeDoc(snapshot, true)
+	if withContent["docid"] != doc.ID || withContent["revision"] != int64(2) {
+		t.Errorf("doc description = %+v", withContent)
+	}
+	if withContent["content"] != "content body" || withContent["updatedby"] != "bob" {
+		t.Errorf("doc content fields = %+v", withContent)
+	}
+
+	withoutContent := agiDescribeDoc(snapshot, false)
+	if _, leaked := withoutContent["content"]; leaked {
+		t.Errorf("content leaked into the no-content description")
+	}
+}

--- a/src/mod/agi/moduleManager.go
+++ b/src/mod/agi/moduleManager.go
@@ -59,6 +59,15 @@ func (g *Gateway) LoadAllFunctionalModules() {
 	g.CNNLibRegister()
 	g.SQLiteLibRegister()
 
+	//Shared collaboration spaces + MeetRoom control, only when the host
+	//system wired the managers in (see src/agi.go)
+	if g.Option.SharedSpaceManager != nil {
+		g.SharedSpaceLibRegister()
+	}
+	if g.Option.MeetRoomManager != nil {
+		g.MeetRoomLibRegister()
+	}
+
 	//Only register ffmpeg lib if host OS have ffmpeg installed
 	ffmpegExists, _ := apt.PackageExists("ffmpeg")
 	if ffmpegExists {

--- a/src/mod/meetroom/meetroom.go
+++ b/src/mod/meetroom/meetroom.go
@@ -55,7 +55,6 @@ var (
 
 const (
 	roomIDLength     = 9         // digits in a meeting room ID, Zoom style
-	sendBufferSize   = 256       // per-participant outgoing frame buffer
 	maxTitleLength   = 64        // room title is clipped to this many runes
 	maxNameLength    = 128       // attachment file names are clipped to this many runes
 	maxAttendance    = 1000      // attendance records kept per room (oldest dropped)
@@ -68,20 +67,24 @@ const (
 	DefaultEmptyIdle = 10 * time.Minute
 )
 
-// Participant is one connected member of a room. The transport layer
-// (WebSocket handler) drains Send and writes each frame to the socket.
+// Participant is one connected member of a room. Since the migration onto
+// the sharedspace channel layer it is a thin wrapper around a channel
+// subscriber: PeerID and Send alias the subscriber's ID and send buffer.
+// The transport layer (WebSocket handler) drains Send and writes each frame
+// to the socket.
 type Participant struct {
 	PeerID   int
 	Username string
 	IsHost   bool
-	Send     chan []byte
+	Send     chan []byte // same channel value as sub.Send
 	joinedAt time.Time
-	once     sync.Once
+	sub      *sharedspace.Subscriber
 }
 
-// CloseSend closes the participant's send channel exactly once.
+// CloseSend closes the participant's send channel exactly once (delegated to
+// the underlying subscriber, which owns the close-once guarantee).
 func (p *Participant) CloseSend() {
-	p.once.Do(func() { close(p.Send) })
+	p.sub.CloseSend()
 }
 
 // Attachment is a file shared into a room, stored on local disk until the
@@ -109,7 +112,12 @@ func (a *AttendanceRecord) Present() bool {
 	return a.LeftAt.IsZero()
 }
 
-// Room is one live meeting room.
+// Room is one live meeting room. The realtime transport (participant
+// registry, broadcast, targeted send) rides the room's sharedspace channel:
+// for space-bound rooms that hub is shared with generic space subscribers,
+// so AGI-facing clients on the space receive meeting frames live. The
+// participants map is the meeting roster proper (host flag, attendance
+// identity) and is always a subset of the channel's subscribers.
 type Room struct {
 	ID           string
 	Title        string
@@ -120,7 +128,7 @@ type Room struct {
 	participants map[int]*Participant
 	attachments  map[string]*Attachment
 	attendance   []*AttendanceRecord
-	nextPeerID   int
+	channel      *sharedspace.Channel // set once in CreateRoom, immutable afterwards
 	lastActivity time.Time
 	closed       bool
 	mu           sync.Mutex
@@ -224,18 +232,19 @@ func (m *Manager) CreateRoom(host string, title string, password string) *Room {
 		participants: make(map[int]*Participant),
 		attachments:  make(map[string]*Attachment),
 		attendance:   []*AttendanceRecord{},
-		nextPeerID:   1,
 		lastActivity: time.Now(),
 	}
 	if password != "" {
 		room.passwordHash = hashRoomPassword(id, password)
 	}
 
-	//Bind a shared space to the room: chat / attachments mirror into it and
-	//externally posted items (AGI) flow back through the item bridge.
+	//Bind a shared space to the room: chat / attachments mirror into it,
+	//externally posted items (AGI) flow back through the item bridge, and
+	//the space's realtime channel carries the meeting signaling.
 	if m.spaces != nil {
 		space := m.spaces.CreateSpace(host, title)
 		room.SpaceID = space.ID
+		room.channel = space.Channel()
 		space.Subscribe(OriginMeetRoom, func(item *sharedspace.Item) {
 			if item.Origin == OriginMeetRoom {
 				return //the room's own echo, already delivered over WebSocket
@@ -247,6 +256,10 @@ func (m *Manager) CreateRoom(host string, title string, password string) *Room {
 				handler(room, item)
 			}
 		})
+	} else {
+		//No space manager bound (e.g. unit tests): the room still needs a
+		//realtime hub of its own
+		room.channel = sharedspace.NewStandaloneChannel()
 	}
 
 	m.rooms[id] = room
@@ -302,22 +315,40 @@ func (r *Room) CheckPassword(password string) bool {
 	return subtle.ConstantTimeCompare(r.passwordHash, candidate) == 1
 }
 
-// AddParticipant registers a new participant and returns it. The transport
+// AddParticipant joins the room's channel as a new subscriber, registers it
+// in the meeting roster and returns the wrapping participant. The transport
 // layer must drain the returned participant's Send channel.
 func (r *Room) AddParticipant(username string) (*Participant, error) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if r.closed {
+		r.mu.Unlock()
 		return nil, ErrRoomClosed
 	}
+	r.mu.Unlock()
+
+	//Rooms bind open spaces, so the channel ACL always admits; a closed
+	//channel means the room was torn down while we were joining.
+	sub, err := r.channel.Join(username)
+	if err != nil {
+		return nil, ErrRoomClosed
+	}
+
 	p := &Participant{
-		PeerID:   r.nextPeerID,
+		PeerID:   sub.ID,
 		Username: username,
 		IsHost:   username == r.Host,
-		Send:     make(chan []byte, sendBufferSize),
-		joinedAt: time.Now(),
+		Send:     sub.Send,
+		joinedAt: sub.JoinedAt(),
+		sub:      sub,
 	}
-	r.nextPeerID++
+
+	r.mu.Lock()
+	if r.closed {
+		//The room closed between the pre-check and the channel join
+		r.mu.Unlock()
+		r.channel.Leave(sub.ID)
+		return nil, ErrRoomClosed
+	}
 	r.participants[p.PeerID] = p
 	r.attendance = append(r.attendance, &AttendanceRecord{
 		Username: username,
@@ -328,13 +359,14 @@ func (r *Room) AddParticipant(username string) (*Participant, error) {
 		r.attendance = r.attendance[len(r.attendance)-maxAttendance:]
 	}
 	r.lastActivity = time.Now()
+	r.mu.Unlock()
 	return p, nil
 }
 
 // RemoveParticipant unregisters a participant and closes its send channel.
 func (r *Room) RemoveParticipant(peerID int) {
 	r.mu.Lock()
-	p, ok := r.participants[peerID]
+	_, ok := r.participants[peerID]
 	if ok {
 		delete(r.participants, peerID)
 	}
@@ -347,7 +379,7 @@ func (r *Room) RemoveParticipant(peerID int) {
 	r.lastActivity = time.Now()
 	r.mu.Unlock()
 	if ok {
-		p.CloseSend()
+		r.channel.Leave(peerID)
 	}
 }
 
@@ -402,37 +434,19 @@ func (r *Room) GetParticipant(peerID int) (*Participant, bool) {
 	return p, ok
 }
 
-// Broadcast queues msg to every participant except excludePeerID (pass a
-// negative value to send to everyone). Full send buffers drop the frame
-// rather than blocking the room.
+// Broadcast queues msg to every channel subscriber except excludePeerID
+// (pass a negative value to send to everyone). For space-bound rooms this
+// includes generic space subscribers, so clients connected through the
+// sharedspace WebSocket receive meeting frames too. Full send buffers drop
+// the frame rather than blocking the room.
 func (r *Room) Broadcast(msg []byte, excludePeerID int) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	for id, p := range r.participants {
-		if id == excludePeerID {
-			continue
-		}
-		select {
-		case p.Send <- append([]byte(nil), msg...):
-		default:
-		}
-	}
+	r.channel.Broadcast(msg, excludePeerID)
 }
 
-// SendTo queues msg to a single participant. It reports whether the peer
-// exists in the room.
+// SendTo queues msg to a single channel subscriber. It reports whether the
+// peer exists on the room's channel.
 func (r *Room) SendTo(peerID int, msg []byte) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	p, ok := r.participants[peerID]
-	if !ok {
-		return false
-	}
-	select {
-	case p.Send <- append([]byte(nil), msg...):
-	default:
-	}
-	return true
+	return r.channel.SendTo(peerID, msg)
 }
 
 // Touch refreshes the room's idle timer.
@@ -606,9 +620,9 @@ func (m *Manager) CloseRoom(id string) []*Participant {
 	room.attachments = make(map[string]*Attachment)
 	room.mu.Unlock()
 
-	for _, p := range members {
-		p.CloseSend()
-	}
+	//Tearing the channel down closes every subscriber's send buffer (the
+	//meeting participants and, for bound rooms, generic space subscribers)
+	room.channel.Close()
 	os.RemoveAll(filepath.Join(m.storageRoot, id))
 
 	//The bound shared space lives and dies with the room

--- a/src/mod/meetroom/meetroom.go
+++ b/src/mod/meetroom/meetroom.go
@@ -7,7 +7,16 @@ package meetroom
 	This package implements the server-side room state for the MeetRoom
 	video conferencing WebApp: meeting rooms joinable by ID + optional
 	password, the participant registry used by the WebSocket signaling
-	relay, and temporary attachment storage for in-meeting file sharing.
+	relay, an attendance log of every join / leave, and temporary
+	attachment storage for in-meeting file sharing.
+
+	When a sharedspace.Manager is bound (BindSpaceManager), every room
+	created afterwards owns a shared space: chat messages and uploaded
+	attachments are mirrored into it (origin OriginMeetRoom) so AGI
+	scripts can read the meeting content, and items posted into the
+	space from outside the room (e.g. by AGI scripts) are handed to the
+	transport layer through SetSpaceItemHandler so they appear in the
+	meeting live. The space is deleted together with the room.
 
 	The package is transport-agnostic: the HTTP / WebSocket handlers live
 	in the main package (src/meetroom.go) and only push byte slices into
@@ -29,6 +38,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"imuslab.com/arozos/mod/sharedspace"
 )
 
 var (
@@ -47,7 +58,13 @@ const (
 	sendBufferSize   = 256       // per-participant outgoing frame buffer
 	maxTitleLength   = 64        // room title is clipped to this many runes
 	maxNameLength    = 128       // attachment file names are clipped to this many runes
+	maxAttendance    = 1000      // attendance records kept per room (oldest dropped)
 	DefaultMaxUpload = 128 << 20 // 128MB per attachment
+
+	//OriginMeetRoom tags shared-space items mirrored from the room itself so
+	//the space item bridge can filter its own echoes
+	OriginMeetRoom = "meetroom"
+
 	DefaultEmptyIdle = 10 * time.Minute
 )
 
@@ -78,15 +95,31 @@ type Attachment struct {
 	DiskPath string
 }
 
+// AttendanceRecord is one join / leave entry in a room's attendance log.
+// LeftAt is the zero time while the participant is still in the meeting.
+type AttendanceRecord struct {
+	Username string
+	PeerID   int
+	JoinedAt time.Time
+	LeftAt   time.Time
+}
+
+// Present reports whether this record's participant is still in the room.
+func (a *AttendanceRecord) Present() bool {
+	return a.LeftAt.IsZero()
+}
+
 // Room is one live meeting room.
 type Room struct {
 	ID           string
 	Title        string
 	Host         string
+	SpaceID      string // bound shared space, empty when no space manager is set
 	CreatedAt    time.Time
 	passwordHash []byte // nil when the room has no password
 	participants map[int]*Participant
 	attachments  map[string]*Attachment
+	attendance   []*AttendanceRecord
 	nextPeerID   int
 	lastActivity time.Time
 	closed       bool
@@ -97,6 +130,8 @@ type Room struct {
 type Manager struct {
 	rooms       map[string]*Room
 	storageRoot string
+	spaces      *sharedspace.Manager                     // optional shared-space binding
+	onSpaceItem func(room *Room, item *sharedspace.Item) // bridge for externally posted space items
 	mu          sync.RWMutex
 }
 
@@ -114,6 +149,36 @@ func NewManager(storageRoot string) *Manager {
 		rooms:       make(map[string]*Room),
 		storageRoot: storageRoot,
 	}
+}
+
+// BindSpaceManager links the manager to a shared-space manager. Every room
+// created afterwards owns a shared space that mirrors its chat and
+// attachments and accepts posts from AGI scripts.
+func (m *Manager) BindSpaceManager(sm *sharedspace.Manager) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.spaces = sm
+}
+
+// SetSpaceItemHandler sets the callback invoked when an item lands in a
+// room's shared space from outside the room itself (anything whose origin is
+// not OriginMeetRoom, e.g. an AGI script). The transport layer uses it to
+// push the item into the meeting as a live chat / file message.
+func (m *Manager) SetSpaceItemHandler(fn func(room *Room, item *sharedspace.Item)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onSpaceItem = fn
+}
+
+// spaceOf returns the shared space bound to the room, if any.
+func (m *Manager) spaceOf(room *Room) (*sharedspace.Space, bool) {
+	m.mu.RLock()
+	sm := m.spaces
+	m.mu.RUnlock()
+	if sm == nil || room.SpaceID == "" {
+		return nil, false
+	}
+	return sm.GetSpace(room.SpaceID)
 }
 
 // hashRoomPassword derives the stored hash for a room password. The room ID
@@ -158,12 +223,32 @@ func (m *Manager) CreateRoom(host string, title string, password string) *Room {
 		CreatedAt:    time.Now(),
 		participants: make(map[int]*Participant),
 		attachments:  make(map[string]*Attachment),
+		attendance:   []*AttendanceRecord{},
 		nextPeerID:   1,
 		lastActivity: time.Now(),
 	}
 	if password != "" {
 		room.passwordHash = hashRoomPassword(id, password)
 	}
+
+	//Bind a shared space to the room: chat / attachments mirror into it and
+	//externally posted items (AGI) flow back through the item bridge.
+	if m.spaces != nil {
+		space := m.spaces.CreateSpace(host, title)
+		room.SpaceID = space.ID
+		space.Subscribe(OriginMeetRoom, func(item *sharedspace.Item) {
+			if item.Origin == OriginMeetRoom {
+				return //the room's own echo, already delivered over WebSocket
+			}
+			m.mu.RLock()
+			handler := m.onSpaceItem
+			m.mu.RUnlock()
+			if handler != nil {
+				handler(room, item)
+			}
+		})
+	}
+
 	m.rooms[id] = room
 	return room
 }
@@ -234,6 +319,14 @@ func (r *Room) AddParticipant(username string) (*Participant, error) {
 	}
 	r.nextPeerID++
 	r.participants[p.PeerID] = p
+	r.attendance = append(r.attendance, &AttendanceRecord{
+		Username: username,
+		PeerID:   p.PeerID,
+		JoinedAt: p.joinedAt,
+	})
+	if len(r.attendance) > maxAttendance {
+		r.attendance = r.attendance[len(r.attendance)-maxAttendance:]
+	}
 	r.lastActivity = time.Now()
 	return p, nil
 }
@@ -245,11 +338,42 @@ func (r *Room) RemoveParticipant(peerID int) {
 	if ok {
 		delete(r.participants, peerID)
 	}
+	for _, record := range r.attendance {
+		if record.PeerID == peerID && record.Present() {
+			record.LeftAt = time.Now()
+			break
+		}
+	}
 	r.lastActivity = time.Now()
 	r.mu.Unlock()
 	if ok {
 		p.CloseSend()
 	}
+}
+
+// Attendance returns a snapshot of the room's join / leave log in
+// chronological join order.
+func (r *Room) Attendance() []AttendanceRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	list := make([]AttendanceRecord, 0, len(r.attendance))
+	for _, record := range r.attendance {
+		list = append(list, *record)
+	}
+	return list
+}
+
+// HasParticipantUsername reports whether a user with the given username is
+// currently connected to the room.
+func (r *Room) HasParticipantUsername(username string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, p := range r.participants {
+		if p.Username == username {
+			return true
+		}
+	}
+	return false
 }
 
 // Participants returns a snapshot of the current participants.
@@ -320,7 +444,8 @@ func (r *Room) Touch() {
 
 // SaveAttachment streams src to disk (up to maxSize bytes) and registers the
 // file in the room under a random ID. name is display-only and never used as
-// a filesystem path.
+// a filesystem path. Rooms with a bound shared space store the file in the
+// space instead, so AGI scripts can access it too.
 func (m *Manager) SaveAttachment(roomID string, name string, uploader string, src io.Reader, maxSize int64) (*Attachment, error) {
 	room, ok := m.GetRoom(roomID)
 	if !ok {
@@ -328,6 +453,32 @@ func (m *Manager) SaveAttachment(roomID string, name string, uploader string, sr
 	}
 	if maxSize <= 0 {
 		maxSize = DefaultMaxUpload
+	}
+
+	//Space-backed room: the shared space owns the blob storage
+	if space, ok := m.spaceOf(room); ok {
+		itemType := sharedspace.ItemTypeFile
+		if sharedspace.IsImageName(name) {
+			itemType = sharedspace.ItemTypeImage
+		}
+		item, err := space.SaveBlob(itemType, name, uploader, OriginMeetRoom, src, maxSize)
+		if err != nil {
+			if err == sharedspace.ErrItemTooLarge {
+				return nil, ErrAttachmentTooLarge
+			}
+			if err == sharedspace.ErrSpaceClosed {
+				return nil, ErrRoomClosed
+			}
+			return nil, err
+		}
+		room.Touch()
+		return &Attachment{
+			ID:       item.ID,
+			Name:     item.Name,
+			Size:     item.Size,
+			Uploader: item.Uploader,
+			DiskPath: item.DiskPath,
+		}, nil
 	}
 
 	idBytes := make([]byte, 16)
@@ -377,16 +528,57 @@ func (m *Manager) SaveAttachment(roomID string, name string, uploader string, sr
 	return attachment, nil
 }
 
-// GetAttachment looks up a shared file in a room by its ID.
+// GetAttachment looks up a shared file in a room by its ID, consulting the
+// bound shared space when the room has one (covering both room uploads and
+// files posted into the space by AGI scripts).
 func (m *Manager) GetAttachment(roomID string, fileID string) (*Attachment, bool) {
 	room, ok := m.GetRoom(roomID)
 	if !ok {
 		return nil, false
 	}
 	room.mu.Lock()
-	defer room.mu.Unlock()
 	attachment, ok := room.attachments[fileID]
-	return attachment, ok
+	room.mu.Unlock()
+	if ok {
+		return attachment, true
+	}
+	if space, hasSpace := m.spaceOf(room); hasSpace {
+		if item, found := space.GetItem(fileID); found && item.DiskPath != "" {
+			return &Attachment{
+				ID:       item.ID,
+				Name:     item.Name,
+				Size:     item.Size,
+				Uploader: item.Uploader,
+				DiskPath: item.DiskPath,
+			}, true
+		}
+	}
+	return nil, false
+}
+
+// LogChat mirrors a chat message into the room's bound shared space so AGI
+// scripts can read the meeting conversation. No-op for rooms without a space.
+func (m *Manager) LogChat(roomID string, username string, text string) {
+	room, ok := m.GetRoom(roomID)
+	if !ok {
+		return
+	}
+	if space, hasSpace := m.spaceOf(room); hasSpace {
+		space.AddText(username, text, OriginMeetRoom)
+	}
+}
+
+// ListRoomsByHost returns a snapshot of the live rooms hosted by host.
+func (m *Manager) ListRoomsByHost(host string) []*Room {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	hosted := []*Room{}
+	for _, room := range m.rooms {
+		if room.Host == host {
+			hosted = append(hosted, room)
+		}
+	}
+	return hosted
 }
 
 // CloseRoom removes the room, closes every participant's send channel and
@@ -418,6 +610,14 @@ func (m *Manager) CloseRoom(id string) []*Participant {
 		p.CloseSend()
 	}
 	os.RemoveAll(filepath.Join(m.storageRoot, id))
+
+	//The bound shared space lives and dies with the room
+	m.mu.RLock()
+	sm := m.spaces
+	m.mu.RUnlock()
+	if sm != nil && room.SpaceID != "" {
+		sm.DeleteSpace(room.SpaceID)
+	}
 	return members
 }
 

--- a/src/mod/meetroom/meetroom_test.go
+++ b/src/mod/meetroom/meetroom_test.go
@@ -8,11 +8,23 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"imuslab.com/arozos/mod/sharedspace"
 )
 
 func newTestManager(t *testing.T) *Manager {
 	t.Helper()
 	return NewManager(filepath.Join(t.TempDir(), "attachments"))
+}
+
+// newSpaceBoundManager returns a room manager wired to a shared-space manager,
+// the way MeetRoomInit binds them in production.
+func newSpaceBoundManager(t *testing.T) (*Manager, *sharedspace.Manager) {
+	t.Helper()
+	m := NewManager(filepath.Join(t.TempDir(), "attachments"))
+	sm := sharedspace.NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	m.BindSpaceManager(sm)
+	return m, sm
 }
 
 func TestCreateRoom(t *testing.T) {
@@ -315,6 +327,167 @@ func TestRoomIDFormatting(t *testing.T) {
 	}
 	if got := FormatRoomID("1234"); got != "1234" {
 		t.Errorf("FormatRoomID(short) = %q, want passthrough", got)
+	}
+}
+
+func TestAttendanceLog(t *testing.T) {
+	m := newTestManager(t)
+	room := m.CreateRoom("alice", "", "")
+
+	host, _ := room.AddParticipant("alice")
+	guest, _ := room.AddParticipant("bob")
+	room.RemoveParticipant(guest.PeerID)
+
+	records := room.Attendance()
+	if len(records) != 2 {
+		t.Fatalf("Attendance() returned %d records, want 2", len(records))
+	}
+	if records[0].Username != "alice" || records[0].PeerID != host.PeerID {
+		t.Errorf("first record = %+v, want alice/%d", records[0], host.PeerID)
+	}
+	if !records[0].Present() {
+		t.Errorf("host record marked as left")
+	}
+	if records[1].Username != "bob" {
+		t.Errorf("second record username = %q, want bob", records[1].Username)
+	}
+	if records[1].Present() {
+		t.Errorf("removed guest still marked as present")
+	}
+	if records[1].LeftAt.Before(records[1].JoinedAt) {
+		t.Errorf("LeftAt %v before JoinedAt %v", records[1].LeftAt, records[1].JoinedAt)
+	}
+
+	//Rejoin appends a fresh record instead of reviving the old one
+	room.AddParticipant("bob")
+	records = room.Attendance()
+	if len(records) != 3 {
+		t.Fatalf("Attendance() after rejoin returned %d records, want 3", len(records))
+	}
+	if records[1].Present() || !records[2].Present() {
+		t.Errorf("rejoin did not append a fresh present record")
+	}
+
+	if !room.HasParticipantUsername("bob") {
+		t.Errorf("HasParticipantUsername(bob) = false, want true")
+	}
+	if room.HasParticipantUsername("mallory") {
+		t.Errorf("HasParticipantUsername(mallory) = true, want false")
+	}
+}
+
+func TestListRoomsByHost(t *testing.T) {
+	m := newTestManager(t)
+	m.CreateRoom("alice", "One", "")
+	m.CreateRoom("alice", "Two", "")
+	m.CreateRoom("bob", "Other", "")
+
+	if got := len(m.ListRoomsByHost("alice")); got != 2 {
+		t.Errorf("alice hosts %d rooms, want 2", got)
+	}
+	if got := len(m.ListRoomsByHost("carol")); got != 0 {
+		t.Errorf("carol hosts %d rooms, want 0", got)
+	}
+}
+
+func TestSpaceBoundRoomLifecycle(t *testing.T) {
+	m, sm := newSpaceBoundManager(t)
+	room := m.CreateRoom("alice", "Standup", "")
+
+	if room.SpaceID == "" {
+		t.Fatalf("space-bound room has no SpaceID")
+	}
+	space, ok := sm.GetSpace(room.SpaceID)
+	if !ok {
+		t.Fatalf("bound space %q not registered", room.SpaceID)
+	}
+	if space.Owner != "alice" || space.Name != "Standup" {
+		t.Errorf("space owner/name = %q/%q, want alice/Standup", space.Owner, space.Name)
+	}
+
+	//Attachments are stored in the space and readable through both APIs
+	att, err := m.SaveAttachment(room.ID, "photo.png", "bob", strings.NewReader("img-bytes"), 1024)
+	if err != nil {
+		t.Fatalf("SaveAttachment() error = %v", err)
+	}
+	item, ok := space.GetItem(att.ID)
+	if !ok {
+		t.Fatalf("attachment not stored as a space item")
+	}
+	if item.Type != sharedspace.ItemTypeImage {
+		t.Errorf("png attachment item type = %q, want image", item.Type)
+	}
+	if item.Origin != OriginMeetRoom {
+		t.Errorf("attachment origin = %q, want %q", item.Origin, OriginMeetRoom)
+	}
+	if got, ok := m.GetAttachment(room.ID, att.ID); !ok || got.DiskPath != item.DiskPath {
+		t.Errorf("GetAttachment did not resolve the space-backed file")
+	}
+
+	//Chat mirrors into the space with the meetroom origin
+	m.LogChat(room.ID, "alice", "hello world")
+	items := space.Items()
+	if len(items) != 2 {
+		t.Fatalf("space holds %d items, want 2", len(items))
+	}
+	if items[1].Type != sharedspace.ItemTypeText || items[1].Text != "hello world" || items[1].Origin != OriginMeetRoom {
+		t.Errorf("mirrored chat item = %+v", items[1])
+	}
+
+	//Oversized uploads map back to the meetroom error
+	if _, err := m.SaveAttachment(room.ID, "big.bin", "bob", strings.NewReader(strings.Repeat("A", 100)), 10); err != ErrAttachmentTooLarge {
+		t.Errorf("oversized upload error = %v, want ErrAttachmentTooLarge", err)
+	}
+
+	//Closing the room deletes the bound space and its blobs
+	m.CloseRoom(room.ID)
+	if _, ok := sm.GetSpace(room.SpaceID); ok {
+		t.Errorf("bound space still registered after CloseRoom")
+	}
+	if _, err := os.Stat(item.DiskPath); !os.IsNotExist(err) {
+		t.Errorf("space blob still on disk after CloseRoom: %v", err)
+	}
+}
+
+func TestSpaceItemBridge(t *testing.T) {
+	m, sm := newSpaceBoundManager(t)
+
+	var bridged []*sharedspace.Item
+	var bridgedRoom *Room
+	m.SetSpaceItemHandler(func(room *Room, item *sharedspace.Item) {
+		bridgedRoom = room
+		bridged = append(bridged, item)
+	})
+
+	room := m.CreateRoom("alice", "", "")
+	space, _ := sm.GetSpace(room.SpaceID)
+
+	//Items posted by the room itself must not echo back through the bridge
+	m.LogChat(room.ID, "alice", "own message")
+	m.SaveAttachment(room.ID, "notes.txt", "alice", strings.NewReader("data"), 1024)
+	if len(bridged) != 0 {
+		t.Fatalf("bridge fired %d times for meetroom-origin items, want 0", len(bridged))
+	}
+
+	//External (AGI) items flow through the bridge
+	agiItem, err := space.AddText("scriptbot", "posted from AGI", "agi")
+	if err != nil {
+		t.Fatalf("AddText() error = %v", err)
+	}
+	if len(bridged) != 1 || bridged[0] != agiItem {
+		t.Fatalf("bridge did not deliver the AGI item (fired %d times)", len(bridged))
+	}
+	if bridgedRoom != room {
+		t.Errorf("bridge delivered wrong room")
+	}
+
+	//AGI-posted files resolve as room attachments for the download endpoint
+	blob, _ := space.SaveBlob(sharedspace.ItemTypeFile, "report.pdf", "scriptbot", "agi", strings.NewReader("pdf"), 1024)
+	if len(bridged) != 2 {
+		t.Fatalf("bridge fired %d times, want 2", len(bridged))
+	}
+	if att, ok := m.GetAttachment(room.ID, blob.ID); !ok || att.Name != "report.pdf" {
+		t.Errorf("AGI-posted file not resolvable via GetAttachment")
 	}
 }
 

--- a/src/mod/meetroom/meetroom_test.go
+++ b/src/mod/meetroom/meetroom_test.go
@@ -491,6 +491,78 @@ func TestSpaceItemBridge(t *testing.T) {
 	}
 }
 
+func TestRoomRidesSpaceChannel(t *testing.T) {
+	//The meeting's realtime transport is the bound space's channel: meeting
+	//participants appear as channel subscribers, and generic subscribers on
+	//the same space receive meeting frames live.
+	m, sm := newSpaceBoundManager(t)
+	room := m.CreateRoom("alice", "", "")
+	space, ok := sm.GetSpace(room.SpaceID)
+	if !ok {
+		t.Fatalf("bound space not found")
+	}
+	channel := space.Channel()
+
+	host, _ := room.AddParticipant("alice")
+	guest, _ := room.AddParticipant("bob")
+	if channel.Count() != room.ParticipantCount() {
+		t.Errorf("channel has %d subscribers, room has %d participants", channel.Count(), room.ParticipantCount())
+	}
+	if _, ok := channel.Get(host.PeerID); !ok {
+		t.Errorf("host peer ID %d not a channel subscriber", host.PeerID)
+	}
+
+	//A generic space subscriber (e.g. a sharedspace WebSocket client)
+	//receives room broadcasts without being a meeting participant
+	watcher, err := channel.Join("watcher")
+	if err != nil {
+		t.Fatalf("generic Join() error = %v", err)
+	}
+	if room.ParticipantCount() != 2 {
+		t.Errorf("generic subscriber leaked into the meeting roster")
+	}
+	room.Broadcast([]byte(`{"type":"chat","text":"hi"}`), host.PeerID)
+	select {
+	case msg := <-watcher.Send:
+		if string(msg) != `{"type":"chat","text":"hi"}` {
+			t.Errorf("watcher received %q", msg)
+		}
+	default:
+		t.Errorf("generic space subscriber did not receive the room broadcast")
+	}
+	//Targeted sends reach meeting participants through the channel
+	if !room.SendTo(guest.PeerID, []byte("direct")) {
+		t.Errorf("SendTo(guest) = false")
+	}
+
+	//Closing the room tears down the shared channel: everyone drops
+	m.CloseRoom(room.ID)
+	if _, open := <-watcher.Send; open {
+		t.Errorf("generic subscriber still connected after CloseRoom")
+	}
+	if _, err := channel.Join("late"); err == nil {
+		t.Errorf("channel still accepts subscribers after CloseRoom")
+	}
+}
+
+func TestUnboundRoomStandaloneChannel(t *testing.T) {
+	//Rooms without a space manager run on a standalone channel with the
+	//same transport semantics.
+	m := newTestManager(t)
+	room := m.CreateRoom("alice", "", "")
+	a, _ := room.AddParticipant("alice")
+	b, _ := room.AddParticipant("bob")
+
+	room.Broadcast([]byte("frame"), a.PeerID)
+	if msg := <-b.Send; string(msg) != "frame" {
+		t.Errorf("b received %q, want frame", msg)
+	}
+	room.RemoveParticipant(b.PeerID)
+	if room.ParticipantCount() != 1 {
+		t.Errorf("ParticipantCount() = %d, want 1", room.ParticipantCount())
+	}
+}
+
 func TestParticipantMessageIsValidJSONFrame(t *testing.T) {
 	//Guards the wire contract: frames pushed by the transport layer are
 	//opaque bytes; make sure Broadcast does not mutate or alias them.

--- a/src/mod/sharedspace/access.go
+++ b/src/mod/sharedspace/access.go
@@ -1,0 +1,347 @@
+package sharedspace
+
+/*
+	SharedSpace access control
+
+	Spaces carry an access mode (open / public / private) and a member
+	list with roles (owner / admin / member):
+
+	  - CanRead: open and public spaces are readable by anyone who can
+	    name them; private spaces only by members.
+	  - CanPost: same as CanRead - reading a space implies being allowed
+	    to contribute to it (the transports decide who may name a space).
+	  - CanManage: owner and space admins - membership, metadata, access
+	    mode, deletion.
+
+	An empty username is the system authority (internal callers) and
+	passes every check. The package never authenticates: transports
+	(prouter endpoints, the AGI gateway) hand in validated usernames.
+*/
+
+import "sort"
+
+// AccessMode returns the space's current access mode.
+func (s *Space) AccessMode() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.access
+}
+
+// Role returns the member role of username in the space and whether the
+// user is a member at all. The owner always reports RoleOwner.
+func (s *Space) Role(username string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	role, ok := s.members[username]
+	return role, ok
+}
+
+// CanRead reports whether username may read the space's content.
+func (s *Space) CanRead(username string) bool {
+	if username == "" {
+		return true //system authority
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.access != AccessPrivate {
+		return true
+	}
+	_, member := s.members[username]
+	return member
+}
+
+// CanPost reports whether username may post items / documents into the
+// space. Posting rights follow reading rights.
+func (s *Space) CanPost(username string) bool {
+	return s.CanRead(username)
+}
+
+// CanManage reports whether username may administer the space (members,
+// metadata, access mode, deletion).
+func (s *Space) CanManage(username string) bool {
+	if username == "" {
+		return true //system authority
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if username == s.Owner {
+		return true
+	}
+	return s.members[username] == RoleAdmin
+}
+
+// Members returns a snapshot copy of the member list (username -> role).
+func (s *Space) Members() map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := make(map[string]string, len(s.members))
+	for username, role := range s.members {
+		snapshot[username] = role
+	}
+	return snapshot
+}
+
+// MemberCount returns the number of members in the space.
+func (s *Space) MemberCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.members)
+}
+
+// AddMember invites username into the space with the given role (RoleAdmin
+// or RoleMember). Only the owner, a space admin or the system may invite.
+func (s *Space) AddMember(requester string, username string, role string) error {
+	if role != RoleAdmin && role != RoleMember {
+		return ErrInvalidRole
+	}
+	if !s.CanManage(requester) {
+		return ErrPermissionDenied
+	}
+	if username == "" {
+		return ErrInvalidRole
+	}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrSpaceClosed
+	}
+	if _, exists := s.members[username]; exists {
+		s.mu.Unlock()
+		return ErrMemberExists
+	}
+	if len(s.members) >= maxMembers {
+		s.mu.Unlock()
+		return ErrSpaceMemberLimit
+	}
+	s.members[username] = role
+	s.mu.Unlock()
+
+	s.mgrPersistSpace()
+	s.emitEvent(&SpaceEvent{Kind: EventMemberChanged, Member: username, Role: role, Action: "add"})
+	return nil
+}
+
+// RemoveMember removes username from the space. Managers may remove anyone
+// but the owner; every member may remove themselves (leave).
+func (s *Space) RemoveMember(requester string, username string) error {
+	if username == s.Owner {
+		return ErrPermissionDenied //the owner cannot be removed
+	}
+	if requester != username && !s.CanManage(requester) {
+		return ErrPermissionDenied
+	}
+
+	s.mu.Lock()
+	if _, exists := s.members[username]; !exists {
+		s.mu.Unlock()
+		return ErrNotMember
+	}
+	delete(s.members, username)
+	s.mu.Unlock()
+
+	s.mgrPersistSpace()
+	s.emitEvent(&SpaceEvent{Kind: EventMemberChanged, Member: username, Action: "remove"})
+	return nil
+}
+
+// SetMemberRole changes an existing member's role (RoleAdmin or RoleMember).
+// The owner's role cannot be changed.
+func (s *Space) SetMemberRole(requester string, username string, role string) error {
+	if role != RoleAdmin && role != RoleMember {
+		return ErrInvalidRole
+	}
+	if username == s.Owner {
+		return ErrPermissionDenied
+	}
+	if !s.CanManage(requester) {
+		return ErrPermissionDenied
+	}
+
+	s.mu.Lock()
+	if _, exists := s.members[username]; !exists {
+		s.mu.Unlock()
+		return ErrNotMember
+	}
+	s.members[username] = role
+	s.mu.Unlock()
+
+	s.mgrPersistSpace()
+	s.emitEvent(&SpaceEvent{Kind: EventMemberChanged, Member: username, Role: role, Action: "role"})
+	return nil
+}
+
+// JoinPublic self-joins username into a public or open space as RoleMember.
+// Open spaces allow joining so the space shows up in the user's joined
+// list; private spaces reject self-joins (invite only).
+func (s *Space) JoinPublic(username string) error {
+	if username == "" {
+		return ErrPermissionDenied
+	}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrSpaceClosed
+	}
+	if s.access == AccessPrivate {
+		s.mu.Unlock()
+		return ErrPermissionDenied
+	}
+	if _, exists := s.members[username]; exists {
+		s.mu.Unlock()
+		return ErrMemberExists
+	}
+	if len(s.members) >= maxMembers {
+		s.mu.Unlock()
+		return ErrSpaceMemberLimit
+	}
+	s.members[username] = RoleMember
+	s.mu.Unlock()
+
+	s.mgrPersistSpace()
+	s.emitEvent(&SpaceEvent{Kind: EventMemberChanged, Member: username, Role: RoleMember, Action: "add"})
+	return nil
+}
+
+// SetAccess changes the space's access mode. Managers only.
+func (s *Space) SetAccess(requester string, access string) error {
+	if !validAccessMode(access) {
+		return ErrInvalidAccess
+	}
+	if !s.CanManage(requester) {
+		return ErrPermissionDenied
+	}
+
+	s.mu.Lock()
+	s.access = access
+	s.mu.Unlock()
+
+	s.mgrPersistSpace()
+	return nil
+}
+
+// SetMeta sets (or, with an empty value, deletes) a metadata entry on the
+// space. Managers only. Keys and values are length-capped and the total
+// number of entries is limited.
+func (s *Space) SetMeta(requester string, key string, value string) error {
+	if !s.CanManage(requester) {
+		return ErrPermissionDenied
+	}
+	key = clipString(key, maxMetadataKeyLen)
+	if key == "" {
+		return ErrPermissionDenied
+	}
+	value = clipString(value, maxMetadataValLen)
+
+	s.mu.Lock()
+	if value == "" {
+		delete(s.metadata, key)
+	} else {
+		if _, exists := s.metadata[key]; !exists && len(s.metadata) >= maxMetadataKeys {
+			s.mu.Unlock()
+			return ErrMetadataLimit
+		}
+		s.metadata[key] = value
+	}
+	s.mu.Unlock()
+
+	s.mgrPersistSpace()
+	return nil
+}
+
+// Metadata returns a snapshot copy of the space's metadata.
+func (s *Space) Metadata() map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := make(map[string]string, len(s.metadata))
+	for key, value := range s.metadata {
+		snapshot[key] = value
+	}
+	return snapshot
+}
+
+// sanitizeMetadata validates and clips an initial metadata map.
+func sanitizeMetadata(meta map[string]string) map[string]string {
+	clean := make(map[string]string)
+	if meta == nil {
+		return clean
+	}
+	//Deterministic pick order when the input exceeds the entry cap
+	keys := make([]string, 0, len(meta))
+	for key := range meta {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if len(clean) >= maxMetadataKeys {
+			break
+		}
+		clippedKey := clipString(key, maxMetadataKeyLen)
+		if clippedKey == "" || meta[key] == "" {
+			continue
+		}
+		clean[clippedKey] = clipString(meta[key], maxMetadataValLen)
+	}
+	return clean
+}
+
+// ListPublicSpaces returns a snapshot of every space with AccessPublic.
+func (m *Manager) ListPublicSpaces() []*Space {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	public := []*Space{}
+	for _, space := range m.spaces {
+		space.mu.Lock()
+		isPublic := space.access == AccessPublic
+		space.mu.Unlock()
+		if isPublic {
+			public = append(public, space)
+		}
+	}
+	return public
+}
+
+// ListSpacesByMember returns a snapshot of the spaces username belongs to
+// (as owner, admin or member).
+func (m *Manager) ListSpacesByMember(username string) []*Space {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	joined := []*Space{}
+	for _, space := range m.spaces {
+		if _, member := space.Role(username); member {
+			joined = append(joined, space)
+		}
+	}
+	return joined
+}
+
+// ListSpaces returns a snapshot of every live space (administrator surface).
+func (m *Manager) ListSpaces() []*Space {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	all := make([]*Space, 0, len(m.spaces))
+	for _, space := range m.spaces {
+		all = append(all, space)
+	}
+	return all
+}
+
+// SpaceDiskUsage returns the approximate bytes a space occupies (item sizes
+// plus document contents), computed from in-memory state.
+func (m *Manager) SpaceDiskUsage(spaceID string) int64 {
+	space, ok := m.GetSpace(spaceID)
+	if !ok {
+		return 0
+	}
+	space.mu.Lock()
+	defer space.mu.Unlock()
+	var total int64
+	for _, item := range space.items {
+		total += item.Size
+	}
+	for _, doc := range space.docs {
+		total += int64(len(doc.content))
+	}
+	return total
+}

--- a/src/mod/sharedspace/access_test.go
+++ b/src/mod/sharedspace/access_test.go
@@ -1,0 +1,253 @@
+package sharedspace
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// newAccessTestSpace builds a space with one admin ("adam") and one plain
+// member ("mia") besides the owner ("alice").
+func newAccessTestSpace(t *testing.T, access string) (*Manager, *Space) {
+	t.Helper()
+	m := NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	space, err := m.CreateSpaceWithOptions("alice", "ACL test", SpaceOptions{Access: access})
+	if err != nil {
+		t.Fatalf("CreateSpaceWithOptions() error = %v", err)
+	}
+	if err := space.AddMember("alice", "adam", RoleAdmin); err != nil {
+		t.Fatalf("AddMember(adam) error = %v", err)
+	}
+	if err := space.AddMember("alice", "mia", RoleMember); err != nil {
+		t.Fatalf("AddMember(mia) error = %v", err)
+	}
+	return m, space
+}
+
+func TestAccessMatrix(t *testing.T) {
+	tests := []struct {
+		access     string
+		username   string
+		wantRead   bool
+		wantPost   bool
+		wantManage bool
+	}{
+		{AccessOpen, "alice", true, true, true}, //owner
+		{AccessOpen, "adam", true, true, true},  //space admin
+		{AccessOpen, "mia", true, true, false},  //member
+		{AccessOpen, "stranger", true, true, false},
+		{AccessOpen, "", true, true, true}, //system authority
+		{AccessPublic, "alice", true, true, true},
+		{AccessPublic, "stranger", true, true, false},
+		{AccessPublic, "", true, true, true},
+		{AccessPrivate, "alice", true, true, true},
+		{AccessPrivate, "adam", true, true, true},
+		{AccessPrivate, "mia", true, true, false},
+		{AccessPrivate, "stranger", false, false, false},
+		{AccessPrivate, "", true, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.access+"/"+tt.username, func(t *testing.T) {
+			_, space := newAccessTestSpace(t, tt.access)
+			if got := space.CanRead(tt.username); got != tt.wantRead {
+				t.Errorf("CanRead(%q) = %v, want %v", tt.username, got, tt.wantRead)
+			}
+			if got := space.CanPost(tt.username); got != tt.wantPost {
+				t.Errorf("CanPost(%q) = %v, want %v", tt.username, got, tt.wantPost)
+			}
+			if got := space.CanManage(tt.username); got != tt.wantManage {
+				t.Errorf("CanManage(%q) = %v, want %v", tt.username, got, tt.wantManage)
+			}
+		})
+	}
+}
+
+func TestCreateSpaceWithOptionsValidation(t *testing.T) {
+	m := NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+
+	if _, err := m.CreateSpaceWithOptions("alice", "x", SpaceOptions{Access: "secret"}); err != ErrInvalidAccess {
+		t.Errorf("invalid access error = %v, want ErrInvalidAccess", err)
+	}
+	//Memory-only manager cannot create persistent spaces
+	if _, err := m.CreateSpaceWithOptions("alice", "x", SpaceOptions{Persistent: true}); err != ErrPersistenceOff {
+		t.Errorf("persistent-on-memory-manager error = %v, want ErrPersistenceOff", err)
+	}
+	//Default access is open, owner is seeded as member
+	space, err := m.CreateSpaceWithOptions("alice", "x", SpaceOptions{})
+	if err != nil {
+		t.Fatalf("CreateSpaceWithOptions() error = %v", err)
+	}
+	if space.AccessMode() != AccessOpen {
+		t.Errorf("default access = %q, want open", space.AccessMode())
+	}
+	if role, ok := space.Role("alice"); !ok || role != RoleOwner {
+		t.Errorf("owner role = %q/%v, want owner/true", role, ok)
+	}
+	//Initial metadata is sanitized in
+	space2, _ := m.CreateSpaceWithOptions("alice", "x", SpaceOptions{
+		Metadata: map[string]string{"purpose": "chat", "": "dropped"},
+	})
+	if meta := space2.Metadata(); meta["purpose"] != "chat" || len(meta) != 1 {
+		t.Errorf("initial metadata = %v, want {purpose:chat}", meta)
+	}
+}
+
+func TestMembershipManagement(t *testing.T) {
+	_, space := newAccessTestSpace(t, AccessPrivate)
+
+	tests := []struct {
+		name    string
+		action  func() error
+		wantErr error
+	}{
+		{"stranger cannot invite", func() error { return space.AddMember("stranger", "eve", RoleMember) }, ErrPermissionDenied},
+		{"member cannot invite", func() error { return space.AddMember("mia", "eve", RoleMember) }, ErrPermissionDenied},
+		{"invalid role rejected", func() error { return space.AddMember("alice", "eve", "superuser") }, ErrInvalidRole},
+		{"owner role not grantable", func() error { return space.AddMember("alice", "eve", RoleOwner) }, ErrInvalidRole},
+		{"admin can invite", func() error { return space.AddMember("adam", "eve", RoleMember) }, nil},
+		{"duplicate invite rejected", func() error { return space.AddMember("alice", "eve", RoleMember) }, ErrMemberExists},
+		{"owner cannot be removed", func() error { return space.RemoveMember("alice", "alice") }, ErrPermissionDenied},
+		{"stranger cannot remove", func() error { return space.RemoveMember("stranger", "mia") }, ErrPermissionDenied},
+		{"self-leave allowed", func() error { return space.RemoveMember("eve", "eve") }, nil},
+		{"remove non-member", func() error { return space.RemoveMember("alice", "eve") }, ErrNotMember},
+		{"owner role immutable", func() error { return space.SetMemberRole("alice", "alice", RoleAdmin) }, ErrPermissionDenied},
+		{"member cannot change roles", func() error { return space.SetMemberRole("mia", "mia", RoleAdmin) }, ErrPermissionDenied},
+		{"promote member to admin", func() error { return space.SetMemberRole("alice", "mia", RoleAdmin) }, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.action(); err != tt.wantErr {
+				t.Errorf("error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+
+	if role, _ := space.Role("mia"); role != RoleAdmin {
+		t.Errorf("mia role after promotion = %q, want admin", role)
+	}
+	if space.MemberCount() != 3 {
+		t.Errorf("MemberCount() = %d, want 3 (alice, adam, mia)", space.MemberCount())
+	}
+}
+
+func TestJoinPublic(t *testing.T) {
+	tests := []struct {
+		access  string
+		wantErr error
+	}{
+		{AccessOpen, nil},
+		{AccessPublic, nil},
+		{AccessPrivate, ErrPermissionDenied},
+	}
+	for _, tt := range tests {
+		t.Run(tt.access, func(t *testing.T) {
+			_, space := newAccessTestSpace(t, tt.access)
+			if err := space.JoinPublic("newbie"); err != tt.wantErr {
+				t.Fatalf("JoinPublic() error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil {
+				if role, ok := space.Role("newbie"); !ok || role != RoleMember {
+					t.Errorf("joined role = %q/%v, want member", role, ok)
+				}
+				if err := space.JoinPublic("newbie"); err != ErrMemberExists {
+					t.Errorf("re-join error = %v, want ErrMemberExists", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSetAccessAndMetadata(t *testing.T) {
+	_, space := newAccessTestSpace(t, AccessOpen)
+
+	if err := space.SetAccess("mia", AccessPrivate); err != ErrPermissionDenied {
+		t.Errorf("member SetAccess error = %v, want ErrPermissionDenied", err)
+	}
+	if err := space.SetAccess("alice", "bogus"); err != ErrInvalidAccess {
+		t.Errorf("bogus access error = %v, want ErrInvalidAccess", err)
+	}
+	if err := space.SetAccess("alice", AccessPrivate); err != nil {
+		t.Fatalf("owner SetAccess error = %v", err)
+	}
+	if space.AccessMode() != AccessPrivate {
+		t.Errorf("access = %q after SetAccess, want private", space.AccessMode())
+	}
+	if space.CanRead("stranger") {
+		t.Errorf("stranger can still read after going private")
+	}
+
+	if err := space.SetMeta("mia", "k", "v"); err != ErrPermissionDenied {
+		t.Errorf("member SetMeta error = %v, want ErrPermissionDenied", err)
+	}
+	if err := space.SetMeta("alice", "purpose", "standup notes"); err != nil {
+		t.Fatalf("SetMeta error = %v", err)
+	}
+	if space.Metadata()["purpose"] != "standup notes" {
+		t.Errorf("metadata not stored: %v", space.Metadata())
+	}
+	//Empty value deletes the key
+	if err := space.SetMeta("alice", "purpose", ""); err != nil {
+		t.Fatalf("SetMeta delete error = %v", err)
+	}
+	if _, exists := space.Metadata()["purpose"]; exists {
+		t.Errorf("metadata key survived deletion")
+	}
+	//Entry cap
+	for i := 0; i < maxMetadataKeys; i++ {
+		if err := space.SetMeta("alice", "key"+string(rune('a'+i%26))+string(rune('a'+i/26)), "v"); err != nil {
+			t.Fatalf("SetMeta cap-fill error = %v", err)
+		}
+	}
+	if err := space.SetMeta("alice", "onemore", "v"); err != ErrMetadataLimit {
+		t.Errorf("over-cap SetMeta error = %v, want ErrMetadataLimit", err)
+	}
+}
+
+func TestSpaceListings(t *testing.T) {
+	m := NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	m.CreateSpaceWithOptions("alice", "Open", SpaceOptions{})
+	pub, _ := m.CreateSpaceWithOptions("alice", "Public", SpaceOptions{Access: AccessPublic})
+	priv, _ := m.CreateSpaceWithOptions("bob", "Private", SpaceOptions{Access: AccessPrivate})
+	priv.AddMember("bob", "alice", RoleMember)
+
+	publicSpaces := m.ListPublicSpaces()
+	if len(publicSpaces) != 1 || publicSpaces[0].ID != pub.ID {
+		t.Errorf("ListPublicSpaces() returned %d spaces, want just the public one", len(publicSpaces))
+	}
+	if got := len(m.ListSpacesByMember("alice")); got != 3 {
+		t.Errorf("alice is member of %d spaces, want 3", got)
+	}
+	if got := len(m.ListSpacesByMember("bob")); got != 1 {
+		t.Errorf("bob is member of %d spaces, want 1", got)
+	}
+	if got := len(m.ListSpaces()); got != 3 {
+		t.Errorf("ListSpaces() = %d, want 3", got)
+	}
+}
+
+func TestAdminCanRemoveOthersItems(t *testing.T) {
+	_, space := newAccessTestSpace(t, AccessOpen)
+	item, err := space.AddText("mia", "my message", "test")
+	if err != nil {
+		t.Fatalf("AddText() error = %v", err)
+	}
+	//A space admin who is neither uploader nor owner may remove items
+	if err := space.RemoveItem(item.ID, "adam"); err != nil {
+		t.Errorf("admin RemoveItem error = %v, want nil", err)
+	}
+	//A plain member may not remove someone else's item
+	item2, _ := space.AddText("adam", "admin note", "test")
+	if err := space.RemoveItem(item2.ID, "mia"); err != ErrPermissionDenied {
+		t.Errorf("member RemoveItem error = %v, want ErrPermissionDenied", err)
+	}
+}
+
+func TestSpaceDiskUsage(t *testing.T) {
+	m, space := newAccessTestSpace(t, AccessOpen)
+	space.AddText("alice", "12345", "test")
+	if usage := m.SpaceDiskUsage(space.ID); usage != 5 {
+		t.Errorf("SpaceDiskUsage() = %d, want 5", usage)
+	}
+	if usage := m.SpaceDiskUsage("nonexistent"); usage != 0 {
+		t.Errorf("SpaceDiskUsage(unknown) = %d, want 0", usage)
+	}
+}

--- a/src/mod/sharedspace/channel.go
+++ b/src/mod/sharedspace/channel.go
@@ -1,0 +1,229 @@
+package sharedspace
+
+/*
+	SharedSpace realtime channel
+
+	A Channel is the realtime fan-out hub of a space: WebSocket handlers
+	(and any other transport) Join it to receive a numbered Subscriber
+	whose Send buffer they drain into their connection. Frames pushed
+	through Broadcast / SendTo are opaque bytes - the channel never
+	interprets them - so the same hub carries chat delivery, document
+	patches, presence and ephemeral WebRTC signaling (MeetRoom runs its
+	meeting signaling over room channels).
+
+	Locking rules:
+	  - Channel.mu is a leaf lock: no Space method is called and no hook
+	    or listener is invoked while it is held. Join / Leave snapshot
+	    under the lock and fire the presence hooks after unlocking.
+	  - Space.mu -> Channel.mu nesting never occurs: Space.Channel()
+	    only constructs the hub, and channel methods never re-enter the
+	    space.
+	  - Full send buffers drop the frame rather than blocking the hub
+	    (same policy as the MeetRoom relay and Arozcast).
+*/
+
+import (
+	"sync"
+	"time"
+)
+
+// SubscriberSendBuffer is the per-subscriber outgoing frame buffer size.
+const SubscriberSendBuffer = 256
+
+// Subscriber is one connected member of a channel. The transport layer
+// drains Send and writes each frame to its connection. IDs are 1-based;
+// ID 0 is reserved for server-side senders in transport protocols.
+type Subscriber struct {
+	ID       int
+	Username string
+	Send     chan []byte
+	joinedAt time.Time
+	once     sync.Once
+}
+
+// CloseSend closes the subscriber's send channel exactly once.
+func (s *Subscriber) CloseSend() {
+	s.once.Do(func() { close(s.Send) })
+}
+
+// JoinedAt returns when the subscriber joined the channel.
+func (s *Subscriber) JoinedAt() time.Time {
+	return s.joinedAt
+}
+
+// Channel is the realtime hub of a space (or a standalone hub when created
+// with NewStandaloneChannel).
+type Channel struct {
+	space       *Space // nil for standalone channels (no ACL applied on Join)
+	subscribers map[int]*Subscriber
+	nextID      int
+	onJoin      func(*Subscriber)
+	onLeave     func(*Subscriber)
+	closed      bool
+	mu          sync.Mutex
+}
+
+// Channel returns the space's realtime hub, creating it on first use. The
+// returned pointer is stable for the lifetime of the space.
+func (s *Space) Channel() *Channel {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.channel == nil {
+		s.channel = &Channel{
+			space:       s,
+			subscribers: make(map[int]*Subscriber),
+			nextID:      1,
+			closed:      s.closed,
+		}
+	}
+	return s.channel
+}
+
+// NewStandaloneChannel creates a hub that is not bound to any space: Join
+// applies no access control. Used by consumers that manage their own
+// membership rules (e.g. MeetRoom rooms without a space manager).
+func NewStandaloneChannel() *Channel {
+	return &Channel{
+		subscribers: make(map[int]*Subscriber),
+		nextID:      1,
+	}
+}
+
+// SetPresenceHooks installs callbacks fired after a subscriber joins or
+// leaves. Hooks run outside the channel lock; set them once, before the
+// first Join, from the subsystem that owns the channel.
+func (c *Channel) SetPresenceHooks(onJoin func(*Subscriber), onLeave func(*Subscriber)) {
+	c.mu.Lock()
+	c.onJoin = onJoin
+	c.onLeave = onLeave
+	c.mu.Unlock()
+}
+
+// Join registers username as a new subscriber. For space-bound channels the
+// space's read permission is enforced. The transport layer must drain the
+// returned subscriber's Send channel.
+func (c *Channel) Join(username string) (*Subscriber, error) {
+	if c.space != nil && !c.space.CanRead(username) {
+		return nil, ErrPermissionDenied
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, ErrSpaceClosed
+	}
+	sub := &Subscriber{
+		ID:       c.nextID,
+		Username: username,
+		Send:     make(chan []byte, SubscriberSendBuffer),
+		joinedAt: time.Now(),
+	}
+	c.nextID++
+	c.subscribers[sub.ID] = sub
+	onJoin := c.onJoin
+	c.mu.Unlock()
+
+	if onJoin != nil {
+		onJoin(sub)
+	}
+	return sub, nil
+}
+
+// Leave unregisters a subscriber and closes its send channel. Safe to call
+// twice or with an unknown ID.
+func (c *Channel) Leave(id int) {
+	c.mu.Lock()
+	sub, ok := c.subscribers[id]
+	if ok {
+		delete(c.subscribers, id)
+	}
+	onLeave := c.onLeave
+	c.mu.Unlock()
+
+	if !ok {
+		return
+	}
+	if onLeave != nil {
+		onLeave(sub)
+	}
+	sub.CloseSend()
+}
+
+// Broadcast queues msg to every subscriber except excludeID (pass a negative
+// value to send to everyone). Full send buffers drop the frame rather than
+// blocking the hub.
+func (c *Channel) Broadcast(msg []byte, excludeID int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, sub := range c.subscribers {
+		if id == excludeID {
+			continue
+		}
+		select {
+		case sub.Send <- append([]byte(nil), msg...):
+		default:
+		}
+	}
+}
+
+// SendTo queues msg to a single subscriber. It reports whether the
+// subscriber exists in the channel.
+func (c *Channel) SendTo(id int, msg []byte) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sub, ok := c.subscribers[id]
+	if !ok {
+		return false
+	}
+	select {
+	case sub.Send <- append([]byte(nil), msg...):
+	default:
+	}
+	return true
+}
+
+// Get returns the subscriber with the given ID.
+func (c *Channel) Get(id int) (*Subscriber, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sub, ok := c.subscribers[id]
+	return sub, ok
+}
+
+// Subscribers returns a snapshot of the current subscribers.
+func (c *Channel) Subscribers() []*Subscriber {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	list := make([]*Subscriber, 0, len(c.subscribers))
+	for _, sub := range c.subscribers {
+		list = append(list, sub)
+	}
+	return list
+}
+
+// Count returns the number of connected subscribers.
+func (c *Channel) Count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.subscribers)
+}
+
+// Close marks the channel closed, removes every subscriber and closes their
+// send channels. It returns the removed subscribers so the transport layer
+// can finish delivering queued frames before the connections drop. Safe to
+// call more than once.
+func (c *Channel) Close() []*Subscriber {
+	c.mu.Lock()
+	c.closed = true
+	members := make([]*Subscriber, 0, len(c.subscribers))
+	for _, sub := range c.subscribers {
+		members = append(members, sub)
+	}
+	c.subscribers = make(map[int]*Subscriber)
+	c.mu.Unlock()
+
+	for _, sub := range members {
+		sub.CloseSend()
+	}
+	return members
+}

--- a/src/mod/sharedspace/channel_test.go
+++ b/src/mod/sharedspace/channel_test.go
@@ -1,0 +1,249 @@
+package sharedspace
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func newChannelTestSpace(t *testing.T, access string) *Space {
+	t.Helper()
+	m := NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	space, err := m.CreateSpaceWithOptions("alice", "Channel test", SpaceOptions{Access: access})
+	if err != nil {
+		t.Fatalf("CreateSpaceWithOptions() error = %v", err)
+	}
+	return space
+}
+
+func TestChannelJoinLeave(t *testing.T) {
+	space := newChannelTestSpace(t, AccessOpen)
+	channel := space.Channel()
+	if channel != space.Channel() {
+		t.Fatalf("Channel() is not stable")
+	}
+
+	a, err := channel.Join("alice")
+	if err != nil {
+		t.Fatalf("Join(alice) error = %v", err)
+	}
+	b, err := channel.Join("bob")
+	if err != nil {
+		t.Fatalf("Join(bob) error = %v", err)
+	}
+	if a.ID == b.ID || a.ID < 1 || b.ID < 1 {
+		t.Errorf("subscriber IDs invalid: %d, %d (must be unique, 1-based)", a.ID, b.ID)
+	}
+	if channel.Count() != 2 {
+		t.Errorf("Count() = %d, want 2", channel.Count())
+	}
+	if got, ok := channel.Get(b.ID); !ok || got != b {
+		t.Errorf("Get(%d) did not return bob", b.ID)
+	}
+
+	channel.Leave(b.ID)
+	if channel.Count() != 1 {
+		t.Errorf("Count() after leave = %d, want 1", channel.Count())
+	}
+	if _, open := <-b.Send; open {
+		t.Errorf("left subscriber's send channel still open")
+	}
+	//Leaving twice or with an unknown ID must not panic
+	channel.Leave(b.ID)
+	channel.Leave(9999)
+}
+
+func TestChannelACL(t *testing.T) {
+	space := newChannelTestSpace(t, AccessPrivate)
+	channel := space.Channel()
+
+	if _, err := channel.Join("stranger"); err != ErrPermissionDenied {
+		t.Errorf("stranger Join error = %v, want ErrPermissionDenied", err)
+	}
+	if _, err := channel.Join("alice"); err != nil {
+		t.Errorf("owner Join error = %v", err)
+	}
+	space.AddMember("alice", "mia", RoleMember)
+	if _, err := channel.Join("mia"); err != nil {
+		t.Errorf("member Join error = %v", err)
+	}
+}
+
+func TestChannelBroadcastAndSendTo(t *testing.T) {
+	space := newChannelTestSpace(t, AccessOpen)
+	channel := space.Channel()
+	a, _ := channel.Join("alice")
+	b, _ := channel.Join("bob")
+	c, _ := channel.Join("carol")
+
+	channel.Broadcast([]byte("hello"), a.ID)
+	for _, sub := range []*Subscriber{b, c} {
+		select {
+		case msg := <-sub.Send:
+			if string(msg) != "hello" {
+				t.Errorf("%s received %q, want hello", sub.Username, msg)
+			}
+		default:
+			t.Errorf("%s received nothing from broadcast", sub.Username)
+		}
+	}
+	select {
+	case msg := <-a.Send:
+		t.Errorf("excluded sender received %q", msg)
+	default:
+	}
+
+	if !channel.SendTo(b.ID, []byte("direct")) {
+		t.Errorf("SendTo(%d) = false, want true", b.ID)
+	}
+	if msg := <-b.Send; string(msg) != "direct" {
+		t.Errorf("b received %q, want direct", msg)
+	}
+	if channel.SendTo(9999, []byte("direct")) {
+		t.Errorf("SendTo(unknown) = true, want false")
+	}
+
+	//Broadcast must not alias the caller's buffer
+	frame := []byte(`{"type":"chat"}`)
+	channel.Broadcast(frame, -1)
+	frame[2] = 'X'
+	if msg := <-a.Send; string(msg) != `{"type":"chat"}` {
+		t.Errorf("broadcast frame mutated by caller: %q", msg)
+	}
+}
+
+func TestChannelBufferFullDrops(t *testing.T) {
+	space := newChannelTestSpace(t, AccessOpen)
+	channel := space.Channel()
+	a, _ := channel.Join("alice")
+
+	//Fill the buffer past capacity: the hub must not block
+	for i := 0; i < SubscriberSendBuffer+10; i++ {
+		channel.Broadcast([]byte("x"), -1)
+	}
+	if len(a.Send) != SubscriberSendBuffer {
+		t.Errorf("send buffer = %d frames, want %d (overflow dropped)", len(a.Send), SubscriberSendBuffer)
+	}
+}
+
+func TestChannelClose(t *testing.T) {
+	space := newChannelTestSpace(t, AccessOpen)
+	channel := space.Channel()
+	a, _ := channel.Join("alice")
+	channel.Join("bob")
+
+	members := channel.Close()
+	if len(members) != 2 {
+		t.Errorf("Close() returned %d members, want 2", len(members))
+	}
+	if _, open := <-a.Send; open {
+		t.Errorf("send channel still open after Close")
+	}
+	if _, err := channel.Join("late"); err != ErrSpaceClosed {
+		t.Errorf("Join after Close error = %v, want ErrSpaceClosed", err)
+	}
+	//Closing twice must not panic
+	if again := channel.Close(); len(again) != 0 {
+		t.Errorf("second Close() returned %d members, want 0", len(again))
+	}
+}
+
+func TestDeleteSpaceClosesChannel(t *testing.T) {
+	m := NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	space := m.CreateSpace("alice", "")
+	channel := space.Channel()
+	a, _ := channel.Join("alice")
+
+	m.DeleteSpace(space.ID)
+	if _, open := <-a.Send; open {
+		t.Errorf("subscriber send channel still open after DeleteSpace")
+	}
+	if _, err := channel.Join("late"); err != ErrSpaceClosed {
+		t.Errorf("Join after DeleteSpace error = %v, want ErrSpaceClosed", err)
+	}
+}
+
+func TestStandaloneChannel(t *testing.T) {
+	channel := NewStandaloneChannel()
+	//No space, no ACL: anyone joins
+	a, err := channel.Join("anyone")
+	if err != nil {
+		t.Fatalf("standalone Join error = %v", err)
+	}
+	channel.Broadcast([]byte("ping"), -1)
+	if msg := <-a.Send; string(msg) != "ping" {
+		t.Errorf("standalone broadcast = %q", msg)
+	}
+}
+
+func TestChannelPresenceHooks(t *testing.T) {
+	space := newChannelTestSpace(t, AccessOpen)
+	channel := space.Channel()
+
+	var mu sync.Mutex
+	joins := []string{}
+	leaves := []string{}
+	channel.SetPresenceHooks(
+		func(sub *Subscriber) {
+			//Hooks must run outside the channel lock: calling back into the
+			//channel here must not deadlock
+			channel.Count()
+			mu.Lock()
+			joins = append(joins, sub.Username)
+			mu.Unlock()
+		},
+		func(sub *Subscriber) {
+			channel.Count()
+			mu.Lock()
+			leaves = append(leaves, sub.Username)
+			mu.Unlock()
+		},
+	)
+
+	a, _ := channel.Join("alice")
+	channel.Leave(a.ID)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(joins) != 1 || joins[0] != "alice" {
+		t.Errorf("join hook calls = %v", joins)
+	}
+	if len(leaves) != 1 || leaves[0] != "alice" {
+		t.Errorf("leave hook calls = %v", leaves)
+	}
+}
+
+func TestChannelConcurrentUse(t *testing.T) {
+	//Exercises the lock discipline under -race: concurrent joins, posts,
+	//broadcasts and leaves must be data-race free and deadlock free.
+	space := newChannelTestSpace(t, AccessOpen)
+	channel := space.Channel()
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				sub, err := channel.Join("user")
+				if err != nil {
+					return
+				}
+				channel.Broadcast([]byte("frame"), sub.ID)
+				if n%2 == 0 {
+					space.AddText("user", "message", "test")
+				}
+				//Drain a little so buffers do not saturate
+				select {
+				case <-sub.Send:
+				default:
+				}
+				channel.Leave(sub.ID)
+			}
+		}(worker)
+	}
+	wg.Wait()
+	if channel.Count() != 0 {
+		t.Errorf("Count() after concurrent churn = %d, want 0", channel.Count())
+	}
+}

--- a/src/mod/sharedspace/doc.go
+++ b/src/mod/sharedspace/doc.go
@@ -1,0 +1,266 @@
+package sharedspace
+
+/*
+	SharedSpace collaborative documents
+
+	Documents are revision-numbered text bodies designed for realtime
+	co-editing without an OT/CRDT engine: every update is a
+	compare-and-swap against the document's current revision. A client
+	sends the full new content together with the revision it based its
+	edit on; if the document moved on in the meantime the update is
+	rejected with ErrRevisionConflict and the client re-fetches, rebases
+	its edit and retries.
+
+	Each accepted update computes a splice patch (common prefix / suffix
+	diff) which is broadcast to live subscribers so other editors can
+	apply the change in place. The server's content is authoritative:
+	a client that detects a revision gap simply re-fetches the document,
+	so convergence never depends on patch application.
+*/
+
+import (
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	//DefaultMaxDocs is the number of documents one space can hold
+	DefaultMaxDocs = 64
+	//MaxDocLength is the maximum document length in runes (~256KB as
+	//UTF-8, safely below the 512KB WebSocket frame limit)
+	MaxDocLength      = 262144
+	maxDocNameLength  = 128
+	docHistoryEntries = 32 // recent revisions kept in memory per document
+)
+
+// Doc is one collaborative document. All fields are guarded by the owning
+// Space's mutex; consumers only ever see DocSnapshot copies.
+type Doc struct {
+	id        string
+	name      string
+	creator   string
+	createdAt time.Time
+	content   string
+	revision  int64
+	updatedAt time.Time
+	updatedBy string
+	history   []DocRevision // ring of recent revisions, newest last
+}
+
+// DocPatch is a single splice edit: at rune offset Pos, delete Del runes and
+// insert Ins.
+type DocPatch struct {
+	Pos int
+	Del int
+	Ins string
+}
+
+// DocRevision records one accepted update, for in-memory audit / undo.
+type DocRevision struct {
+	Revision  int64
+	UpdatedBy string
+	UpdatedAt time.Time
+	Patch     DocPatch
+}
+
+// DocSnapshot is an immutable copy of a document's state.
+type DocSnapshot struct {
+	ID        string
+	Name      string
+	Creator   string
+	Content   string
+	Revision  int64
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	UpdatedBy string
+}
+
+// snapshot builds a DocSnapshot. Callers must hold the owning Space's mutex.
+func (d *Doc) snapshot() *DocSnapshot {
+	return &DocSnapshot{
+		ID:        d.id,
+		Name:      d.name,
+		Creator:   d.creator,
+		Content:   d.content,
+		Revision:  d.revision,
+		CreatedAt: d.createdAt,
+		UpdatedAt: d.updatedAt,
+		UpdatedBy: d.updatedBy,
+	}
+}
+
+// CreateDoc creates an empty document in the space. Requires post rights.
+func (s *Space) CreateDoc(requester string, name string) (*DocSnapshot, error) {
+	if !s.CanPost(requester) {
+		return nil, ErrPermissionDenied
+	}
+	name = clipString(name, maxDocNameLength)
+	if name == "" {
+		name = "Untitled document"
+	}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, ErrSpaceClosed
+	}
+	if len(s.docs) >= DefaultMaxDocs {
+		s.mu.Unlock()
+		return nil, ErrDocLimitReached
+	}
+	now := time.Now()
+	doc := &Doc{
+		id:        randomID(itemIDBytes),
+		name:      name,
+		creator:   requester,
+		createdAt: now,
+		revision:  1,
+		updatedAt: now,
+		updatedBy: requester,
+	}
+	s.docs[doc.id] = doc
+	snapshot := doc.snapshot()
+	s.mu.Unlock()
+
+	s.mgrPersistDoc(snapshot)
+	s.emitEvent(&SpaceEvent{Kind: EventDocCreated, Doc: snapshot})
+	return snapshot, nil
+}
+
+// GetDoc returns a snapshot of the document with the given ID.
+func (s *Space) GetDoc(docID string) (*DocSnapshot, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	doc, ok := s.docs[docID]
+	if !ok {
+		return nil, false
+	}
+	return doc.snapshot(), true
+}
+
+// ListDocs returns snapshots of every document in the space, without their
+// content (Content is left empty to keep listings cheap).
+func (s *Space) ListDocs() []*DocSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list := make([]*DocSnapshot, 0, len(s.docs))
+	for _, doc := range s.docs {
+		snapshot := doc.snapshot()
+		snapshot.Content = ""
+		list = append(list, snapshot)
+	}
+	return list
+}
+
+// DocCount returns the number of documents in the space.
+func (s *Space) DocCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.docs)
+}
+
+// UpdateDoc applies a compare-and-swap update: content replaces the document
+// body only when baseRevision matches the current revision, otherwise
+// ErrRevisionConflict is returned and the caller must re-fetch and rebase.
+// On success the revision increments and a doc-updated event carrying the
+// new snapshot and the splice patch is emitted.
+func (s *Space) UpdateDoc(requester string, docID string, baseRevision int64, content string) (*DocSnapshot, error) {
+	if !s.CanPost(requester) {
+		return nil, ErrPermissionDenied
+	}
+	if utf8.RuneCountInString(content) > MaxDocLength {
+		return nil, ErrDocTooLarge
+	}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, ErrSpaceClosed
+	}
+	doc, ok := s.docs[docID]
+	if !ok {
+		s.mu.Unlock()
+		return nil, ErrDocNotFound
+	}
+	if doc.revision != baseRevision {
+		s.mu.Unlock()
+		return nil, ErrRevisionConflict
+	}
+	patch := computeSplicePatch(doc.content, content)
+	doc.content = content
+	doc.revision++
+	doc.updatedAt = time.Now()
+	doc.updatedBy = requester
+	doc.history = append(doc.history, DocRevision{
+		Revision:  doc.revision,
+		UpdatedBy: requester,
+		UpdatedAt: doc.updatedAt,
+		Patch:     patch,
+	})
+	if len(doc.history) > docHistoryEntries {
+		doc.history = doc.history[len(doc.history)-docHistoryEntries:]
+	}
+	snapshot := doc.snapshot()
+	s.mu.Unlock()
+
+	s.mgrPersistDoc(snapshot)
+	s.emitEvent(&SpaceEvent{Kind: EventDocUpdated, Doc: snapshot, Patch: &patch})
+	return snapshot, nil
+}
+
+// DocHistory returns the recent revision log of a document (newest last).
+func (s *Space) DocHistory(docID string) ([]DocRevision, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	doc, ok := s.docs[docID]
+	if !ok {
+		return nil, false
+	}
+	history := make([]DocRevision, len(doc.history))
+	copy(history, doc.history)
+	return history, true
+}
+
+// DeleteDoc removes a document. Only the document's creator, a space
+// manager, or the system may delete it.
+func (s *Space) DeleteDoc(requester string, docID string) error {
+	s.mu.Lock()
+	doc, ok := s.docs[docID]
+	if !ok {
+		s.mu.Unlock()
+		return ErrDocNotFound
+	}
+	if requester != "" && requester != doc.creator && requester != s.Owner && s.members[requester] != RoleAdmin {
+		s.mu.Unlock()
+		return ErrPermissionDenied
+	}
+	delete(s.docs, docID)
+	snapshot := doc.snapshot()
+	s.mu.Unlock()
+
+	s.mgrDeleteDocRecord(docID)
+	s.emitEvent(&SpaceEvent{Kind: EventDocDeleted, Doc: snapshot})
+	return nil
+}
+
+// computeSplicePatch derives the single splice (common prefix / suffix diff)
+// that turns oldStr into newStr, in rune offsets.
+func computeSplicePatch(oldStr string, newStr string) DocPatch {
+	oldRunes := []rune(oldStr)
+	newRunes := []rune(newStr)
+
+	prefix := 0
+	for prefix < len(oldRunes) && prefix < len(newRunes) && oldRunes[prefix] == newRunes[prefix] {
+		prefix++
+	}
+	suffix := 0
+	for suffix < len(oldRunes)-prefix && suffix < len(newRunes)-prefix &&
+		oldRunes[len(oldRunes)-1-suffix] == newRunes[len(newRunes)-1-suffix] {
+		suffix++
+	}
+	return DocPatch{
+		Pos: prefix,
+		Del: len(oldRunes) - prefix - suffix,
+		Ins: string(newRunes[prefix : len(newRunes)-suffix]),
+	}
+}

--- a/src/mod/sharedspace/doc_test.go
+++ b/src/mod/sharedspace/doc_test.go
@@ -1,0 +1,204 @@
+package sharedspace
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newDocTestSpace(t *testing.T) *Space {
+	t.Helper()
+	m := NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	return m.CreateSpace("alice", "Doc test")
+}
+
+func TestDocLifecycle(t *testing.T) {
+	space := newDocTestSpace(t)
+
+	doc, err := space.CreateDoc("alice", "Meeting notes")
+	if err != nil {
+		t.Fatalf("CreateDoc() error = %v", err)
+	}
+	if doc.Revision != 1 || doc.Name != "Meeting notes" || doc.Creator != "alice" {
+		t.Errorf("new doc snapshot = %+v", doc)
+	}
+
+	//Default name
+	unnamed, _ := space.CreateDoc("alice", "")
+	if unnamed.Name != "Untitled document" {
+		t.Errorf("unnamed doc name = %q", unnamed.Name)
+	}
+
+	got, ok := space.GetDoc(doc.ID)
+	if !ok || got.ID != doc.ID {
+		t.Fatalf("GetDoc() did not return the document")
+	}
+	if _, ok := space.GetDoc("nonexistent"); ok {
+		t.Errorf("GetDoc(unknown) returned ok")
+	}
+
+	list := space.ListDocs()
+	if len(list) != 2 {
+		t.Fatalf("ListDocs() = %d docs, want 2", len(list))
+	}
+	for _, snapshot := range list {
+		if snapshot.Content != "" {
+			t.Errorf("ListDocs() leaked content")
+		}
+	}
+	if space.DocCount() != 2 {
+		t.Errorf("DocCount() = %d, want 2", space.DocCount())
+	}
+
+	//Deletion permissions: stranger no, creator yes
+	if err := space.DeleteDoc("mallory", doc.ID); err != ErrPermissionDenied {
+		t.Errorf("stranger DeleteDoc error = %v, want ErrPermissionDenied", err)
+	}
+	if err := space.DeleteDoc("alice", doc.ID); err != nil {
+		t.Errorf("creator DeleteDoc error = %v", err)
+	}
+	if err := space.DeleteDoc("alice", doc.ID); err != ErrDocNotFound {
+		t.Errorf("double DeleteDoc error = %v, want ErrDocNotFound", err)
+	}
+}
+
+func TestDocUpdateCAS(t *testing.T) {
+	space := newDocTestSpace(t)
+	doc, _ := space.CreateDoc("alice", "notes")
+
+	//Sequential updates advance the revision
+	first, err := space.UpdateDoc("alice", doc.ID, 1, "hello world")
+	if err != nil {
+		t.Fatalf("first UpdateDoc error = %v", err)
+	}
+	if first.Revision != 2 || first.Content != "hello world" {
+		t.Errorf("first update snapshot = %+v", first)
+	}
+	second, err := space.UpdateDoc("bob", doc.ID, 2, "hello brave world")
+	if err != nil {
+		t.Fatalf("second UpdateDoc error = %v", err)
+	}
+	if second.Revision != 3 || second.UpdatedBy != "bob" {
+		t.Errorf("second update snapshot = %+v", second)
+	}
+
+	//Stale base revision is rejected without content change
+	if _, err := space.UpdateDoc("carol", doc.ID, 2, "clobber"); err != ErrRevisionConflict {
+		t.Errorf("stale update error = %v, want ErrRevisionConflict", err)
+	}
+	if got, _ := space.GetDoc(doc.ID); got.Content != "hello brave world" {
+		t.Errorf("conflict mutated content: %q", got.Content)
+	}
+
+	//Unknown doc and oversized content
+	if _, err := space.UpdateDoc("alice", "nonexistent", 1, "x"); err != ErrDocNotFound {
+		t.Errorf("unknown doc error = %v, want ErrDocNotFound", err)
+	}
+	if _, err := space.UpdateDoc("alice", doc.ID, 3, strings.Repeat("a", MaxDocLength+1)); err != ErrDocTooLarge {
+		t.Errorf("oversized update error = %v, want ErrDocTooLarge", err)
+	}
+
+	//History records the accepted revisions
+	history, ok := space.DocHistory(doc.ID)
+	if !ok || len(history) != 2 {
+		t.Fatalf("DocHistory() = %d entries, want 2", len(history))
+	}
+	if history[0].Revision != 2 || history[1].Revision != 3 {
+		t.Errorf("history revisions = %d, %d", history[0].Revision, history[1].Revision)
+	}
+}
+
+func TestDocLimits(t *testing.T) {
+	space := newDocTestSpace(t)
+	for i := 0; i < DefaultMaxDocs; i++ {
+		if _, err := space.CreateDoc("alice", "doc"); err != nil {
+			t.Fatalf("CreateDoc #%d error = %v", i, err)
+		}
+	}
+	if _, err := space.CreateDoc("alice", "one too many"); err != ErrDocLimitReached {
+		t.Errorf("over-limit CreateDoc error = %v, want ErrDocLimitReached", err)
+	}
+}
+
+func TestDocPermissions(t *testing.T) {
+	m := NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+	space, _ := m.CreateSpaceWithOptions("alice", "private docs", SpaceOptions{Access: AccessPrivate})
+
+	if _, err := space.CreateDoc("stranger", "sneaky"); err != ErrPermissionDenied {
+		t.Errorf("stranger CreateDoc error = %v, want ErrPermissionDenied", err)
+	}
+	doc, err := space.CreateDoc("alice", "insider")
+	if err != nil {
+		t.Fatalf("owner CreateDoc error = %v", err)
+	}
+	if _, err := space.UpdateDoc("stranger", doc.ID, 1, "hijack"); err != ErrPermissionDenied {
+		t.Errorf("stranger UpdateDoc error = %v, want ErrPermissionDenied", err)
+	}
+	//Space admins may delete docs they did not create
+	space.AddMember("alice", "adam", RoleAdmin)
+	if err := space.DeleteDoc("adam", doc.ID); err != nil {
+		t.Errorf("admin DeleteDoc error = %v", err)
+	}
+}
+
+func TestDocUpdateEmitsPatchEvent(t *testing.T) {
+	space := newDocTestSpace(t)
+	doc, _ := space.CreateDoc("alice", "notes")
+
+	var events []*SpaceEvent
+	space.SubscribeEvents("test", func(event *SpaceEvent) {
+		events = append(events, event)
+	})
+
+	space.UpdateDoc("alice", doc.ID, 1, "hello")
+	if len(events) != 1 || events[0].Kind != EventDocUpdated {
+		t.Fatalf("expected one doc-updated event, got %d", len(events))
+	}
+	if events[0].Patch == nil || events[0].Patch.Ins != "hello" {
+		t.Errorf("event patch = %+v", events[0].Patch)
+	}
+	if events[0].Doc == nil || events[0].Doc.Revision != 2 {
+		t.Errorf("event snapshot = %+v", events[0].Doc)
+	}
+
+	space.DeleteDoc("alice", doc.ID)
+	if len(events) != 2 || events[1].Kind != EventDocDeleted {
+		t.Errorf("expected doc-deleted event, got %+v", events)
+	}
+}
+
+func TestComputeSplicePatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		oldStr  string
+		newStr  string
+		wantPos int
+		wantDel int
+		wantIns string
+	}{
+		{"append", "hello", "hello world", 5, 0, " world"},
+		{"prepend", "world", "hello world", 0, 0, "hello "},
+		{"insert middle", "helo", "hello", 3, 0, "l"},
+		{"delete middle", "hello", "helo", 3, 1, ""},
+		{"replace middle", "hello brave world", "hello bold world", 7, 4, "old"},
+		{"clear all", "abc", "", 0, 3, ""},
+		{"from empty", "", "abc", 0, 0, "abc"},
+		{"no change", "same", "same", 4, 0, ""},
+		{"unicode aware", "café au lait", "cafés au lait", 4, 0, "s"},
+		{"full rewrite", "abc", "xyz", 0, 3, "xyz"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patch := computeSplicePatch(tt.oldStr, tt.newStr)
+			if patch.Pos != tt.wantPos || patch.Del != tt.wantDel || patch.Ins != tt.wantIns {
+				t.Errorf("patch = %+v, want {Pos:%d Del:%d Ins:%q}", patch, tt.wantPos, tt.wantDel, tt.wantIns)
+			}
+			//Applying the patch must reproduce newStr
+			oldRunes := []rune(tt.oldStr)
+			rebuilt := string(oldRunes[:patch.Pos]) + patch.Ins + string(oldRunes[patch.Pos+patch.Del:])
+			if rebuilt != tt.newStr {
+				t.Errorf("patch application = %q, want %q", rebuilt, tt.newStr)
+			}
+		})
+	}
+}

--- a/src/mod/sharedspace/persistence.go
+++ b/src/mod/sharedspace/persistence.go
@@ -1,0 +1,428 @@
+package sharedspace
+
+/*
+	SharedSpace persistence
+
+	Persistent spaces write through to the ArozOS system database and
+	keep their blobs under a durable storage root, so chat history,
+	shared files and collaborative documents survive server restarts.
+
+	Layout (values are JSON, one bolt transaction per write):
+
+	  table "sharedspace":      key "space/<spaceID>" -> spaceRecord
+	                            (key "conf/<name>" is reserved for the
+	                            admin configuration written by the main
+	                            package)
+	  table "sharedspaceitem":  key "<spaceID>/<itemID>" -> itemRecord
+	  table "sharedspacedoc":   key "<spaceID>/<docID>"  -> docRecord
+
+	Blobs live at <persistRoot>/<spaceID>/<itemID>; disk paths are never
+	persisted - they are rebuilt from the root at reload. Reload is
+	self-healing: records whose space vanished, blob went missing or
+	JSON no longer parses are deleted, and blob directories without a
+	live space are removed.
+*/
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"imuslab.com/arozos/mod/info/logger"
+)
+
+const (
+	dbTableSpaces    = "sharedspace"
+	dbTableItems     = "sharedspaceitem"
+	dbTableDocs      = "sharedspacedoc"
+	dbSpaceKeyPrefix = "space/"
+)
+
+// spaceRecord is the persisted form of a Space.
+type spaceRecord struct {
+	ID        string            `json:"id"`
+	Name      string            `json:"name"`
+	Owner     string            `json:"owner"`
+	CreatedAt int64             `json:"createdat"`
+	Access    string            `json:"access"`
+	Metadata  map[string]string `json:"metadata"`
+	Members   map[string]string `json:"members"`
+	MaxItems  int               `json:"maxitems"`
+}
+
+// itemRecord is the persisted form of an Item. Disk paths are rebuilt from
+// the persistent root at reload and never stored.
+type itemRecord struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	Text      string `json:"text"`
+	Size      int64  `json:"size"`
+	Uploader  string `json:"uploader"`
+	Origin    string `json:"origin"`
+	Seq       int64  `json:"seq"`
+	CreatedAt int64  `json:"createdat"`
+	HasBlob   bool   `json:"hasblob"`
+}
+
+// docRecord is the persisted form of a document (current revision only; the
+// in-memory history ring is not persisted).
+type docRecord struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Creator   string `json:"creator"`
+	Content   string `json:"content"`
+	Revision  int64  `json:"revision"`
+	CreatedAt int64  `json:"createdat"`
+	UpdatedAt int64  `json:"updatedat"`
+	UpdatedBy string `json:"updatedby"`
+}
+
+// initPersistenceTables creates the sharedspace tables when missing.
+func (m *Manager) initPersistenceTables() {
+	m.db.NewTable(dbTableSpaces)
+	m.db.NewTable(dbTableItems)
+	m.db.NewTable(dbTableDocs)
+}
+
+// record snapshots the space's persisted state.
+func (s *Space) record() *spaceRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	metadata := make(map[string]string, len(s.metadata))
+	for key, value := range s.metadata {
+		metadata[key] = value
+	}
+	members := make(map[string]string, len(s.members))
+	for username, role := range s.members {
+		members[username] = role
+	}
+	return &spaceRecord{
+		ID:        s.ID,
+		Name:      s.Name,
+		Owner:     s.Owner,
+		CreatedAt: s.CreatedAt.Unix(),
+		Access:    s.access,
+		Metadata:  metadata,
+		Members:   members,
+		MaxItems:  s.maxItems,
+	}
+}
+
+// persistSpace writes the space record through to the database. No-op for
+// ephemeral spaces or persistence-less managers.
+func (m *Manager) persistSpace(s *Space) {
+	if s == nil || !s.Persistent || m.db == nil {
+		return
+	}
+	err := m.db.Write(dbTableSpaces, dbSpaceKeyPrefix+s.ID, s.record())
+	if err != nil {
+		logger.PrintAndLog("SharedSpace", "Failed to persist space "+s.ID, err)
+	}
+}
+
+// mgrPersistSpace lets Space methods write their record through without
+// holding any lock. Nil-safe for spaces built directly in tests.
+func (s *Space) mgrPersistSpace() {
+	if s.mgr != nil {
+		s.mgr.persistSpace(s)
+	}
+}
+
+// mgrPersistItem writes an item record through to the database.
+func (s *Space) mgrPersistItem(item *Item) {
+	if s.mgr == nil || !s.Persistent || s.mgr.db == nil {
+		return
+	}
+	record := &itemRecord{
+		ID:        item.ID,
+		Type:      item.Type,
+		Name:      item.Name,
+		Text:      item.Text,
+		Size:      item.Size,
+		Uploader:  item.Uploader,
+		Origin:    item.Origin,
+		Seq:       item.Seq,
+		CreatedAt: item.CreatedAt.Unix(),
+		HasBlob:   item.DiskPath != "",
+	}
+	err := s.mgr.db.Write(dbTableItems, s.ID+"/"+item.ID, record)
+	if err != nil {
+		logger.PrintAndLog("SharedSpace", "Failed to persist item "+item.ID, err)
+	}
+}
+
+// mgrDeleteItemRecord removes an item record from the database.
+func (s *Space) mgrDeleteItemRecord(itemID string) {
+	if s.mgr == nil || !s.Persistent || s.mgr.db == nil {
+		return
+	}
+	s.mgr.db.Delete(dbTableItems, s.ID+"/"+itemID)
+}
+
+// mgrPersistDoc writes a document record through to the database.
+func (s *Space) mgrPersistDoc(snapshot *DocSnapshot) {
+	if s.mgr == nil || !s.Persistent || s.mgr.db == nil {
+		return
+	}
+	record := &docRecord{
+		ID:        snapshot.ID,
+		Name:      snapshot.Name,
+		Creator:   snapshot.Creator,
+		Content:   snapshot.Content,
+		Revision:  snapshot.Revision,
+		CreatedAt: snapshot.CreatedAt.Unix(),
+		UpdatedAt: snapshot.UpdatedAt.Unix(),
+		UpdatedBy: snapshot.UpdatedBy,
+	}
+	err := s.mgr.db.Write(dbTableDocs, s.ID+"/"+snapshot.ID, record)
+	if err != nil {
+		logger.PrintAndLog("SharedSpace", "Failed to persist document "+snapshot.ID, err)
+	}
+}
+
+// mgrDeleteDocRecord removes a document record from the database.
+func (s *Space) mgrDeleteDocRecord(docID string) {
+	if s.mgr == nil || !s.Persistent || s.mgr.db == nil {
+		return
+	}
+	s.mgr.db.Delete(dbTableDocs, s.ID+"/"+docID)
+}
+
+// deleteSpaceRecords removes every database record belonging to a space.
+func (m *Manager) deleteSpaceRecords(spaceID string) {
+	if m.db == nil {
+		return
+	}
+	m.db.Delete(dbTableSpaces, dbSpaceKeyPrefix+spaceID)
+	for _, table := range []string{dbTableItems, dbTableDocs} {
+		entries, err := m.db.ListTable(table)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			key := string(entry[0])
+			if strings.HasPrefix(key, spaceID+"/") {
+				m.db.Delete(table, key)
+			}
+		}
+	}
+}
+
+// loadPersistedSpaces rebuilds every persistent space from the database at
+// construction time, restoring items (with blobs) and documents.
+func (m *Manager) loadPersistedSpaces() {
+	entries, err := m.db.ListTable(dbTableSpaces)
+	if err != nil {
+		logger.PrintAndLog("SharedSpace", "Failed to list persisted spaces", err)
+		return
+	}
+
+	//1. Space records
+	for _, entry := range entries {
+		key := string(entry[0])
+		if !strings.HasPrefix(key, dbSpaceKeyPrefix) {
+			continue //conf/* and future keys
+		}
+		record := spaceRecord{}
+		if err := json.Unmarshal(entry[1], &record); err != nil || record.ID == "" {
+			logger.PrintAndLog("SharedSpace", "Dropping corrupted space record "+key, err)
+			m.db.Delete(dbTableSpaces, key)
+			continue
+		}
+		if !validAccessMode(record.Access) {
+			record.Access = AccessOpen
+		}
+		if record.MaxItems <= 0 {
+			record.MaxItems = m.defaultMaxItems
+		}
+		members := record.Members
+		if members == nil {
+			members = map[string]string{}
+		}
+		members[record.Owner] = RoleOwner
+		metadata := record.Metadata
+		if metadata == nil {
+			metadata = map[string]string{}
+		}
+		space := &Space{
+			ID:          record.ID,
+			Name:        record.Name,
+			Owner:       record.Owner,
+			access:      record.Access,
+			Persistent:  true,
+			CreatedAt:   time.Unix(record.CreatedAt, 0),
+			storageDir:  filepath.Join(m.persistRoot, record.ID),
+			metadata:    metadata,
+			members:     members,
+			docs:        make(map[string]*Doc),
+			items:       []*Item{},
+			itemIdx:     make(map[string]*Item),
+			listeners:   make(map[string]func(*Item)),
+			evListeners: make(map[string]func(*SpaceEvent)),
+			nextSeq:     1,
+			maxItems:    record.MaxItems,
+			trimOldest:  true,
+			mgr:         m,
+		}
+		m.spaces[space.ID] = space
+	}
+
+	//2. Item records
+	itemEntries, err := m.db.ListTable(dbTableItems)
+	if err == nil {
+		for _, entry := range itemEntries {
+			key := string(entry[0])
+			slash := strings.Index(key, "/")
+			if slash <= 0 {
+				m.db.Delete(dbTableItems, key)
+				continue
+			}
+			spaceID := key[:slash]
+			space, exists := m.spaces[spaceID]
+			if !exists {
+				m.db.Delete(dbTableItems, key) //space vanished: self-heal
+				continue
+			}
+			record := itemRecord{}
+			if err := json.Unmarshal(entry[1], &record); err != nil || record.ID == "" {
+				logger.PrintAndLog("SharedSpace", "Dropping corrupted item record "+key, err)
+				m.db.Delete(dbTableItems, key)
+				continue
+			}
+			item := &Item{
+				ID:        record.ID,
+				Type:      record.Type,
+				Name:      record.Name,
+				Text:      record.Text,
+				Size:      record.Size,
+				Uploader:  record.Uploader,
+				Origin:    record.Origin,
+				Seq:       record.Seq,
+				CreatedAt: time.Unix(record.CreatedAt, 0),
+			}
+			if record.HasBlob {
+				item.DiskPath = filepath.Join(m.persistRoot, spaceID, record.ID)
+				if _, err := os.Stat(item.DiskPath); err != nil {
+					m.db.Delete(dbTableItems, key) //blob vanished: self-heal
+					continue
+				}
+			}
+			space.items = append(space.items, item)
+			space.itemIdx[item.ID] = item
+		}
+	}
+
+	//3. Document records
+	docEntries, err := m.db.ListTable(dbTableDocs)
+	if err == nil {
+		for _, entry := range docEntries {
+			key := string(entry[0])
+			slash := strings.Index(key, "/")
+			if slash <= 0 {
+				m.db.Delete(dbTableDocs, key)
+				continue
+			}
+			spaceID := key[:slash]
+			space, exists := m.spaces[spaceID]
+			if !exists {
+				m.db.Delete(dbTableDocs, key)
+				continue
+			}
+			record := docRecord{}
+			if err := json.Unmarshal(entry[1], &record); err != nil || record.ID == "" {
+				logger.PrintAndLog("SharedSpace", "Dropping corrupted document record "+key, err)
+				m.db.Delete(dbTableDocs, key)
+				continue
+			}
+			space.docs[record.ID] = &Doc{
+				id:        record.ID,
+				name:      record.Name,
+				creator:   record.Creator,
+				createdAt: time.Unix(record.CreatedAt, 0),
+				content:   record.Content,
+				revision:  record.Revision,
+				updatedAt: time.Unix(record.UpdatedAt, 0),
+				updatedBy: record.UpdatedBy,
+			}
+		}
+	}
+
+	//4. Restore chronological ordering and the per-space sequence counter
+	loadedSpaces := 0
+	for _, space := range m.spaces {
+		sort.Slice(space.items, func(i, j int) bool {
+			return space.items[i].Seq < space.items[j].Seq
+		})
+		if count := len(space.items); count > 0 {
+			space.nextSeq = space.items[count-1].Seq + 1
+		}
+		loadedSpaces++
+	}
+
+	//5. Remove blob directories that no longer belong to a live space
+	if dirEntries, err := os.ReadDir(m.persistRoot); err == nil {
+		for _, dirEntry := range dirEntries {
+			if !dirEntry.IsDir() {
+				continue
+			}
+			if _, exists := m.spaces[dirEntry.Name()]; !exists {
+				os.RemoveAll(filepath.Join(m.persistRoot, dirEntry.Name()))
+			}
+		}
+	}
+
+	if loadedSpaces > 0 {
+		logger.PrintAndLog("SharedSpace", "Restored "+strconv.Itoa(loadedSpaces)+" persistent shared space(s)", nil)
+	}
+}
+
+// SweepStaleSpaces deletes persistent spaces whose most recent activity
+// (newest item, newest document update, or creation) is older than maxAge
+// and that have no live channel subscribers. It returns the IDs it deleted.
+// Ephemeral spaces are left to their owning subsystems (e.g. MeetRoom).
+func (m *Manager) SweepStaleSpaces(maxAge time.Duration) []string {
+	if maxAge <= 0 {
+		return nil
+	}
+	cutoff := time.Now().Add(-maxAge)
+
+	var stale []string
+	m.mu.RLock()
+	for id, space := range m.spaces {
+		if !space.Persistent {
+			continue
+		}
+		space.mu.Lock()
+		last := space.CreatedAt
+		for _, item := range space.items {
+			if item.CreatedAt.After(last) {
+				last = item.CreatedAt
+			}
+		}
+		for _, doc := range space.docs {
+			if doc.updatedAt.After(last) {
+				last = doc.updatedAt
+			}
+		}
+		channel := space.channel
+		space.mu.Unlock()
+		if channel != nil && channel.Count() > 0 {
+			continue
+		}
+		if last.Before(cutoff) {
+			stale = append(stale, id)
+		}
+	}
+	m.mu.RUnlock()
+
+	for _, id := range stale {
+		m.DeleteSpace(id)
+		logger.PrintAndLog("SharedSpace", "Removed stale shared space "+id, nil)
+	}
+	return stale
+}

--- a/src/mod/sharedspace/persistence_test.go
+++ b/src/mod/sharedspace/persistence_test.go
@@ -1,0 +1,312 @@
+package sharedspace
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"imuslab.com/arozos/mod/database"
+)
+
+// persistenceEnv keeps the shared db file + roots so a "restart" can be
+// simulated by building a second manager over the same state.
+type persistenceEnv struct {
+	dbfile      string
+	ephemeral   string
+	persistRoot string
+}
+
+func newPersistenceEnv(t *testing.T) *persistenceEnv {
+	t.Helper()
+	if raceDetectorEnabled {
+		t.Skip("boltdb v1.3.1 trips checkptr under -race; run without -race to cover persistence")
+	}
+	base := t.TempDir()
+	return &persistenceEnv{
+		dbfile:      filepath.Join(base, "test.db"),
+		ephemeral:   filepath.Join(base, "ephemeral"),
+		persistRoot: filepath.Join(base, "persist"),
+	}
+}
+
+// open builds a manager over the environment, closing the db at test end.
+func (env *persistenceEnv) open(t *testing.T) (*Manager, *database.Database) {
+	t.Helper()
+	db, err := database.NewDatabase(env.dbfile, false)
+	if err != nil {
+		t.Fatalf("NewDatabase() error = %v", err)
+	}
+	m := NewManagerWithOptions(ManagerOptions{
+		EphemeralRoot:  env.ephemeral,
+		PersistentRoot: env.persistRoot,
+		Database:       db,
+	})
+	return m, db
+}
+
+func TestPersistenceRoundTrip(t *testing.T) {
+	env := newPersistenceEnv(t)
+	m1, db1 := env.open(t)
+
+	//Build a persistent space with the full feature surface
+	space, err := m1.CreateSpaceWithOptions("alice", "Team chat", SpaceOptions{
+		Access:     AccessPrivate,
+		Persistent: true,
+		Metadata:   map[string]string{"purpose": "chat"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSpaceWithOptions() error = %v", err)
+	}
+	space.AddMember("alice", "bob", RoleAdmin)
+	space.SetMeta("alice", "topic", "launch")
+
+	textItem, err := space.AddText("alice", "first message", "test")
+	if err != nil {
+		t.Fatalf("AddText() error = %v", err)
+	}
+	blobItem, err := space.SaveBlob(ItemTypeImage, "pic.png", "bob", "test", strings.NewReader("png-bytes"), 1024)
+	if err != nil {
+		t.Fatalf("SaveBlob() error = %v", err)
+	}
+
+	doc, err := space.CreateDoc("alice", "spec")
+	if err != nil {
+		t.Fatalf("CreateDoc() error = %v", err)
+	}
+	space.UpdateDoc("alice", doc.ID, 1, "v2")
+	space.UpdateDoc("bob", doc.ID, 2, "v2 final")
+
+	//An ephemeral space must NOT survive
+	ephemeralSpace := m1.CreateSpace("alice", "throwaway")
+	ephemeralSpace.AddText("alice", "gone after restart", "test")
+
+	//Simulate a restart
+	db1.Close()
+	m2, db2 := env.open(t)
+	defer db2.Close()
+
+	if _, ok := m2.GetSpace(ephemeralSpace.ID); ok {
+		t.Errorf("ephemeral space survived the restart")
+	}
+	restored, ok := m2.GetSpace(space.ID)
+	if !ok {
+		t.Fatalf("persistent space did not survive the restart")
+	}
+
+	//Space-level state
+	if restored.Name != "Team chat" || restored.Owner != "alice" || !restored.Persistent {
+		t.Errorf("restored space = %+v", restored)
+	}
+	if restored.AccessMode() != AccessPrivate {
+		t.Errorf("restored access = %q, want private", restored.AccessMode())
+	}
+	if role, _ := restored.Role("bob"); role != RoleAdmin {
+		t.Errorf("restored bob role = %q, want admin", role)
+	}
+	meta := restored.Metadata()
+	if meta["purpose"] != "chat" || meta["topic"] != "launch" {
+		t.Errorf("restored metadata = %v", meta)
+	}
+
+	//Items: order, content and blob bytes
+	items := restored.Items()
+	if len(items) != 2 {
+		t.Fatalf("restored %d items, want 2", len(items))
+	}
+	if items[0].ID != textItem.ID || items[0].Text != "first message" {
+		t.Errorf("first restored item = %+v", items[0])
+	}
+	if items[1].ID != blobItem.ID || items[1].Type != ItemTypeImage {
+		t.Errorf("second restored item = %+v", items[1])
+	}
+	blobBytes, err := os.ReadFile(items[1].DiskPath)
+	if err != nil || !bytes.Equal(blobBytes, []byte("png-bytes")) {
+		t.Errorf("restored blob = %q, err = %v", blobBytes, err)
+	}
+
+	//New posts continue the sequence after the restored ones
+	newItem, err := restored.AddText("bob", "after restart", "test")
+	if err != nil {
+		t.Fatalf("AddText() after restore error = %v", err)
+	}
+	if newItem.Seq <= items[1].Seq {
+		t.Errorf("post-restart Seq %d not after restored max %d", newItem.Seq, items[1].Seq)
+	}
+
+	//Documents: content, revision and CAS across the restart
+	restoredDoc, ok := restored.GetDoc(doc.ID)
+	if !ok {
+		t.Fatalf("document did not survive the restart")
+	}
+	if restoredDoc.Content != "v2 final" || restoredDoc.Revision != 3 || restoredDoc.UpdatedBy != "bob" {
+		t.Errorf("restored doc = %+v", restoredDoc)
+	}
+	if _, err := restored.UpdateDoc("alice", doc.ID, 1, "stale"); err != ErrRevisionConflict {
+		t.Errorf("stale update after restart error = %v, want ErrRevisionConflict", err)
+	}
+	if _, err := restored.UpdateDoc("alice", doc.ID, 3, "v3"); err != nil {
+		t.Errorf("valid update after restart error = %v", err)
+	}
+}
+
+func TestPersistentDeletionCleansDatabase(t *testing.T) {
+	env := newPersistenceEnv(t)
+	m1, db1 := env.open(t)
+
+	space, _ := m1.CreateSpaceWithOptions("alice", "Doomed", SpaceOptions{Persistent: true})
+	space.AddText("alice", "message", "test")
+	blob, _ := space.SaveBlob(ItemTypeFile, "f.bin", "alice", "test", strings.NewReader("data"), 1024)
+	doc, _ := space.CreateDoc("alice", "doc")
+	_ = doc
+
+	removedItemID := blob.ID
+	space.RemoveItem(removedItemID, "alice")
+	if db1.KeyExists(dbTableItems, space.ID+"/"+removedItemID) {
+		t.Errorf("removed item record still in database")
+	}
+
+	m1.DeleteSpace(space.ID)
+	if db1.KeyExists(dbTableSpaces, dbSpaceKeyPrefix+space.ID) {
+		t.Errorf("space record still in database after DeleteSpace")
+	}
+
+	//After a restart nothing comes back
+	db1.Close()
+	m2, db2 := env.open(t)
+	defer db2.Close()
+	if m2.SpaceCount() != 0 {
+		t.Errorf("deleted space resurrected: %d spaces", m2.SpaceCount())
+	}
+}
+
+func TestReloadSelfHealing(t *testing.T) {
+	env := newPersistenceEnv(t)
+	m1, db1 := env.open(t)
+
+	space, _ := m1.CreateSpaceWithOptions("alice", "Healing", SpaceOptions{Persistent: true})
+	blob, _ := space.SaveBlob(ItemTypeFile, "f.bin", "alice", "test", strings.NewReader("data"), 1024)
+	keeper, _ := space.AddText("alice", "keeper", "test")
+
+	//Sabotage: blob file vanishes, an orphan item record points at a dead
+	//space, and an orphan blob directory has no space
+	os.Remove(blob.DiskPath)
+	db1.Write(dbTableItems, "deadspace/deaditem", &itemRecord{ID: "deaditem", Type: ItemTypeText, Text: "orphan"})
+	orphanDir := filepath.Join(env.persistRoot, "0000deadbeef0000")
+	os.MkdirAll(orphanDir, 0755)
+
+	db1.Close()
+	m2, db2 := env.open(t)
+	defer db2.Close()
+
+	restored, ok := m2.GetSpace(space.ID)
+	if !ok {
+		t.Fatalf("space did not survive")
+	}
+	items := restored.Items()
+	if len(items) != 1 || items[0].ID != keeper.ID {
+		t.Errorf("restored items = %d, want only the keeper", len(items))
+	}
+	if db2.KeyExists(dbTableItems, space.ID+"/"+blob.ID) {
+		t.Errorf("missing-blob item record not self-healed")
+	}
+	if db2.KeyExists(dbTableItems, "deadspace/deaditem") {
+		t.Errorf("orphan item record not self-healed")
+	}
+	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
+		t.Errorf("orphan blob directory not removed")
+	}
+}
+
+func TestPersistentTrimAtCap(t *testing.T) {
+	env := newPersistenceEnv(t)
+	m, db := env.open(t)
+	defer db.Close()
+
+	space, _ := m.CreateSpaceWithOptions("alice", "Trim", SpaceOptions{Persistent: true, MaxItems: 3})
+	first, _ := space.AddText("alice", "one", "test")
+	space.AddText("alice", "two", "test")
+	space.AddText("alice", "three", "test")
+
+	//Persistent spaces trim the oldest instead of failing
+	fourth, err := space.AddText("alice", "four", "test")
+	if err != nil {
+		t.Fatalf("AddText at cap error = %v (persistent spaces must trim)", err)
+	}
+	if space.ItemCount() != 3 {
+		t.Errorf("ItemCount() = %d, want 3", space.ItemCount())
+	}
+	if _, ok := space.GetItem(first.ID); ok {
+		t.Errorf("oldest item still present after trim")
+	}
+	if db.KeyExists(dbTableItems, space.ID+"/"+first.ID) {
+		t.Errorf("trimmed item record still in database")
+	}
+	if _, ok := space.GetItem(fourth.ID); !ok {
+		t.Errorf("newest item missing after trim")
+	}
+}
+
+func TestPersistenceToggle(t *testing.T) {
+	env := newPersistenceEnv(t)
+	m, db := env.open(t)
+	defer db.Close()
+
+	if !m.PersistenceAvailable() {
+		t.Fatalf("PersistenceAvailable() = false on a persistence-enabled manager")
+	}
+	m.SetAllowPersistent(false)
+	if m.PersistenceAvailable() {
+		t.Errorf("PersistenceAvailable() = true after disable")
+	}
+	if _, err := m.CreateSpaceWithOptions("alice", "x", SpaceOptions{Persistent: true}); err != ErrPersistenceOff {
+		t.Errorf("persistent create while disabled error = %v, want ErrPersistenceOff", err)
+	}
+	m.SetAllowPersistent(true)
+	if _, err := m.CreateSpaceWithOptions("alice", "x", SpaceOptions{Persistent: true}); err != nil {
+		t.Errorf("persistent create after re-enable error = %v", err)
+	}
+}
+
+func TestSweepStaleSpaces(t *testing.T) {
+	env := newPersistenceEnv(t)
+	m, db := env.open(t)
+	defer db.Close()
+
+	stale, _ := m.CreateSpaceWithOptions("alice", "Stale", SpaceOptions{Persistent: true})
+	fresh, _ := m.CreateSpaceWithOptions("alice", "Fresh", SpaceOptions{Persistent: true})
+	fresh.AddText("alice", "recent activity", "test")
+	occupied, _ := m.CreateSpaceWithOptions("alice", "Occupied", SpaceOptions{Persistent: true})
+	occupied.Channel().Join("alice")
+	ephemeral := m.CreateSpace("alice", "Ephemeral")
+
+	//Backdate the stale and occupied spaces
+	for _, space := range []*Space{stale, occupied} {
+		space.mu.Lock()
+		space.CreatedAt = time.Now().Add(-48 * time.Hour)
+		space.mu.Unlock()
+	}
+	ephemeral.mu.Lock()
+	ephemeral.CreatedAt = time.Now().Add(-48 * time.Hour)
+	ephemeral.mu.Unlock()
+
+	swept := m.SweepStaleSpaces(24 * time.Hour)
+	if len(swept) != 1 || swept[0] != stale.ID {
+		t.Errorf("SweepStaleSpaces() = %v, want [%s]", swept, stale.ID)
+	}
+	if _, ok := m.GetSpace(fresh.ID); !ok {
+		t.Errorf("fresh space was swept")
+	}
+	if _, ok := m.GetSpace(occupied.ID); !ok {
+		t.Errorf("occupied space was swept despite live subscriber")
+	}
+	if _, ok := m.GetSpace(ephemeral.ID); !ok {
+		t.Errorf("ephemeral space was swept (not this sweeper's job)")
+	}
+	//maxAge <= 0 disables the sweep
+	if swept := m.SweepStaleSpaces(0); swept != nil {
+		t.Errorf("SweepStaleSpaces(0) = %v, want nil", swept)
+	}
+}

--- a/src/mod/sharedspace/race_disabled_test.go
+++ b/src/mod/sharedspace/race_disabled_test.go
@@ -1,0 +1,7 @@
+//go:build !race
+
+package sharedspace
+
+// raceDetectorEnabled reports whether this test binary was built with the
+// race detector; see race_enabled_test.go.
+const raceDetectorEnabled = false

--- a/src/mod/sharedspace/race_enabled_test.go
+++ b/src/mod/sharedspace/race_enabled_test.go
@@ -1,0 +1,10 @@
+//go:build race
+
+package sharedspace
+
+// raceDetectorEnabled reports whether this test binary was built with the
+// race detector. The bundled boltdb v1.3.1 performs unsafe pointer
+// arithmetic that trips the race detector's checkptr instrumentation, so
+// database-backed tests skip themselves under -race (CI runs the full
+// suite without -race, where they always execute).
+const raceDetectorEnabled = true

--- a/src/mod/sharedspace/sharedspace.go
+++ b/src/mod/sharedspace/sharedspace.go
@@ -4,17 +4,38 @@ package sharedspace
 	SharedSpace - Multi-user shared collaboration area
 	author: tobychui / AI assisted
 
-	A shared space is a named, in-memory area where multiple different
-	users can share text snippets, images and files together. Spaces are
-	addressed by a random ID that acts as the access capability: any
-	logged-in user who knows the ID can read and post items. Blob items
-	(images / files) are stored on local disk until the space is deleted;
-	like meeting rooms, spaces never survive a server restart.
+	A shared space is a named area where multiple different users can
+	share text snippets, images, files and collaboratively edited
+	documents together. Spaces are the collaboration backbone of ArozOS:
+	chat-style apps, document collaboration and even video conferencing
+	(MeetRoom) are built on top of them.
+
+	Access control (access.go): a space is "open" (the random space ID
+	acts as the access capability - anyone who knows it can read and
+	post), "public" (discoverable in a directory, any logged-in user can
+	self-join) or "private" (members only, invited by the owner or a
+	space admin). Every space carries a member list with owner / admin /
+	member roles and a small metadata key-value store.
+
+	Persistence (persistence.go): a space is either ephemeral (in-memory
+	only, blobs in temporary storage, gone after a restart - e.g. the
+	space bound to a MeetRoom meeting) or persistent (space, items and
+	documents write through to the system database and blobs live in a
+	durable storage root, surviving restarts - e.g. a Teams/Slack style
+	chat room).
+
+	Realtime (channel.go): every space owns a Channel, a WebSocket-ready
+	fan-out hub with numbered subscribers, targeted send and broadcast.
+	Item / document / membership mutations additionally emit SpaceEvents
+	to in-process listeners so transports can push them to clients live.
+
+	Documents (doc.go): revision-numbered collaborative documents with
+	compare-and-swap updates and splice patches for realtime co-editing.
 
 	The package is consumer-agnostic: the AGI "sharedspace" library
-	exposes it to server-side scripts, and mod/meetroom binds one space
-	to every meeting room so in-meeting chat and file sharing land in a
-	space that AGI scripts can read from and post into.
+	exposes it to server-side scripts, the /system/sharedspace/* HTTP and
+	WebSocket endpoints expose it to web clients, and mod/meetroom runs
+	its meeting signaling over space channels.
 */
 
 import (
@@ -27,6 +48,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"imuslab.com/arozos/mod/database"
 )
 
 var (
@@ -44,8 +67,30 @@ var (
 	ErrInvalidItemType = errors.New("invalid item type")
 	//ErrEmptyText is returned when adding a text item with no content
 	ErrEmptyText = errors.New("empty text item")
-	//ErrPermissionDenied is returned when the requester may not modify the target
+	//ErrPermissionDenied is returned when the requester may not perform the action
 	ErrPermissionDenied = errors.New("permission denied")
+	//ErrInvalidAccess is returned for unknown space access modes
+	ErrInvalidAccess = errors.New("invalid access mode")
+	//ErrInvalidRole is returned for unknown member roles
+	ErrInvalidRole = errors.New("invalid member role")
+	//ErrNotMember is returned when the target user is not a member of the space
+	ErrNotMember = errors.New("not a member of this space")
+	//ErrMemberExists is returned when inviting a user who is already a member
+	ErrMemberExists = errors.New("already a member")
+	//ErrSpaceMemberLimit is returned when a space reached its member limit
+	ErrSpaceMemberLimit = errors.New("member limit reached")
+	//ErrMetadataLimit is returned when a space reached its metadata entry limit
+	ErrMetadataLimit = errors.New("metadata entry limit reached")
+	//ErrPersistenceOff is returned when persistent spaces are unavailable or disabled
+	ErrPersistenceOff = errors.New("persistence not available")
+	//ErrRevisionConflict is returned when a document update carries a stale base revision
+	ErrRevisionConflict = errors.New("document revision conflict")
+	//ErrDocNotFound is returned when the requested document ID does not exist
+	ErrDocNotFound = errors.New("document not found")
+	//ErrDocLimitReached is returned when a space reached its document limit
+	ErrDocLimitReached = errors.New("document limit reached")
+	//ErrDocTooLarge is returned when a document update exceeds the size limit
+	ErrDocTooLarge = errors.New("document exceeds size limit")
 )
 
 const (
@@ -54,13 +99,37 @@ const (
 	ItemTypeImage = "image"
 	ItemTypeFile  = "file"
 
-	spaceIDBytes     = 8         // random bytes per space ID (hex encoded to 16 chars)
-	itemIDBytes      = 16        // random bytes per item ID
-	maxSpaceName     = 64        // space names are clipped to this many runes
-	maxItemName      = 128       // item display names are clipped to this many runes
-	maxTextLength    = 4000      // runes per text item
-	DefaultMaxUpload = 128 << 20 // 128MB per blob item
-	DefaultMaxItems  = 1024      // items per space before posting fails
+	//Space access modes
+	AccessOpen    = "open"    // space ID is the capability; anyone who knows it may read/post
+	AccessPublic  = "public"  // listed in the public directory; any logged-in user may self-join
+	AccessPrivate = "private" // members only; owner / space admins invite
+
+	//Member roles
+	RoleOwner  = "owner"
+	RoleAdmin  = "admin"
+	RoleMember = "member"
+
+	spaceIDBytes      = 8         // random bytes per space ID (hex encoded to 16 chars)
+	itemIDBytes       = 16        // random bytes per item ID
+	maxSpaceName      = 64        // space names are clipped to this many runes
+	maxItemName       = 128       // item display names are clipped to this many runes
+	maxTextLength     = 4000      // runes per text item
+	maxMetadataKeys   = 32        // metadata entries per space
+	maxMetadataKeyLen = 64        // runes per metadata key
+	maxMetadataValLen = 1024      // runes per metadata value
+	maxMembers        = 512       // members per space
+	DefaultMaxUpload  = 128 << 20 // 128MB per blob item
+	DefaultMaxItems   = 1024      // items per space before posting fails / trims
+)
+
+// Space event kinds delivered to SubscribeEvents listeners.
+const (
+	EventItemAdded     = "item-added"
+	EventItemRemoved   = "item-removed"
+	EventDocCreated    = "doc-created"
+	EventDocUpdated    = "doc-updated"
+	EventDocDeleted    = "doc-deleted"
+	EventMemberChanged = "member-changed"
 )
 
 // imageExtensions lists the raster formats treated as inline-displayable
@@ -79,8 +148,21 @@ type Item struct {
 	Size      int64
 	Uploader  string
 	Origin    string // free-form tag identifying which subsystem posted the item
+	Seq       int64  // per-space monotonic sequence, restores ordering on reload
 	CreatedAt time.Time
 	DiskPath  string // blob location on disk, empty for text items
+}
+
+// SpaceEvent describes a mutation inside a space, delivered synchronously to
+// SubscribeEvents listeners so transports can fan it out to live clients.
+type SpaceEvent struct {
+	Kind   string       // one of the Event* constants
+	Item   *Item        // set for item-* events
+	Doc    *DocSnapshot // set for doc-* events
+	Patch  *DocPatch    // set for doc-updated events
+	Member string       // set for member-changed events
+	Role   string       // set for member-changed add / role events
+	Action string       // member-changed action: "add", "remove" or "role"
 }
 
 // Space is one live shared area.
@@ -88,48 +170,157 @@ type Space struct {
 	ID         string
 	Name       string
 	Owner      string
+	Persistent bool // write-through to the system database + durable blob storage
 	CreatedAt  time.Time
-	storageDir string
-	items      []*Item // chronological order
-	itemIdx    map[string]*Item
-	listeners  map[string]func(*Item)
-	maxItems   int
-	closed     bool
-	mu         sync.Mutex
+
+	access      string // AccessOpen, AccessPublic or AccessPrivate; guarded by mu (see AccessMode)
+	storageDir  string
+	metadata    map[string]string
+	members     map[string]string // username -> role; the owner is always present
+	docs        map[string]*Doc
+	items       []*Item // chronological order
+	itemIdx     map[string]*Item
+	listeners   map[string]func(*Item)
+	evListeners map[string]func(*SpaceEvent)
+	channel     *Channel // lazily created realtime hub, stable once created
+	nextSeq     int64
+	maxItems    int
+	trimOldest  bool // drop the oldest item at the cap instead of failing (chat semantics)
+	closed      bool
+	mgr         *Manager // owning manager, for persistence write-through
+	mu          sync.Mutex
 }
 
 // Manager owns all live spaces and their blob storage.
 type Manager struct {
-	spaces      map[string]*Space
-	storageRoot string
-	maxUpload   int64
-	mu          sync.RWMutex
+	spaces          map[string]*Space
+	storageRoot     string             // ephemeral blob root, wiped at construction
+	persistRoot     string             // durable blob root, never wiped ("" disables persistence)
+	db              *database.Database // nil disables persistence
+	maxUpload       int64
+	defaultMaxItems int
+	allowPersistent bool
+	mu              sync.RWMutex
 }
 
-// NewManager creates a space manager. storageRoot is the directory used for
-// blob storage; pass "" to use a folder inside os.TempDir(). maxUpload is the
-// per-item blob size limit in bytes; pass 0 for DefaultMaxUpload. Any leftover
-// blob files from a previous run are removed.
+// ManagerOptions configures NewManagerWithOptions.
+type ManagerOptions struct {
+	EphemeralRoot   string             // "" -> a folder inside os.TempDir(); wiped at construction
+	PersistentRoot  string             // durable blob root, e.g. "system/sharedspace"; "" disables persistence
+	MaxUpload       int64              // per-blob size limit; 0 -> DefaultMaxUpload
+	DefaultMaxItems int                // per-space item cap; 0 -> DefaultMaxItems
+	Database        *database.Database // nil disables persistence
+}
+
+// SpaceOptions configures CreateSpaceWithOptions.
+type SpaceOptions struct {
+	Access     string            // "" -> AccessOpen
+	Persistent bool              // survive restarts (requires a persistence-enabled manager)
+	Metadata   map[string]string // initial metadata (validated and clipped)
+	MaxItems   int               // 0 -> manager default
+}
+
+// NewManager creates a memory-only space manager: every space is ephemeral
+// and gone after a restart. storageRoot is the directory used for blob
+// storage; pass "" to use a folder inside os.TempDir(). maxUpload is the
+// per-item blob size limit in bytes; pass 0 for DefaultMaxUpload. Any
+// leftover blob files from a previous run are removed.
 func NewManager(storageRoot string, maxUpload int64) *Manager {
-	if storageRoot == "" {
-		storageRoot = filepath.Join(os.TempDir(), "arozos", "sharedspace")
+	return NewManagerWithOptions(ManagerOptions{
+		EphemeralRoot: storageRoot,
+		MaxUpload:     maxUpload,
+	})
+}
+
+// NewManagerWithOptions creates a space manager. When both a database and a
+// persistent root are supplied, spaces created with SpaceOptions.Persistent
+// survive restarts: their records are reloaded from the database and their
+// blobs from the persistent root (which is never wiped). The ephemeral root
+// is always cleared at construction.
+func NewManagerWithOptions(opt ManagerOptions) *Manager {
+	ephemeralRoot := opt.EphemeralRoot
+	if ephemeralRoot == "" {
+		ephemeralRoot = filepath.Join(os.TempDir(), "arozos", "sharedspace")
 	}
+	maxUpload := opt.MaxUpload
 	if maxUpload <= 0 {
 		maxUpload = DefaultMaxUpload
 	}
-	//Spaces are in-memory only: blobs never survive a restart
-	os.RemoveAll(storageRoot)
-	os.MkdirAll(storageRoot, 0755)
-	return &Manager{
-		spaces:      make(map[string]*Space),
-		storageRoot: storageRoot,
-		maxUpload:   maxUpload,
+	defaultMaxItems := opt.DefaultMaxItems
+	if defaultMaxItems <= 0 {
+		defaultMaxItems = DefaultMaxItems
 	}
+
+	//Ephemeral blobs never survive a restart
+	os.RemoveAll(ephemeralRoot)
+	os.MkdirAll(ephemeralRoot, 0755)
+
+	m := &Manager{
+		spaces:          make(map[string]*Space),
+		storageRoot:     ephemeralRoot,
+		maxUpload:       maxUpload,
+		defaultMaxItems: defaultMaxItems,
+	}
+
+	if opt.Database != nil && opt.PersistentRoot != "" {
+		m.db = opt.Database
+		m.persistRoot = opt.PersistentRoot
+		m.allowPersistent = true
+		os.MkdirAll(m.persistRoot, 0755)
+		m.initPersistenceTables()
+		m.loadPersistedSpaces()
+	}
+	return m
 }
 
 // MaxUpload returns the per-item blob size limit of this manager.
 func (m *Manager) MaxUpload() int64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.maxUpload
+}
+
+// SetMaxUpload updates the per-item blob size limit (admin configuration).
+func (m *Manager) SetMaxUpload(limit int64) {
+	if limit <= 0 {
+		limit = DefaultMaxUpload
+	}
+	m.mu.Lock()
+	m.maxUpload = limit
+	m.mu.Unlock()
+}
+
+// DefaultItemLimit returns the item cap applied to newly created spaces.
+func (m *Manager) DefaultItemLimit() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.defaultMaxItems
+}
+
+// SetDefaultItemLimit updates the item cap for newly created spaces.
+func (m *Manager) SetDefaultItemLimit(limit int) {
+	if limit <= 0 {
+		limit = DefaultMaxItems
+	}
+	m.mu.Lock()
+	m.defaultMaxItems = limit
+	m.mu.Unlock()
+}
+
+// PersistenceAvailable reports whether persistent spaces can currently be
+// created (persistence wired in and not disabled by an administrator).
+func (m *Manager) PersistenceAvailable() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.db != nil && m.persistRoot != "" && m.allowPersistent
+}
+
+// SetAllowPersistent enables or disables the creation of new persistent
+// spaces (admin configuration). Existing persistent spaces are unaffected.
+func (m *Manager) SetAllowPersistent(allow bool) {
+	m.mu.Lock()
+	m.allowPersistent = allow
+	m.mu.Unlock()
 }
 
 // randomID returns n random bytes hex encoded.
@@ -160,11 +351,35 @@ func IsImageName(name string) bool {
 	return false
 }
 
-// CreateSpace creates a new space owned by owner. The generated space ID is
-// unique among live spaces.
+// validAccessMode reports whether access is a known space access mode.
+func validAccessMode(access string) bool {
+	return access == AccessOpen || access == AccessPublic || access == AccessPrivate
+}
+
+// CreateSpace creates a new open, ephemeral space owned by owner - the
+// behaviour every pre-existing consumer (MeetRoom, AGI scripts) relies on.
 func (m *Manager) CreateSpace(owner string, name string) *Space {
+	space, _ := m.CreateSpaceWithOptions(owner, name, SpaceOptions{})
+	return space
+}
+
+// CreateSpaceWithOptions creates a new space owned by owner. The generated
+// space ID is unique among live spaces. Persistent spaces require a
+// persistence-enabled manager (ErrPersistenceOff otherwise).
+func (m *Manager) CreateSpaceWithOptions(owner string, name string, opt SpaceOptions) (*Space, error) {
+	access := opt.Access
+	if access == "" {
+		access = AccessOpen
+	}
+	if !validAccessMode(access) {
+		return nil, ErrInvalidAccess
+	}
+
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	if opt.Persistent && (m.db == nil || m.persistRoot == "" || !m.allowPersistent) {
+		m.mu.Unlock()
+		return nil, ErrPersistenceOff
+	}
 
 	var id string
 	for {
@@ -179,19 +394,39 @@ func (m *Manager) CreateSpace(owner string, name string) *Space {
 		name = owner + "'s space"
 	}
 
+	maxItems := opt.MaxItems
+	if maxItems <= 0 {
+		maxItems = m.defaultMaxItems
+	}
+
 	space := &Space{
-		ID:         id,
-		Name:       name,
-		Owner:      owner,
-		CreatedAt:  time.Now(),
-		storageDir: filepath.Join(m.storageRoot, id),
-		items:      []*Item{},
-		itemIdx:    make(map[string]*Item),
-		listeners:  make(map[string]func(*Item)),
-		maxItems:   DefaultMaxItems,
+		ID:          id,
+		Name:        name,
+		Owner:       owner,
+		access:      access,
+		Persistent:  opt.Persistent,
+		CreatedAt:   time.Now(),
+		storageDir:  filepath.Join(m.storageRoot, id),
+		metadata:    sanitizeMetadata(opt.Metadata),
+		members:     map[string]string{owner: RoleOwner},
+		docs:        make(map[string]*Doc),
+		items:       []*Item{},
+		itemIdx:     make(map[string]*Item),
+		listeners:   make(map[string]func(*Item)),
+		evListeners: make(map[string]func(*SpaceEvent)),
+		nextSeq:     1,
+		maxItems:    maxItems,
+		trimOldest:  opt.Persistent, // persistent chat rooms trim; ephemeral spaces fail at the cap
+		mgr:         m,
+	}
+	if opt.Persistent {
+		space.storageDir = filepath.Join(m.persistRoot, id)
 	}
 	m.spaces[id] = space
-	return space
+	m.mu.Unlock()
+
+	m.persistSpace(space)
+	return space, nil
 }
 
 // GetSpace returns the live space with the given ID.
@@ -222,8 +457,9 @@ func (m *Manager) SpaceCount() int {
 	return len(m.spaces)
 }
 
-// DeleteSpace removes a space and its blob files. It reports whether the
-// space existed. Safe to call on an unknown ID.
+// DeleteSpace removes a space, its realtime channel, its blob files and (for
+// persistent spaces) its database records. It reports whether the space
+// existed. Safe to call on an unknown ID.
 func (m *Manager) DeleteSpace(id string) bool {
 	m.mu.Lock()
 	space, exists := m.spaces[id]
@@ -239,10 +475,19 @@ func (m *Manager) DeleteSpace(id string) bool {
 	space.closed = true
 	space.items = []*Item{}
 	space.itemIdx = make(map[string]*Item)
+	space.docs = make(map[string]*Doc)
 	space.listeners = make(map[string]func(*Item))
+	space.evListeners = make(map[string]func(*SpaceEvent))
+	channel := space.channel
 	space.mu.Unlock()
 
+	if channel != nil {
+		channel.Close()
+	}
 	os.RemoveAll(space.storageDir)
+	if space.Persistent {
+		m.deleteSpaceRecords(id)
+	}
 	return true
 }
 
@@ -254,15 +499,30 @@ func (s *Space) Subscribe(key string, fn func(*Item)) {
 	s.listeners[key] = fn
 }
 
-// Unsubscribe removes a previously registered listener.
+// Unsubscribe removes a previously registered item listener.
 func (s *Space) Unsubscribe(key string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.listeners, key)
 }
 
-// notify invokes every listener with the freshly added item. Callers must
-// not hold s.mu.
+// SubscribeEvents registers a listener invoked (synchronously) for every
+// space mutation event. Re-using a key replaces the previous listener.
+func (s *Space) SubscribeEvents(key string, fn func(*SpaceEvent)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.evListeners[key] = fn
+}
+
+// UnsubscribeEvents removes a previously registered event listener.
+func (s *Space) UnsubscribeEvents(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.evListeners, key)
+}
+
+// notify invokes every item listener with the freshly added item. Callers
+// must not hold s.mu.
 func (s *Space) notify(item *Item) {
 	s.mu.Lock()
 	fns := make([]func(*Item), 0, len(s.listeners))
@@ -275,22 +535,55 @@ func (s *Space) notify(item *Item) {
 	}
 }
 
-// register appends a fully built item to the space. Callers must not hold
-// s.mu. Listeners fire after the item is registered.
+// emitEvent invokes every event listener with the given event. Callers must
+// not hold s.mu.
+func (s *Space) emitEvent(event *SpaceEvent) {
+	s.mu.Lock()
+	fns := make([]func(*SpaceEvent), 0, len(s.evListeners))
+	for _, fn := range s.evListeners {
+		fns = append(fns, fn)
+	}
+	s.mu.Unlock()
+	for _, fn := range fns {
+		fn(event)
+	}
+}
+
+// register appends a fully built item to the space, trimming the oldest item
+// first when a trim-enabled space is at its cap. Callers must not hold s.mu.
+// Listeners and events fire after the item is registered.
 func (s *Space) register(item *Item) error {
+	var victim *Item
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
 		return ErrSpaceClosed
 	}
 	if len(s.items) >= s.maxItems {
-		s.mu.Unlock()
-		return ErrSpaceFull
+		if !s.trimOldest {
+			s.mu.Unlock()
+			return ErrSpaceFull
+		}
+		victim = s.items[0]
+		s.items = s.items[1:]
+		delete(s.itemIdx, victim.ID)
 	}
+	item.Seq = s.nextSeq
+	s.nextSeq++
 	s.items = append(s.items, item)
 	s.itemIdx[item.ID] = item
 	s.mu.Unlock()
+
+	if victim != nil {
+		if victim.DiskPath != "" {
+			os.Remove(victim.DiskPath)
+		}
+		s.mgrDeleteItemRecord(victim.ID)
+		s.emitEvent(&SpaceEvent{Kind: EventItemRemoved, Item: victim})
+	}
+	s.mgrPersistItem(item)
 	s.notify(item)
+	s.emitEvent(&SpaceEvent{Kind: EventItemAdded, Item: item})
 	return nil
 }
 
@@ -391,8 +684,8 @@ func (s *Space) ItemCount() int {
 }
 
 // RemoveItem deletes an item (and its blob file) from the space. Only the
-// item's uploader, the space owner, or the system (empty requester) may
-// remove an item.
+// item's uploader, the space owner, a space admin, or the system (empty
+// requester) may remove an item.
 func (s *Space) RemoveItem(itemID string, requester string) error {
 	s.mu.Lock()
 	item, ok := s.itemIdx[itemID]
@@ -400,7 +693,7 @@ func (s *Space) RemoveItem(itemID string, requester string) error {
 		s.mu.Unlock()
 		return ErrItemNotFound
 	}
-	if requester != "" && requester != item.Uploader && requester != s.Owner {
+	if requester != "" && requester != item.Uploader && requester != s.Owner && s.members[requester] != RoleAdmin {
 		s.mu.Unlock()
 		return ErrPermissionDenied
 	}
@@ -416,5 +709,7 @@ func (s *Space) RemoveItem(itemID string, requester string) error {
 	if item.DiskPath != "" {
 		os.Remove(item.DiskPath)
 	}
+	s.mgrDeleteItemRecord(itemID)
+	s.emitEvent(&SpaceEvent{Kind: EventItemRemoved, Item: item})
 	return nil
 }

--- a/src/mod/sharedspace/sharedspace.go
+++ b/src/mod/sharedspace/sharedspace.go
@@ -1,0 +1,420 @@
+package sharedspace
+
+/*
+	SharedSpace - Multi-user shared collaboration area
+	author: tobychui / AI assisted
+
+	A shared space is a named, in-memory area where multiple different
+	users can share text snippets, images and files together. Spaces are
+	addressed by a random ID that acts as the access capability: any
+	logged-in user who knows the ID can read and post items. Blob items
+	(images / files) are stored on local disk until the space is deleted;
+	like meeting rooms, spaces never survive a server restart.
+
+	The package is consumer-agnostic: the AGI "sharedspace" library
+	exposes it to server-side scripts, and mod/meetroom binds one space
+	to every meeting room so in-meeting chat and file sharing land in a
+	space that AGI scripts can read from and post into.
+*/
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	//ErrSpaceNotFound is returned when the requested space ID does not exist
+	ErrSpaceNotFound = errors.New("shared space not found")
+	//ErrSpaceClosed is returned when posting into a deleted space
+	ErrSpaceClosed = errors.New("shared space closed")
+	//ErrSpaceFull is returned when a space reached its item limit
+	ErrSpaceFull = errors.New("shared space item limit reached")
+	//ErrItemNotFound is returned when the requested item ID does not exist
+	ErrItemNotFound = errors.New("item not found")
+	//ErrItemTooLarge is returned when an uploaded blob exceeds the size limit
+	ErrItemTooLarge = errors.New("item exceeds size limit")
+	//ErrInvalidItemType is returned for item types other than text / image / file
+	ErrInvalidItemType = errors.New("invalid item type")
+	//ErrEmptyText is returned when adding a text item with no content
+	ErrEmptyText = errors.New("empty text item")
+	//ErrPermissionDenied is returned when the requester may not modify the target
+	ErrPermissionDenied = errors.New("permission denied")
+)
+
+const (
+	//Item types storable in a space
+	ItemTypeText  = "text"
+	ItemTypeImage = "image"
+	ItemTypeFile  = "file"
+
+	spaceIDBytes     = 8         // random bytes per space ID (hex encoded to 16 chars)
+	itemIDBytes      = 16        // random bytes per item ID
+	maxSpaceName     = 64        // space names are clipped to this many runes
+	maxItemName      = 128       // item display names are clipped to this many runes
+	maxTextLength    = 4000      // runes per text item
+	DefaultMaxUpload = 128 << 20 // 128MB per blob item
+	DefaultMaxItems  = 1024      // items per space before posting fails
+)
+
+// imageExtensions lists the raster formats treated as inline-displayable
+// images. SVG is deliberately excluded: serving user-uploaded SVG inline
+// from the ArozOS origin would allow script execution.
+var imageExtensions = []string{".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+
+// Item is one entry shared into a space: a text snippet or an image / file
+// blob stored on disk. Blobs are addressed by a random ID so the original
+// file name never becomes part of a filesystem path.
+type Item struct {
+	ID        string
+	Type      string // ItemTypeText, ItemTypeImage or ItemTypeFile
+	Name      string // display name of image / file items
+	Text      string // content of text items
+	Size      int64
+	Uploader  string
+	Origin    string // free-form tag identifying which subsystem posted the item
+	CreatedAt time.Time
+	DiskPath  string // blob location on disk, empty for text items
+}
+
+// Space is one live shared area.
+type Space struct {
+	ID         string
+	Name       string
+	Owner      string
+	CreatedAt  time.Time
+	storageDir string
+	items      []*Item // chronological order
+	itemIdx    map[string]*Item
+	listeners  map[string]func(*Item)
+	maxItems   int
+	closed     bool
+	mu         sync.Mutex
+}
+
+// Manager owns all live spaces and their blob storage.
+type Manager struct {
+	spaces      map[string]*Space
+	storageRoot string
+	maxUpload   int64
+	mu          sync.RWMutex
+}
+
+// NewManager creates a space manager. storageRoot is the directory used for
+// blob storage; pass "" to use a folder inside os.TempDir(). maxUpload is the
+// per-item blob size limit in bytes; pass 0 for DefaultMaxUpload. Any leftover
+// blob files from a previous run are removed.
+func NewManager(storageRoot string, maxUpload int64) *Manager {
+	if storageRoot == "" {
+		storageRoot = filepath.Join(os.TempDir(), "arozos", "sharedspace")
+	}
+	if maxUpload <= 0 {
+		maxUpload = DefaultMaxUpload
+	}
+	//Spaces are in-memory only: blobs never survive a restart
+	os.RemoveAll(storageRoot)
+	os.MkdirAll(storageRoot, 0755)
+	return &Manager{
+		spaces:      make(map[string]*Space),
+		storageRoot: storageRoot,
+		maxUpload:   maxUpload,
+	}
+}
+
+// MaxUpload returns the per-item blob size limit of this manager.
+func (m *Manager) MaxUpload() int64 {
+	return m.maxUpload
+}
+
+// randomID returns n random bytes hex encoded.
+func randomID(n int) string {
+	idBytes := make([]byte, n)
+	rand.Read(idBytes)
+	return hex.EncodeToString(idBytes)
+}
+
+// clipString trims s to at most max runes.
+func clipString(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) > max {
+		return string(runes[:max])
+	}
+	return s
+}
+
+// IsImageName reports whether the display name looks like an inline-safe
+// raster image, used to classify uploads and to gate inline serving.
+func IsImageName(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	for _, imgExt := range imageExtensions {
+		if ext == imgExt {
+			return true
+		}
+	}
+	return false
+}
+
+// CreateSpace creates a new space owned by owner. The generated space ID is
+// unique among live spaces.
+func (m *Manager) CreateSpace(owner string, name string) *Space {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var id string
+	for {
+		id = randomID(spaceIDBytes)
+		if _, exists := m.spaces[id]; !exists {
+			break
+		}
+	}
+
+	name = clipString(name, maxSpaceName)
+	if name == "" {
+		name = owner + "'s space"
+	}
+
+	space := &Space{
+		ID:         id,
+		Name:       name,
+		Owner:      owner,
+		CreatedAt:  time.Now(),
+		storageDir: filepath.Join(m.storageRoot, id),
+		items:      []*Item{},
+		itemIdx:    make(map[string]*Item),
+		listeners:  make(map[string]func(*Item)),
+		maxItems:   DefaultMaxItems,
+	}
+	m.spaces[id] = space
+	return space
+}
+
+// GetSpace returns the live space with the given ID.
+func (m *Manager) GetSpace(id string) (*Space, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	space, ok := m.spaces[id]
+	return space, ok
+}
+
+// ListSpacesByOwner returns a snapshot of the spaces owned by owner.
+func (m *Manager) ListSpacesByOwner(owner string) []*Space {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	owned := []*Space{}
+	for _, space := range m.spaces {
+		if space.Owner == owner {
+			owned = append(owned, space)
+		}
+	}
+	return owned
+}
+
+// SpaceCount returns the number of live spaces.
+func (m *Manager) SpaceCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.spaces)
+}
+
+// DeleteSpace removes a space and its blob files. It reports whether the
+// space existed. Safe to call on an unknown ID.
+func (m *Manager) DeleteSpace(id string) bool {
+	m.mu.Lock()
+	space, exists := m.spaces[id]
+	if exists {
+		delete(m.spaces, id)
+	}
+	m.mu.Unlock()
+	if !exists {
+		return false
+	}
+
+	space.mu.Lock()
+	space.closed = true
+	space.items = []*Item{}
+	space.itemIdx = make(map[string]*Item)
+	space.listeners = make(map[string]func(*Item))
+	space.mu.Unlock()
+
+	os.RemoveAll(space.storageDir)
+	return true
+}
+
+// Subscribe registers a listener invoked (synchronously) for every item
+// posted into the space. Re-using a key replaces the previous listener.
+func (s *Space) Subscribe(key string, fn func(*Item)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listeners[key] = fn
+}
+
+// Unsubscribe removes a previously registered listener.
+func (s *Space) Unsubscribe(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.listeners, key)
+}
+
+// notify invokes every listener with the freshly added item. Callers must
+// not hold s.mu.
+func (s *Space) notify(item *Item) {
+	s.mu.Lock()
+	fns := make([]func(*Item), 0, len(s.listeners))
+	for _, fn := range s.listeners {
+		fns = append(fns, fn)
+	}
+	s.mu.Unlock()
+	for _, fn := range fns {
+		fn(item)
+	}
+}
+
+// register appends a fully built item to the space. Callers must not hold
+// s.mu. Listeners fire after the item is registered.
+func (s *Space) register(item *Item) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrSpaceClosed
+	}
+	if len(s.items) >= s.maxItems {
+		s.mu.Unlock()
+		return ErrSpaceFull
+	}
+	s.items = append(s.items, item)
+	s.itemIdx[item.ID] = item
+	s.mu.Unlock()
+	s.notify(item)
+	return nil
+}
+
+// AddText posts a text snippet into the space. origin tags which subsystem
+// posted it (e.g. "agi", meetroom.OriginMeetRoom) so consumers can filter
+// their own echoes.
+func (s *Space) AddText(uploader string, text string, origin string) (*Item, error) {
+	if strings.TrimSpace(text) == "" {
+		return nil, ErrEmptyText
+	}
+	text = clipString(text, maxTextLength)
+	item := &Item{
+		ID:        randomID(itemIDBytes),
+		Type:      ItemTypeText,
+		Text:      text,
+		Size:      int64(len(text)),
+		Uploader:  uploader,
+		Origin:    origin,
+		CreatedAt: time.Now(),
+	}
+	if err := s.register(item); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+// SaveBlob streams src to disk (up to maxSize bytes) and registers it as an
+// image / file item. name is display-only and never used as a filesystem
+// path. Pass maxSize 0 for DefaultMaxUpload.
+func (s *Space) SaveBlob(itemType string, name string, uploader string, origin string, src io.Reader, maxSize int64) (*Item, error) {
+	if itemType != ItemTypeImage && itemType != ItemTypeFile {
+		return nil, ErrInvalidItemType
+	}
+	if maxSize <= 0 {
+		maxSize = DefaultMaxUpload
+	}
+
+	itemID := randomID(itemIDBytes)
+	if err := os.MkdirAll(s.storageDir, 0755); err != nil {
+		return nil, err
+	}
+	diskPath := filepath.Join(s.storageDir, itemID)
+
+	dst, err := os.Create(diskPath)
+	if err != nil {
+		return nil, err
+	}
+	written, err := io.Copy(dst, io.LimitReader(src, maxSize+1))
+	dst.Close()
+	if err != nil {
+		os.Remove(diskPath)
+		return nil, err
+	}
+	if written > maxSize {
+		os.Remove(diskPath)
+		return nil, ErrItemTooLarge
+	}
+
+	item := &Item{
+		ID:        itemID,
+		Type:      itemType,
+		Name:      clipString(name, maxItemName),
+		Size:      written,
+		Uploader:  uploader,
+		Origin:    origin,
+		CreatedAt: time.Now(),
+		DiskPath:  diskPath,
+	}
+	if err := s.register(item); err != nil {
+		os.Remove(diskPath)
+		return nil, err
+	}
+	return item, nil
+}
+
+// GetItem looks up an item in the space by its ID.
+func (s *Space) GetItem(itemID string) (*Item, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.itemIdx[itemID]
+	return item, ok
+}
+
+// Items returns a chronological snapshot of the current items.
+func (s *Space) Items() []*Item {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list := make([]*Item, len(s.items))
+	copy(list, s.items)
+	return list
+}
+
+// ItemCount returns the number of items in the space.
+func (s *Space) ItemCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.items)
+}
+
+// RemoveItem deletes an item (and its blob file) from the space. Only the
+// item's uploader, the space owner, or the system (empty requester) may
+// remove an item.
+func (s *Space) RemoveItem(itemID string, requester string) error {
+	s.mu.Lock()
+	item, ok := s.itemIdx[itemID]
+	if !ok {
+		s.mu.Unlock()
+		return ErrItemNotFound
+	}
+	if requester != "" && requester != item.Uploader && requester != s.Owner {
+		s.mu.Unlock()
+		return ErrPermissionDenied
+	}
+	delete(s.itemIdx, itemID)
+	for i, listed := range s.items {
+		if listed.ID == itemID {
+			s.items = append(s.items[:i], s.items[i+1:]...)
+			break
+		}
+	}
+	s.mu.Unlock()
+
+	if item.DiskPath != "" {
+		os.Remove(item.DiskPath)
+	}
+	return nil
+}

--- a/src/mod/sharedspace/sharedspace_test.go
+++ b/src/mod/sharedspace/sharedspace_test.go
@@ -1,0 +1,310 @@
+package sharedspace
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	return NewManager(filepath.Join(t.TempDir(), "spaces"), 0)
+}
+
+func TestCreateSpace(t *testing.T) {
+	m := newTestManager(t)
+	tests := []struct {
+		name     string
+		owner    string
+		title    string
+		wantName string
+	}{
+		{"named space", "alice", "Design sync", "Design sync"},
+		{"default name", "bob", "", "bob's space"},
+		{"overlong name clipped", "carol", strings.Repeat("x", 200), strings.Repeat("x", maxSpaceName)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			space := m.CreateSpace(tt.owner, tt.title)
+			if len(space.ID) != spaceIDBytes*2 {
+				t.Errorf("space ID %q length = %d, want %d", space.ID, len(space.ID), spaceIDBytes*2)
+			}
+			if space.Name != tt.wantName {
+				t.Errorf("name = %q, want %q", space.Name, tt.wantName)
+			}
+			if space.Owner != tt.owner {
+				t.Errorf("owner = %q, want %q", space.Owner, tt.owner)
+			}
+			if got, ok := m.GetSpace(space.ID); !ok || got != space {
+				t.Errorf("GetSpace(%q) did not return the created space", space.ID)
+			}
+		})
+	}
+
+	if _, ok := m.GetSpace("nonexistent"); ok {
+		t.Errorf("GetSpace returned ok for unknown ID")
+	}
+}
+
+func TestListSpacesByOwner(t *testing.T) {
+	m := newTestManager(t)
+	m.CreateSpace("alice", "One")
+	m.CreateSpace("alice", "Two")
+	m.CreateSpace("bob", "Other")
+
+	if got := len(m.ListSpacesByOwner("alice")); got != 2 {
+		t.Errorf("alice owns %d spaces, want 2", got)
+	}
+	if got := len(m.ListSpacesByOwner("bob")); got != 1 {
+		t.Errorf("bob owns %d spaces, want 1", got)
+	}
+	if got := len(m.ListSpacesByOwner("carol")); got != 0 {
+		t.Errorf("carol owns %d spaces, want 0", got)
+	}
+	if m.SpaceCount() != 3 {
+		t.Errorf("SpaceCount() = %d, want 3", m.SpaceCount())
+	}
+}
+
+func TestAddText(t *testing.T) {
+	m := newTestManager(t)
+	space := m.CreateSpace("alice", "")
+
+	tests := []struct {
+		name     string
+		text     string
+		wantErr  error
+		wantText string
+	}{
+		{"normal text", "hello there", nil, "hello there"},
+		{"empty text rejected", "   ", ErrEmptyText, ""},
+		{"overlong text clipped", strings.Repeat("a", maxTextLength+100), nil, strings.Repeat("a", maxTextLength)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item, err := space.AddText("alice", tt.text, "test")
+			if err != tt.wantErr {
+				t.Fatalf("AddText() error = %v, want %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if item.Type != ItemTypeText {
+				t.Errorf("item type = %q, want %q", item.Type, ItemTypeText)
+			}
+			if item.Text != tt.wantText {
+				t.Errorf("item text = %q, want %q", item.Text, tt.wantText)
+			}
+			if stored, ok := space.GetItem(item.ID); !ok || stored != item {
+				t.Errorf("GetItem(%q) did not return the added item", item.ID)
+			}
+		})
+	}
+}
+
+func TestSaveBlob(t *testing.T) {
+	m := newTestManager(t)
+	space := m.CreateSpace("alice", "")
+
+	tests := []struct {
+		name     string
+		itemType string
+		fileName string
+		content  string
+		maxSize  int64
+		wantErr  error
+	}{
+		{"file upload", ItemTypeFile, "notes.txt", "shared notes", 1024, nil},
+		{"image upload", ItemTypeImage, "photo.png", "png-bytes", 1024, nil},
+		{"invalid type", "video", "clip.mp4", "data", 1024, ErrInvalidItemType},
+		{"oversized upload", ItemTypeFile, "big.bin", strings.Repeat("A", 100), 10, ErrItemTooLarge},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item, err := space.SaveBlob(tt.itemType, tt.fileName, "alice", "test", strings.NewReader(tt.content), tt.maxSize)
+			if err != tt.wantErr {
+				t.Fatalf("SaveBlob() error = %v, want %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if item.Size != int64(len(tt.content)) {
+				t.Errorf("item size = %d, want %d", item.Size, len(tt.content))
+			}
+			data, err := os.ReadFile(item.DiskPath)
+			if err != nil {
+				t.Fatalf("reading stored blob: %v", err)
+			}
+			if !bytes.Equal(data, []byte(tt.content)) {
+				t.Errorf("stored content = %q, want %q", data, tt.content)
+			}
+		})
+	}
+
+	//Chronological ordering across mixed successes
+	items := space.Items()
+	if len(items) != 2 {
+		t.Fatalf("ItemCount = %d, want 2", len(items))
+	}
+	if items[0].Name != "notes.txt" || items[1].Name != "photo.png" {
+		t.Errorf("items out of order: %q, %q", items[0].Name, items[1].Name)
+	}
+}
+
+func TestSpaceItemLimit(t *testing.T) {
+	m := newTestManager(t)
+	space := m.CreateSpace("alice", "")
+	space.mu.Lock()
+	space.maxItems = 2
+	space.mu.Unlock()
+
+	if _, err := space.AddText("alice", "one", "test"); err != nil {
+		t.Fatalf("first AddText error = %v", err)
+	}
+	if _, err := space.AddText("alice", "two", "test"); err != nil {
+		t.Fatalf("second AddText error = %v", err)
+	}
+	if _, err := space.AddText("alice", "three", "test"); err != ErrSpaceFull {
+		t.Errorf("AddText on full space error = %v, want ErrSpaceFull", err)
+	}
+	if _, err := space.SaveBlob(ItemTypeFile, "f.txt", "alice", "test", strings.NewReader("x"), 10); err != ErrSpaceFull {
+		t.Errorf("SaveBlob on full space error = %v, want ErrSpaceFull", err)
+	}
+}
+
+func TestRemoveItemPermissions(t *testing.T) {
+	m := newTestManager(t)
+	space := m.CreateSpace("alice", "")
+	item, err := space.SaveBlob(ItemTypeFile, "doc.pdf", "bob", "test", strings.NewReader("content"), 1024)
+	if err != nil {
+		t.Fatalf("SaveBlob() error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		requester string
+		wantErr   error
+	}{
+		{"stranger denied", "mallory", ErrPermissionDenied},
+		{"unknown item", "alice", ErrItemNotFound},
+		{"uploader allowed", "bob", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := item.ID
+			if tt.wantErr == ErrItemNotFound {
+				target = "nonexistent"
+			}
+			if err := space.RemoveItem(target, tt.requester); err != tt.wantErr {
+				t.Errorf("RemoveItem() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+
+	if _, err := os.Stat(item.DiskPath); !os.IsNotExist(err) {
+		t.Errorf("blob file still on disk after RemoveItem: %v", err)
+	}
+	if space.ItemCount() != 0 {
+		t.Errorf("ItemCount() = %d after removal, want 0", space.ItemCount())
+	}
+
+	//Space owner can remove other users' items
+	item2, _ := space.SaveBlob(ItemTypeFile, "doc2.pdf", "bob", "test", strings.NewReader("content"), 1024)
+	if err := space.RemoveItem(item2.ID, "alice"); err != nil {
+		t.Errorf("owner RemoveItem() error = %v, want nil", err)
+	}
+
+	//System (empty requester) can remove anything
+	item3, _ := space.AddText("bob", "note", "test")
+	if err := space.RemoveItem(item3.ID, ""); err != nil {
+		t.Errorf("system RemoveItem() error = %v, want nil", err)
+	}
+}
+
+func TestListeners(t *testing.T) {
+	m := newTestManager(t)
+	space := m.CreateSpace("alice", "")
+
+	var seen []*Item
+	space.Subscribe("test", func(item *Item) {
+		seen = append(seen, item)
+	})
+
+	textItem, _ := space.AddText("alice", "hello", "agi")
+	blobItem, _ := space.SaveBlob(ItemTypeImage, "pic.png", "bob", "meetroom", strings.NewReader("img"), 1024)
+
+	if len(seen) != 2 {
+		t.Fatalf("listener saw %d items, want 2", len(seen))
+	}
+	if seen[0] != textItem || seen[1] != blobItem {
+		t.Errorf("listener received wrong items")
+	}
+	if seen[0].Origin != "agi" || seen[1].Origin != "meetroom" {
+		t.Errorf("origins = %q, %q; want agi, meetroom", seen[0].Origin, seen[1].Origin)
+	}
+
+	space.Unsubscribe("test")
+	space.AddText("alice", "after unsubscribe", "agi")
+	if len(seen) != 2 {
+		t.Errorf("listener fired after Unsubscribe")
+	}
+}
+
+func TestDeleteSpaceCleansUp(t *testing.T) {
+	m := newTestManager(t)
+	space := m.CreateSpace("alice", "")
+	item, err := space.SaveBlob(ItemTypeFile, "doc.pdf", "alice", "test", strings.NewReader("content"), 1024)
+	if err != nil {
+		t.Fatalf("SaveBlob() error = %v", err)
+	}
+
+	if !m.DeleteSpace(space.ID) {
+		t.Errorf("DeleteSpace returned false for live space")
+	}
+	if _, ok := m.GetSpace(space.ID); ok {
+		t.Errorf("space still registered after DeleteSpace")
+	}
+	if _, err := os.Stat(item.DiskPath); !os.IsNotExist(err) {
+		t.Errorf("blob file still on disk after DeleteSpace: %v", err)
+	}
+	if _, err := space.AddText("alice", "late", "test"); err != ErrSpaceClosed {
+		t.Errorf("AddText on closed space error = %v, want ErrSpaceClosed", err)
+	}
+	if _, err := space.SaveBlob(ItemTypeFile, "f.txt", "alice", "test", strings.NewReader("x"), 10); err != ErrSpaceClosed {
+		t.Errorf("SaveBlob on closed space error = %v, want ErrSpaceClosed", err)
+	}
+	//Deleting an unknown space must be a no-op
+	if m.DeleteSpace("nonexistent") {
+		t.Errorf("DeleteSpace returned true for unknown ID")
+	}
+}
+
+func TestIsImageName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"photo.png", true},
+		{"photo.PNG", true},
+		{"pic.jpeg", true},
+		{"pic.jpg", true},
+		{"anim.gif", true},
+		{"modern.webp", true},
+		{"old.bmp", true},
+		{"vector.svg", false}, //svg excluded: inline serving would execute scripts
+		{"doc.pdf", false},
+		{"noextension", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsImageName(tt.name); got != tt.want {
+			t.Errorf("IsImageName(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/src/sharedspace.go
+++ b/src/sharedspace.go
@@ -1,25 +1,1075 @@
 package main
 
 /*
-	SharedSpace - Shared collaboration area wiring
+	SharedSpace - Collaboration backbone endpoints
 	author: tobychui / AI assisted
 
-	Creates the system-wide shared space manager (mod/sharedspace): an
-	in-memory area where multiple different users can share texts, images
-	and files together. It is consumed by the AGI "sharedspace" library
-	(scripts create / read / post into spaces) and by MeetRoom, which
-	binds one space to every meeting room.
+	HTTP + WebSocket wiring for mod/sharedspace, the ArozOS collaboration
+	backbone: multi-user spaces holding chat texts, images, files and
+	revision-synced collaborative documents, with open / public / private
+	access control, optional persistence and a realtime channel per space.
+	MeetRoom runs its meeting signaling over the same channels.
 
-	Must be initiated before MeetRoomInit and AGIInit (see startup.go).
+	User endpoints (login required; the space ACL is the authorization
+	layer - see mod/sharedspace/access.go):
+
+	  POST /system/sharedspace/create        name=&access=&persistent=
+	  POST /system/sharedspace/delete        spaceid=            (manage)
+	  GET  /system/sharedspace/info?spaceid=
+	  GET  /system/sharedspace/list                              (joined)
+	  GET  /system/sharedspace/listpublic
+	  POST /system/sharedspace/join          spaceid=
+	  POST /system/sharedspace/leave         spaceid=
+	  POST /system/sharedspace/members/add   spaceid=&username=&role=
+	  POST /system/sharedspace/members/remove spaceid=&username=
+	  POST /system/sharedspace/members/role  spaceid=&username=&role=
+	  POST /system/sharedspace/access        spaceid=&access=
+	  POST /system/sharedspace/meta          spaceid=&key=&value=
+	  GET  /system/sharedspace/items?spaceid=
+	  POST /system/sharedspace/addtext       spaceid=&text=
+	  POST /system/sharedspace/upload        multipart (spaceid, file)
+	  GET  /system/sharedspace/download?spaceid=&itemid=[&inline=1]
+	  POST /system/sharedspace/removeitem    spaceid=&itemid=
+	  POST /system/sharedspace/doc/create    spaceid=&name=
+	  GET  /system/sharedspace/doc/list?spaceid=
+	  GET  /system/sharedspace/doc/get?spaceid=&docid=
+	  POST /system/sharedspace/doc/update    spaceid=&docid=&baserev=&content=
+	  POST /system/sharedspace/doc/delete    spaceid=&docid=
+	  GET  /system/sharedspace/ws?spaceid=   WebSocket upgrade
+
+	Admin endpoints (System Settings > Shared Spaces):
+
+	  GET  /system/sharedspace/admin/list
+	  POST /system/sharedspace/admin/delete     spaceid=
+	  GET  /system/sharedspace/admin/config
+	  POST /system/sharedspace/admin/setconfig  maxupload=&maxitems=&allowpersistent=&retentiondays=
+
+	WebSocket protocol (JSON frames over /system/sharedspace/ws):
+	  client -> server: {"type":"signal","to":subid,"data":{...}}  ephemeral relay (WebRTC etc.)
+	                    {"type":"broadcast","data":{...}}          ephemeral fan-out to peers
+	                    {"type":"chat","text":"..."}               persisted text item
+	                    {"type":"doc-update","docid":"..","baserev":n,"content":".."}
+	                    {"type":"ping"}                            app-level heartbeat
+	  server -> client: {"type":"welcome","subid":n,"username":u,"space":{...},"peers":[...]}
+	                    {"type":"peer-join","peer":{...}} / {"type":"peer-leave","subid":n,"username":u}
+	                    {"type":"signal","from":n,"data":{...}}
+	                    {"type":"broadcast","from":n,"username":u,"data":{...}}
+	                    {"type":"item","item":{...}} / {"type":"item-removed","itemid":i}
+	                    {"type":"doc","docid":d,"revision":r,"by":u,"patch":{pos,del,ins}}
+	                    {"type":"doc-created","doc":{...}} / {"type":"doc-deleted","docid":d}
+	                    {"type":"doc-conflict","docid":d,"revision":r}   sender only
+	                    {"type":"member","action":a,"username":u,"role":r}
+	                    {"type":"error","error":"..."}                   sender only
+	                    {"type":"pong"}, {"type":"space-closed"}
+
+	Ephemeral frames (signal / broadcast) fan out through the space channel
+	and are never persisted; chat and documents write through the space so
+	AGI scripts and, on meeting spaces, MeetRoom clients see them too. A
+	client that receives a doc revision gap re-fetches with doc/get - the
+	server content is always authoritative. Document saves should be
+	debounced client-side (~500ms); every accepted revision is one database
+	write.
 */
 
 import (
+	"encoding/json"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	prout "imuslab.com/arozos/mod/prouter"
 	"imuslab.com/arozos/mod/sharedspace"
+	"imuslab.com/arozos/mod/utils"
 )
 
-var sharedSpaceManager *sharedspace.Manager
+const (
+	ssMaxChatLength  = 4000             // runes per chat message over the ws
+	ssMaxSocketFrame = 512 << 10        // 512KB per ws frame (doc contents included)
+	ssPingInterval   = 20 * time.Second // server keepalive ping cadence
+	ssReadTimeout    = 60 * time.Second // drop a subscriber whose socket goes silent this long
+	ssWriteTimeout   = 10 * time.Second // per-frame write deadline
+	ssSweepInterval  = 1 * time.Hour    // retention sweep cadence
 
-// SharedSpaceInit creates the shared collaboration space manager.
+	//Admin configuration keys, stored in the sharedspace table next to the
+	//space records (see mod/sharedspace/persistence.go for the layout)
+	ssDBTable             = "sharedspace"
+	ssConfMaxUpload       = "conf/maxupload"
+	ssConfMaxItems        = "conf/maxitems"
+	ssConfAllowPersistent = "conf/allowpersistent"
+	ssConfRetentionDays   = "conf/retentiondays"
+)
+
+var (
+	sharedSpaceManager *sharedspace.Manager
+	ssUpgrader         = websocket.Upgrader{
+		ReadBufferSize:  4096,
+		WriteBufferSize: 4096,
+		CheckOrigin:     func(r *http.Request) bool { return true },
+	}
+)
+
+/* ================= Configuration helpers ================= */
+
+// ssConfInt64 reads an integer admin setting, falling back when unset or
+// out of range.
+func ssConfInt64(key string, fallback int64) int64 {
+	if sysdb == nil || !sysdb.KeyExists(ssDBTable, key) {
+		return fallback
+	}
+	value := int64(0)
+	sysdb.Read(ssDBTable, key, &value)
+	if value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+// ssConfBool reads a boolean admin setting, falling back when unset.
+func ssConfBool(key string, fallback bool) bool {
+	if sysdb == nil || !sysdb.KeyExists(ssDBTable, key) {
+		return fallback
+	}
+	value := fallback
+	sysdb.Read(ssDBTable, key, &value)
+	return value
+}
+
+/* ================= Descriptors ================= */
+
+// ssDescribeSpace renders the space fields shared with clients. When a
+// username is given the caller's own role is included.
+func ssDescribeSpace(space *sharedspace.Space, username string) map[string]interface{} {
+	desc := map[string]interface{}{
+		"spaceid":    space.ID,
+		"name":       space.Name,
+		"owner":      space.Owner,
+		"access":     space.AccessMode(),
+		"persistent": space.Persistent,
+		"items":      space.ItemCount(),
+		"docs":       space.DocCount(),
+		"members":    space.MemberCount(),
+		"metadata":   space.Metadata(),
+		"createdat":  space.CreatedAt.Unix(),
+	}
+	if username != "" {
+		role, isMember := space.Role(username)
+		desc["myrole"] = role
+		desc["ismember"] = isMember
+	}
+	return desc
+}
+
+// ssDescribeItem renders a space item for clients.
+func ssDescribeItem(item *sharedspace.Item) map[string]interface{} {
+	return map[string]interface{}{
+		"itemid":   item.ID,
+		"type":     item.Type,
+		"name":     item.Name,
+		"text":     item.Text,
+		"size":     item.Size,
+		"uploader": item.Uploader,
+		"origin":   item.Origin,
+		"time":     item.CreatedAt.Unix(),
+	}
+}
+
+// ssDescribeDoc renders a document snapshot for clients. includeContent
+// controls whether the body travels with it.
+func ssDescribeDoc(doc *sharedspace.DocSnapshot, includeContent bool) map[string]interface{} {
+	desc := map[string]interface{}{
+		"docid":     doc.ID,
+		"name":      doc.Name,
+		"creator":   doc.Creator,
+		"revision":  doc.Revision,
+		"createdat": doc.CreatedAt.Unix(),
+		"updatedat": doc.UpdatedAt.Unix(),
+		"updatedby": doc.UpdatedBy,
+	}
+	if includeContent {
+		desc["content"] = doc.Content
+	}
+	return desc
+}
+
+/* ================= Request helpers ================= */
+
+// ssRequestParam reads a request parameter from POST form or query string
+// depending on the endpoint's method convention.
+func ssRequestParam(r *http.Request, post bool, key string) (string, error) {
+	if post {
+		return utils.PostPara(r, key)
+	}
+	return utils.GetPara(r, key)
+}
+
+// ssResolveSpaceRequest authenticates the caller and resolves the spaceid
+// parameter to a live space the caller may read. On failure the error
+// response is already written and ok is false.
+func ssResolveSpaceRequest(w http.ResponseWriter, r *http.Request, post bool) (username string, space *sharedspace.Space, ok bool) {
+	userinfo, err := userHandler.GetUserInfoFromRequest(w, r)
+	if err != nil {
+		utils.SendErrorResponse(w, "Not logged in")
+		return "", nil, false
+	}
+	spaceID, err := ssRequestParam(r, post, "spaceid")
+	if err != nil {
+		utils.SendErrorResponse(w, "Missing space ID")
+		return "", nil, false
+	}
+	space, exists := sharedSpaceManager.GetSpace(spaceID)
+	if !exists || !space.CanRead(userinfo.Username) {
+		//Private spaces are indistinguishable from missing ones to outsiders
+		utils.SendErrorResponse(w, "Space not found")
+		return "", nil, false
+	}
+	return userinfo.Username, space, true
+}
+
+// ssCloseSpace announces the shutdown to live subscribers and deletes the
+// space (used by the user delete endpoint and the admin surface).
+func ssCloseSpace(spaceID string) {
+	space, ok := sharedSpaceManager.GetSpace(spaceID)
+	if !ok {
+		return
+	}
+	space.Channel().Broadcast([]byte(`{"type":"space-closed"}`), -1)
+	sharedSpaceManager.DeleteSpace(spaceID)
+}
+
+// ssBroadcastSpaceEvent builds the event listener that fans space mutations
+// out to the space's channel as protocol frames. Registered once per space
+// under a fixed key, so repeated registration is idempotent.
+func ssBroadcastSpaceEvent(space *sharedspace.Space) func(*sharedspace.SpaceEvent) {
+	channel := space.Channel()
+	return func(event *sharedspace.SpaceEvent) {
+		var frame []byte
+		switch event.Kind {
+		case sharedspace.EventItemAdded:
+			frame = mrMarshalOrDrop(map[string]interface{}{
+				"type": "item",
+				"item": ssDescribeItem(event.Item),
+			})
+		case sharedspace.EventItemRemoved:
+			frame = mrMarshalOrDrop(map[string]interface{}{
+				"type":   "item-removed",
+				"itemid": event.Item.ID,
+			})
+		case sharedspace.EventDocCreated:
+			frame = mrMarshalOrDrop(map[string]interface{}{
+				"type": "doc-created",
+				"doc":  ssDescribeDoc(event.Doc, false),
+			})
+		case sharedspace.EventDocUpdated:
+			frame = mrMarshalOrDrop(map[string]interface{}{
+				"type":     "doc",
+				"docid":    event.Doc.ID,
+				"revision": event.Doc.Revision,
+				"by":       event.Doc.UpdatedBy,
+				"patch": map[string]interface{}{
+					"pos": event.Patch.Pos,
+					"del": event.Patch.Del,
+					"ins": event.Patch.Ins,
+				},
+			})
+		case sharedspace.EventDocDeleted:
+			frame = mrMarshalOrDrop(map[string]interface{}{
+				"type":  "doc-deleted",
+				"docid": event.Doc.ID,
+			})
+		case sharedspace.EventMemberChanged:
+			frame = mrMarshalOrDrop(map[string]interface{}{
+				"type":     "member",
+				"action":   event.Action,
+				"username": event.Member,
+				"role":     event.Role,
+			})
+		}
+		if frame != nil {
+			channel.Broadcast(frame, -1)
+		}
+	}
+}
+
+// SharedSpaceInit creates the system-wide shared collaboration space manager
+// and wires up its HTTP / WebSocket endpoints and the admin surface.
+// Must be initiated before MeetRoomInit and AGIInit (see startup.go).
 func SharedSpaceInit() {
-	sharedSpaceManager = sharedspace.NewManager("", 0)
+	sharedSpaceManager = sharedspace.NewManagerWithOptions(sharedspace.ManagerOptions{
+		PersistentRoot:  filepath.Join("system", "sharedspace"),
+		Database:        sysdb,
+		MaxUpload:       ssConfInt64(ssConfMaxUpload, sharedspace.DefaultMaxUpload),
+		DefaultMaxItems: int(ssConfInt64(ssConfMaxItems, sharedspace.DefaultMaxItems)),
+	})
+	sharedSpaceManager.SetAllowPersistent(ssConfBool(ssConfAllowPersistent, true))
+
+	//Retention: periodically remove persistent spaces idle for longer than
+	//the admin-configured retention window (0 disables the sweep)
+	go func() {
+		ticker := time.NewTicker(ssSweepInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			retentionDays := ssConfInt64(ssConfRetentionDays, 0)
+			if retentionDays > 0 {
+				sharedSpaceManager.SweepStaleSpaces(time.Duration(retentionDays) * 24 * time.Hour)
+			}
+		}
+	}()
+
+	//User endpoints: login-only universal router. Spaces carry their own
+	//access control (open capability / public / private membership), which
+	//is the authorization layer for everything below.
+	router := prout.NewModuleRouter(prout.RouterOption{
+		ModuleName:  "",
+		AdminOnly:   false,
+		UserHandler: userHandler,
+		DeniedHandler: func(w http.ResponseWriter, r *http.Request) {
+			errorHandlePermissionDenied(w, r)
+		},
+	})
+
+	//Create a new space; the creator becomes the owner.
+	router.HandleFunc("/system/sharedspace/create", func(w http.ResponseWriter, r *http.Request) {
+		userinfo, err := userHandler.GetUserInfoFromRequest(w, r)
+		if err != nil {
+			utils.SendErrorResponse(w, "Not logged in")
+			return
+		}
+		name, _ := utils.PostPara(r, "name")
+		access, _ := utils.PostPara(r, "access")
+		persistent, _ := utils.PostPara(r, "persistent")
+
+		space, err := sharedSpaceManager.CreateSpaceWithOptions(userinfo.Username, name, sharedspace.SpaceOptions{
+			Access:     access,
+			Persistent: persistent == "true",
+		})
+		if err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		js := mrMarshalOrDrop(ssDescribeSpace(space, userinfo.Username))
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Delete a space; space managers only.
+	router.HandleFunc("/system/sharedspace/delete", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		if !space.CanManage(username) {
+			utils.SendErrorResponse(w, "Permission denied")
+			return
+		}
+		ssCloseSpace(space.ID)
+		utils.SendOK(w)
+	})
+
+	//Describe one space.
+	router.HandleFunc("/system/sharedspace/info", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, false)
+		if !ok {
+			return
+		}
+		desc := ssDescribeSpace(space, username)
+		//The member list is only revealed to members and managers
+		if _, isMember := space.Role(username); isMember || space.CanManage(username) {
+			desc["memberlist"] = space.Members()
+		}
+		js := mrMarshalOrDrop(desc)
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//List the spaces the caller has joined (or owns).
+	router.HandleFunc("/system/sharedspace/list", func(w http.ResponseWriter, r *http.Request) {
+		userinfo, err := userHandler.GetUserInfoFromRequest(w, r)
+		if err != nil {
+			utils.SendErrorResponse(w, "Not logged in")
+			return
+		}
+		joined := sharedSpaceManager.ListSpacesByMember(userinfo.Username)
+		list := make([]map[string]interface{}, 0, len(joined))
+		for _, space := range joined {
+			list = append(list, ssDescribeSpace(space, userinfo.Username))
+		}
+		js := mrMarshalOrDrop(list)
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//List every public space (the discovery directory).
+	router.HandleFunc("/system/sharedspace/listpublic", func(w http.ResponseWriter, r *http.Request) {
+		userinfo, err := userHandler.GetUserInfoFromRequest(w, r)
+		if err != nil {
+			utils.SendErrorResponse(w, "Not logged in")
+			return
+		}
+		public := sharedSpaceManager.ListPublicSpaces()
+		list := make([]map[string]interface{}, 0, len(public))
+		for _, space := range public {
+			list = append(list, ssDescribeSpace(space, userinfo.Username))
+		}
+		js := mrMarshalOrDrop(list)
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Self-join a public (or open) space.
+	router.HandleFunc("/system/sharedspace/join", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		if err := space.JoinPublic(username); err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		utils.SendOK(w)
+	})
+
+	//Leave a space.
+	router.HandleFunc("/system/sharedspace/leave", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		if err := space.RemoveMember(username, username); err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		utils.SendOK(w)
+	})
+
+	//Invite a user into the space; managers only.
+	router.HandleFunc("/system/sharedspace/members/add", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		target, err := utils.PostPara(r, "username")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing username")
+			return
+		}
+		role, _ := utils.PostPara(r, "role")
+		if role == "" {
+			role = sharedspace.RoleMember
+		}
+		//The invitee must be a real user on this host
+		if _, err := userHandler.GetUserInfoFromUsername(target); err != nil {
+			utils.SendErrorResponse(w, "User not found")
+			return
+		}
+		if err := space.AddMember(username, target, role); err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		utils.SendOK(w)
+	})
+
+	//Remove a member; managers (or the member themselves) only.
+	router.HandleFunc("/system/sharedspace/members/remove", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		target, err := utils.PostPara(r, "username")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing username")
+			return
+		}
+		if err := space.RemoveMember(username, target); err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		utils.SendOK(w)
+	})
+
+	//Change a member's role; managers only.
+	router.HandleFunc("/system/sharedspace/members/role", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		target, err := utils.PostPara(r, "username")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing username")
+			return
+		}
+		role, err := utils.PostPara(r, "role")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing role")
+			return
+		}
+		if err := space.SetMemberRole(username, target, role); err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		utils.SendOK(w)
+	})
+
+	//Change the access mode; managers only.
+	router.HandleFunc("/system/sharedspace/access", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		access, err := utils.PostPara(r, "access")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing access mode")
+			return
+		}
+		if err := space.SetAccess(username, access); err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		utils.SendOK(w)
+	})
+
+	//Set (or with an empty value delete) a metadata entry; managers only.
+	router.HandleFunc("/system/sharedspace/meta", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		key, err := utils.PostPara(r, "key")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing key")
+			return
+		}
+		value, _ := utils.PostPara(r, "value")
+		if err := space.SetMeta(username, key, value); err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		utils.SendOK(w)
+	})
+
+	//List the items in a space.
+	router.HandleFunc("/system/sharedspace/items", func(w http.ResponseWriter, r *http.Request) {
+		_, space, ok := ssResolveSpaceRequest(w, r, false)
+		if !ok {
+			return
+		}
+		items := space.Items()
+		list := make([]map[string]interface{}, 0, len(items))
+		for _, item := range items {
+			list = append(list, ssDescribeItem(item))
+		}
+		js := mrMarshalOrDrop(list)
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Post a text snippet.
+	router.HandleFunc("/system/sharedspace/addtext", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		text, err := utils.PostPara(r, "text")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing text")
+			return
+		}
+		item, err := space.AddText(username, text, "http")
+		if err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		js := mrMarshalOrDrop(map[string]interface{}{"itemid": item.ID})
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Upload a file / image into the space.
+	router.HandleFunc("/system/sharedspace/upload", func(w http.ResponseWriter, r *http.Request) {
+		userinfo, err := userHandler.GetUserInfoFromRequest(w, r)
+		if err != nil {
+			utils.SendErrorResponse(w, "Not logged in")
+			return
+		}
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			utils.SendErrorResponse(w, "Invalid upload")
+			return
+		}
+		space, exists := sharedSpaceManager.GetSpace(r.FormValue("spaceid"))
+		if !exists || !space.CanPost(userinfo.Username) {
+			utils.SendErrorResponse(w, "Space not found")
+			return
+		}
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing file")
+			return
+		}
+		defer file.Close()
+
+		itemType := sharedspace.ItemTypeFile
+		if sharedspace.IsImageName(header.Filename) {
+			itemType = sharedspace.ItemTypeImage
+		}
+		item, err := space.SaveBlob(itemType, header.Filename, userinfo.Username, "http", file, sharedSpaceManager.MaxUpload())
+		if err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		js := mrMarshalOrDrop(map[string]interface{}{
+			"itemid": item.ID,
+			"name":   item.Name,
+			"size":   item.Size,
+		})
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Download an item blob. inline=1 serves raster images for in-browser
+	//display; everything else (notably SVG, which can carry scripts) keeps
+	//the attachment disposition.
+	router.HandleFunc("/system/sharedspace/download", func(w http.ResponseWriter, r *http.Request) {
+		_, space, ok := ssResolveSpaceRequest(w, r, false)
+		if !ok {
+			return
+		}
+		itemID, err := utils.GetPara(r, "itemid")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing item ID")
+			return
+		}
+		item, exists := space.GetItem(itemID)
+		if !exists || item.DiskPath == "" {
+			http.NotFound(w, r)
+			return
+		}
+		f, err := os.Open(item.DiskPath)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		defer f.Close()
+
+		//Serve with the original name; the ASCII fallback strips anything
+		//that could break the header, the RFC 5987 form keeps unicode names.
+		fallback := strings.Map(func(c rune) rune {
+			if c < 32 || c == '"' || c == '\\' || c > 126 {
+				return '_'
+			}
+			return c
+		}, item.Name)
+		disposition := "attachment"
+		if r.URL.Query().Get("inline") == "1" && sharedspace.IsImageName(item.Name) {
+			disposition = "inline"
+		}
+		w.Header().Set("Content-Disposition", disposition+"; filename=\""+fallback+"\"; filename*=UTF-8''"+url.PathEscape(item.Name))
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		if ctype := mime.TypeByExtension(strings.ToLower(filepathExt(item.Name))); ctype != "" {
+			w.Header().Set("Content-Type", ctype)
+		} else {
+			w.Header().Set("Content-Type", "application/octet-stream")
+		}
+		http.ServeContent(w, r, "", time.Now(), f)
+	})
+
+	//Remove an item; uploader, space managers or the system.
+	router.HandleFunc("/system/sharedspace/removeitem", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		itemID, err := utils.PostPara(r, "itemid")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing item ID")
+			return
+		}
+		if err := space.RemoveItem(itemID, username); err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		utils.SendOK(w)
+	})
+
+	//Create a collaborative document.
+	router.HandleFunc("/system/sharedspace/doc/create", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		name, _ := utils.PostPara(r, "name")
+		doc, err := space.CreateDoc(username, name)
+		if err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		js := mrMarshalOrDrop(ssDescribeDoc(doc, true))
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//List documents (without contents).
+	router.HandleFunc("/system/sharedspace/doc/list", func(w http.ResponseWriter, r *http.Request) {
+		_, space, ok := ssResolveSpaceRequest(w, r, false)
+		if !ok {
+			return
+		}
+		docs := space.ListDocs()
+		list := make([]map[string]interface{}, 0, len(docs))
+		for _, doc := range docs {
+			list = append(list, ssDescribeDoc(doc, false))
+		}
+		js := mrMarshalOrDrop(list)
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Fetch one document with content (also the conflict recovery path).
+	router.HandleFunc("/system/sharedspace/doc/get", func(w http.ResponseWriter, r *http.Request) {
+		_, space, ok := ssResolveSpaceRequest(w, r, false)
+		if !ok {
+			return
+		}
+		docID, err := utils.GetPara(r, "docid")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing document ID")
+			return
+		}
+		doc, exists := space.GetDoc(docID)
+		if !exists {
+			utils.SendErrorResponse(w, "Document not found")
+			return
+		}
+		js := mrMarshalOrDrop(ssDescribeDoc(doc, true))
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Compare-and-swap document update over HTTP.
+	router.HandleFunc("/system/sharedspace/doc/update", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		docID, err := utils.PostPara(r, "docid")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing document ID")
+			return
+		}
+		baseRevStr, err := utils.PostPara(r, "baserev")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing base revision")
+			return
+		}
+		baseRev, err := strconv.ParseInt(baseRevStr, 10, 64)
+		if err != nil {
+			utils.SendErrorResponse(w, "Invalid base revision")
+			return
+		}
+		content, _ := utils.PostPara(r, "content")
+
+		doc, err := space.UpdateDoc(username, docID, baseRev, content)
+		if err == sharedspace.ErrRevisionConflict {
+			//Report the current revision so the client can re-fetch + rebase
+			current, _ := space.GetDoc(docID)
+			revision := int64(0)
+			if current != nil {
+				revision = current.Revision
+			}
+			js := mrMarshalOrDrop(map[string]interface{}{
+				"error":    "revision conflict",
+				"revision": revision,
+			})
+			utils.SendJSONResponse(w, string(js))
+			return
+		}
+		if err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		js := mrMarshalOrDrop(map[string]interface{}{
+			"ok":       true,
+			"revision": doc.Revision,
+		})
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Delete a document; creator or space managers.
+	router.HandleFunc("/system/sharedspace/doc/delete", func(w http.ResponseWriter, r *http.Request) {
+		username, space, ok := ssResolveSpaceRequest(w, r, true)
+		if !ok {
+			return
+		}
+		docID, err := utils.PostPara(r, "docid")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing document ID")
+			return
+		}
+		if err := space.DeleteDoc(username, docID); err != nil {
+			utils.SendErrorResponse(w, err.Error())
+			return
+		}
+		utils.SendOK(w)
+	})
+
+	//WebSocket: realtime bidirectional exchange on a space.
+	router.HandleFunc("/system/sharedspace/ws", ssHandleWebSocket)
+
+	//Admin surface: System Settings > Shared Spaces
+	adminRouter := prout.NewModuleRouter(prout.RouterOption{
+		ModuleName:  "System Settings",
+		AdminOnly:   true,
+		UserHandler: userHandler,
+		DeniedHandler: func(w http.ResponseWriter, r *http.Request) {
+			errorHandlePermissionDenied(w, r)
+		},
+	})
+
+	//Enumerate every space with usage figures.
+	adminRouter.HandleFunc("/system/sharedspace/admin/list", func(w http.ResponseWriter, r *http.Request) {
+		all := sharedSpaceManager.ListSpaces()
+		list := make([]map[string]interface{}, 0, len(all))
+		for _, space := range all {
+			desc := ssDescribeSpace(space, "")
+			desc["subscribers"] = space.Channel().Count()
+			desc["diskusage"] = sharedSpaceManager.SpaceDiskUsage(space.ID)
+			list = append(list, desc)
+		}
+		js := mrMarshalOrDrop(list)
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Delete any space with system authority.
+	adminRouter.HandleFunc("/system/sharedspace/admin/delete", func(w http.ResponseWriter, r *http.Request) {
+		spaceID, err := utils.PostPara(r, "spaceid")
+		if err != nil {
+			utils.SendErrorResponse(w, "Missing space ID")
+			return
+		}
+		if _, exists := sharedSpaceManager.GetSpace(spaceID); !exists {
+			utils.SendErrorResponse(w, "Space not found")
+			return
+		}
+		ssCloseSpace(spaceID)
+		utils.SendOK(w)
+	})
+
+	//Current admin configuration.
+	adminRouter.HandleFunc("/system/sharedspace/admin/config", func(w http.ResponseWriter, r *http.Request) {
+		js := mrMarshalOrDrop(map[string]interface{}{
+			"maxupload":       sharedSpaceManager.MaxUpload(),
+			"maxitems":        sharedSpaceManager.DefaultItemLimit(),
+			"allowpersistent": sharedSpaceManager.PersistenceAvailable(),
+			"retentiondays":   ssConfInt64(ssConfRetentionDays, 0),
+			"spaces":          sharedSpaceManager.SpaceCount(),
+		})
+		utils.SendJSONResponse(w, string(js))
+	})
+
+	//Update the admin configuration (persisted; applied live).
+	adminRouter.HandleFunc("/system/sharedspace/admin/setconfig", func(w http.ResponseWriter, r *http.Request) {
+		if maxUpload, err := utils.PostPara(r, "maxupload"); err == nil {
+			if value, err := strconv.ParseInt(maxUpload, 10, 64); err == nil && value > 0 {
+				sysdb.Write(ssDBTable, ssConfMaxUpload, value)
+				sharedSpaceManager.SetMaxUpload(value)
+			}
+		}
+		if maxItems, err := utils.PostPara(r, "maxitems"); err == nil {
+			if value, err := strconv.Atoi(maxItems); err == nil && value > 0 {
+				sysdb.Write(ssDBTable, ssConfMaxItems, int64(value))
+				sharedSpaceManager.SetDefaultItemLimit(value)
+			}
+		}
+		if allowPersistent, err := utils.PostPara(r, "allowpersistent"); err == nil {
+			enabled := allowPersistent == "true"
+			sysdb.Write(ssDBTable, ssConfAllowPersistent, enabled)
+			sharedSpaceManager.SetAllowPersistent(enabled)
+		}
+		if retentionDays, err := utils.PostPara(r, "retentiondays"); err == nil {
+			if value, err := strconv.ParseInt(retentionDays, 10, 64); err == nil && value >= 0 {
+				sysdb.Write(ssDBTable, ssConfRetentionDays, value)
+			}
+		}
+		utils.SendOK(w)
+	})
+
+	//Settings tile in System Settings
+	registerSetting(settingModule{
+		Name:         "Shared Spaces",
+		Desc:         "Collaboration spaces: storage, limits and cleanup",
+		IconPath:     "SystemAO/system_setting/img/module.svg",
+		Group:        "Advance",
+		StartDir:     "SystemAO/sharedspace/spaces.html",
+		RequireAdmin: true,
+	})
+}
+
+// ssHandleWebSocket upgrades the request and joins the caller to the
+// space's realtime channel.
+func ssHandleWebSocket(w http.ResponseWriter, r *http.Request) {
+	userinfo, err := userHandler.GetUserInfoFromRequest(w, r)
+	if err != nil {
+		http.Error(w, "Not logged in", http.StatusUnauthorized)
+		return
+	}
+	username := userinfo.Username
+	space, exists := sharedSpaceManager.GetSpace(r.URL.Query().Get("spaceid"))
+	if !exists || !space.CanRead(username) {
+		http.Error(w, "Space not found", http.StatusForbidden)
+		return
+	}
+
+	conn, err := ssUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	conn.SetReadLimit(ssMaxSocketFrame)
+
+	//Liveness: a client that goes silent (no frames and no pong replies)
+	//past ssReadTimeout is dropped so it does not linger as a ghost.
+	conn.SetReadDeadline(time.Now().Add(ssReadTimeout))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(ssReadTimeout))
+		return nil
+	})
+
+	channel := space.Channel()
+	sub, err := channel.Join(username)
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	//Fan space mutations out to this channel as protocol frames. The fixed
+	//key makes re-registration on every connection idempotent.
+	space.SubscribeEvents("wstransport", ssBroadcastSpaceEvent(space))
+
+	//Writer: drain the send buffer until it is closed, interleaving
+	//keepalive pings, then hang up.
+	go func() {
+		pinger := time.NewTicker(ssPingInterval)
+		defer pinger.Stop()
+		defer conn.Close()
+		for {
+			select {
+			case msg, ok := <-sub.Send:
+				if !ok {
+					return
+				}
+				conn.SetWriteDeadline(time.Now().Add(ssWriteTimeout))
+				if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+					return
+				}
+			case <-pinger.C:
+				conn.SetWriteDeadline(time.Now().Add(ssWriteTimeout))
+				if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	//Welcome frame: own identity, space descriptor and current peers.
+	peers := []map[string]interface{}{}
+	for _, peer := range channel.Subscribers() {
+		if peer.ID == sub.ID {
+			continue
+		}
+		peers = append(peers, map[string]interface{}{"subid": peer.ID, "username": peer.Username})
+	}
+	channel.SendTo(sub.ID, mrMarshalOrDrop(map[string]interface{}{
+		"type":     "welcome",
+		"subid":    sub.ID,
+		"username": username,
+		"space":    ssDescribeSpace(space, username),
+		"peers":    peers,
+	}))
+
+	//Announce the newcomer to everyone else.
+	channel.Broadcast(mrMarshalOrDrop(map[string]interface{}{
+		"type": "peer-join",
+		"peer": map[string]interface{}{"subid": sub.ID, "username": username},
+	}), sub.ID)
+
+	defer func() {
+		channel.Leave(sub.ID)
+		channel.Broadcast(mrMarshalOrDrop(map[string]interface{}{
+			"type":     "peer-leave",
+			"subid":    sub.ID,
+			"username": username,
+		}), -1)
+	}()
+
+	sendError := func(message string) {
+		channel.SendTo(sub.ID, mrMarshalOrDrop(map[string]interface{}{
+			"type":  "error",
+			"error": message,
+		}))
+	}
+
+	for {
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		conn.SetReadDeadline(time.Now().Add(ssReadTimeout))
+		var frame struct {
+			Type    string          `json:"type"`
+			To      int             `json:"to"`
+			Data    json.RawMessage `json:"data"`
+			Text    string          `json:"text"`
+			DocID   string          `json:"docid"`
+			BaseRev int64           `json:"baserev"`
+			Content string          `json:"content"`
+		}
+		if json.Unmarshal(raw, &frame) != nil {
+			continue
+		}
+
+		switch frame.Type {
+		case "signal":
+			//Ephemeral point-to-point relay (WebRTC SDP/ICE and friends)
+			channel.SendTo(frame.To, mrMarshalOrDrop(map[string]interface{}{
+				"type": "signal",
+				"from": sub.ID,
+				"data": frame.Data,
+			}))
+		case "broadcast":
+			//Ephemeral application fan-out to every other subscriber
+			channel.Broadcast(mrMarshalOrDrop(map[string]interface{}{
+				"type":     "broadcast",
+				"from":     sub.ID,
+				"username": username,
+				"data":     frame.Data,
+			}), sub.ID)
+		case "chat":
+			text := frame.Text
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
+			if runes := []rune(text); len(runes) > ssMaxChatLength {
+				text = string(runes[:ssMaxChatLength])
+			}
+			//Persisted: delivery to every subscriber happens through the
+			//item-added event fan-out (no double send)
+			if _, err := space.AddText(username, text, "ws"); err != nil {
+				sendError(err.Error())
+			}
+		case "doc-update":
+			_, err := space.UpdateDoc(username, frame.DocID, frame.BaseRev, frame.Content)
+			if err == sharedspace.ErrRevisionConflict {
+				current, _ := space.GetDoc(frame.DocID)
+				revision := int64(0)
+				if current != nil {
+					revision = current.Revision
+				}
+				channel.SendTo(sub.ID, mrMarshalOrDrop(map[string]interface{}{
+					"type":     "doc-conflict",
+					"docid":    frame.DocID,
+					"revision": revision,
+				}))
+			} else if err != nil {
+				sendError(err.Error())
+			}
+			//Success needs no direct reply: the doc-updated event fan-out
+			//delivers the accepted patch (with the new revision) to
+			//everyone, the sender included.
+		case "ping":
+			channel.SendTo(sub.ID, []byte(`{"type":"pong"}`))
+		}
+	}
 }

--- a/src/sharedspace.go
+++ b/src/sharedspace.go
@@ -1,0 +1,25 @@
+package main
+
+/*
+	SharedSpace - Shared collaboration area wiring
+	author: tobychui / AI assisted
+
+	Creates the system-wide shared space manager (mod/sharedspace): an
+	in-memory area where multiple different users can share texts, images
+	and files together. It is consumed by the AGI "sharedspace" library
+	(scripts create / read / post into spaces) and by MeetRoom, which
+	binds one space to every meeting room.
+
+	Must be initiated before MeetRoomInit and AGIInit (see startup.go).
+*/
+
+import (
+	"imuslab.com/arozos/mod/sharedspace"
+)
+
+var sharedSpaceManager *sharedspace.Manager
+
+// SharedSpaceInit creates the shared collaboration space manager.
+func SharedSpaceInit() {
+	sharedSpaceManager = sharedspace.NewManager("", 0)
+}

--- a/src/startup.go
+++ b/src/startup.go
@@ -127,11 +127,12 @@ func RunStartup() {
 	//StorageDaemonInit() //Start File System handler daemon (for backup and other sync process)
 
 	//8 Start AGI and Subservice modules (Must start after module)
-	AGIInit()        //ArOZ Javascript Gateway Interface, must start after fs
-	SchedulerInit()  //Start System Scheudler
-	SubserviceInit() //Subservice Handler
-	ArozcastInit()   //Arozcast remote projection pub/sub relay
-	MeetRoomInit()   //MeetRoom video conferencing signaling backend
+	SharedSpaceInit() //Shared collaboration space manager, must start before MeetRoom and AGI
+	MeetRoomInit()    //MeetRoom video conferencing signaling backend, before AGI so the meetroom lib can bind
+	AGIInit()         //ArOZ Javascript Gateway Interface, must start after fs
+	SchedulerInit()   //Start System Scheudler
+	SubserviceInit()  //Subservice Handler
+	ArozcastInit()    //Arozcast remote projection pub/sub relay
 
 	//9. Initiate System Settings Handlers
 	SystemSettingInit()       //Start System Setting Core

--- a/src/web/MeetRoom/app.css
+++ b/src/web/MeetRoom/app.css
@@ -61,6 +61,7 @@ body {
     height: 100vh;
     background: #16181d;
     color: #e6e8ec;
+    position: relative;
 }
 
 #roomHeader {
@@ -281,10 +282,128 @@ body {
     opacity: 0.8;
 }
 
+.chat-msg .chat-image {
+    display: block;
+    max-width: 100%;
+    max-height: 220px;
+    border-radius: 6px;
+    cursor: pointer;
+    margin-bottom: 4px;
+}
+
 .chat-input {
     flex: 0 0 auto;
     padding: 0.7em;
     border-top: 1px solid #2b2f38;
+}
+
+/* Participants / attendance panel */
+#peoplePanel {
+    flex: 0 0 320px;
+    display: flex;
+    flex-direction: column;
+    background: #1e2128;
+    border-left: 1px solid #2b2f38;
+    min-width: 0;
+}
+
+#attendanceList {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 0.8em;
+}
+
+.attendance-group {
+    font-size: 0.78em;
+    color: #9aa4b2;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 0.6em 0 0.4em 0;
+}
+
+.attendance-entry {
+    display: flex;
+    align-items: center;
+    gap: 0.6em;
+    background: #262a33;
+    border-radius: 8px;
+    padding: 6px 10px;
+    margin-bottom: 6px;
+}
+
+.attendance-entry .icon {
+    margin: 0;
+    color: #9aa4b2;
+}
+
+.attendance-entry.present .icon {
+    color: #7bed9f;
+}
+
+.attendance-entry .attendee-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.attendance-entry .host-tag {
+    flex: 0 0 auto;
+    font-size: 0.72em;
+    background: #2f80ed;
+    color: #fff;
+    border-radius: 8px;
+    padding: 1px 8px;
+}
+
+.attendance-entry .attendee-times {
+    flex: 0 0 auto;
+    font-size: 0.75em;
+    color: #9aa4b2;
+    text-align: right;
+    white-space: nowrap;
+}
+
+/* New chat message popup */
+#msgToast {
+    position: absolute;
+    right: 16px;
+    bottom: 78px;
+    max-width: 300px;
+    background: #262a33;
+    color: #e6e8ec;
+    border: 1px solid #3a3f4a;
+    border-left: 3px solid #2f80ed;
+    border-radius: 8px;
+    padding: 10px 14px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+    z-index: 30;
+}
+
+#msgToast .toast-title {
+    font-weight: bold;
+    font-size: 0.85em;
+    margin-bottom: 3px;
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+}
+
+#msgToast .toast-title .icon {
+    margin: 0;
+    color: #7db4ff;
+}
+
+#msgToast .toast-body {
+    font-size: 0.85em;
+    color: #c3c9d4;
+    word-break: break-word;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
 }
 
 #uploadStatus {
@@ -371,7 +490,8 @@ body {
 
 /* Narrow layouts (embedded / mobile) */
 @media (max-width: 720px) {
-    #chatPanel {
+    #chatPanel,
+    #peoplePanel {
         position: absolute;
         right: 0;
         top: 0;

--- a/src/web/MeetRoom/app.js
+++ b/src/web/MeetRoom/app.js
@@ -36,12 +36,17 @@
     var API = {
         create: "/system/meetroom/create",
         join: "/system/meetroom/join",
+        info: "/system/meetroom/info",
         end: "/system/meetroom/end",
         ice: "/system/meetroom/iceservers",
         upload: "/system/meetroom/upload",
         download: "/system/meetroom/download",
         ws: "/system/meetroom/ws"
     };
+
+    //File extensions the chat renders inline as images; must match the
+    //server-side raster whitelist (mod/sharedspace IsImageName)
+    var IMAGE_EXTS = ["png", "jpg", "jpeg", "gif", "webp", "bmp"];
 
     var state = {
         ws: null,
@@ -62,6 +67,7 @@
         camOn: true,
         sharing: false,
         chatOpen: false,
+        peopleOpen: false,
         unreadChat: 0,
         leaving: false,
         currentRoomId: "",
@@ -81,6 +87,12 @@
         var div = document.createElement("div");
         div.textContent = text;
         return div.innerHTML;
+    }
+
+    //For values placed inside HTML attributes: escapeHtml does not cover
+    //quotes, so escape them explicitly to stay inside the attribute.
+    function escapeAttr(text) {
+        return escapeHtml(text).replace(/"/g, "&quot;").replace(/'/g, "&#39;");
     }
 
     function formatBytes(bytes) {
@@ -119,6 +131,63 @@
         if (typeof ao_module_setWindowTitle === "function") {
             try { ao_module_setWindowTitle(title); } catch (e) { }
         }
+    }
+
+    function isImageName(name) {
+        var idx = name.lastIndexOf(".");
+        if (idx < 0) return false;
+        return IMAGE_EXTS.indexOf(name.substring(idx + 1).toLowerCase()) >= 0;
+    }
+
+    /* ================= Sound effects ================= */
+    //Short synthesized chimes via WebAudio: no bundled audio assets needed.
+    //The context is created lazily on the first join (a user gesture has
+    //happened by then, so autoplay policies allow it).
+
+    var audioCtx = null;
+
+    function playChime(notes) {
+        try {
+            if (!audioCtx) {
+                var Ctx = window.AudioContext || window.webkitAudioContext;
+                if (!Ctx) return;
+                audioCtx = new Ctx();
+            }
+            if (audioCtx.state === "suspended") {
+                var resumed = audioCtx.resume();
+                if (resumed && resumed.catch) resumed.catch(function () { });
+            }
+            var t = audioCtx.currentTime;
+            notes.forEach(function (note) {
+                var osc = audioCtx.createOscillator();
+                var gain = audioCtx.createGain();
+                osc.type = "sine";
+                osc.frequency.value = note.freq;
+                gain.gain.setValueAtTime(0.0001, t + note.at);
+                gain.gain.linearRampToValueAtTime(0.12, t + note.at + 0.02);
+                gain.gain.exponentialRampToValueAtTime(0.0001, t + note.at + note.len);
+                osc.connect(gain);
+                gain.connect(audioCtx.destination);
+                osc.start(t + note.at);
+                osc.stop(t + note.at + note.len + 0.05);
+            });
+        } catch (e) { }
+    }
+
+    function playJoinSound() {
+        //Ascending two-note chime (C5 -> G5)
+        playChime([
+            { freq: 523.25, at: 0, len: 0.18 },
+            { freq: 783.99, at: 0.13, len: 0.25 }
+        ]);
+    }
+
+    function playLeaveSound() {
+        //Descending two-note chime (E5 -> G4)
+        playChime([
+            { freq: 659.25, at: 0, len: 0.18 },
+            { freq: 392.00, at: 0.13, len: 0.25 }
+        ]);
     }
 
     /* ================= Lobby actions ================= */
@@ -370,6 +439,8 @@
                 updateParticipantCount();
                 if (wasReconnect) {
                     addSystemChat("Reconnected to the meeting");
+                } else {
+                    playJoinSound();
                 }
                 break;
             case "pong":
@@ -378,13 +449,17 @@
             case "peer-join":
                 createPeerRecord(msg.peer);
                 addSystemChat(msg.peer.username + " joined the meeting");
+                playJoinSound();
                 broadcastState(); //let the newcomer learn our mute/cam state
                 updateParticipantCount();
+                refreshAttendance();
                 break;
             case "peer-leave":
                 removePeer(msg.peerid);
                 addSystemChat(msg.username + " left the meeting");
+                playLeaveSound();
                 updateParticipantCount();
+                refreshAttendance();
                 break;
             case "signal":
                 handleSignal(msg.from, msg.data);
@@ -397,6 +472,9 @@
                 break;
             case "state":
                 updatePeerState(msg);
+                break;
+            case "attendance":
+                renderAttendance(msg.records || []);
                 break;
             case "room-closed":
                 state.leaving = true;
@@ -743,6 +821,7 @@
 
     $id("leaveBtn").addEventListener("click", function () {
         state.leaving = true;
+        playLeaveSound();
         cleanupRoom();
         showLobbyError("");
     });
@@ -751,6 +830,7 @@
         if (!confirm("End the meeting for all participants?")) return;
         sendFrame({ type: "end" });
         state.leaving = true;
+        playLeaveSound();
         cleanupRoom();
         showLobbyError("");
     });
@@ -766,6 +846,8 @@
         state.chatOpen = open;
         $id("chatPanel").style.display = open ? "flex" : "none";
         if (open) {
+            if (state.peopleOpen) togglePeople(false);
+            hideMessageToast();
             state.unreadChat = 0;
             $id("chatBadge").style.display = "none";
             $id("chatText").focus();
@@ -775,6 +857,93 @@
 
     $id("chatBtn").addEventListener("click", function () { toggleChat(!state.chatOpen); });
     $id("chatCloseBtn").addEventListener("click", function () { toggleChat(false); });
+
+    /* ================= Participants & attendance ================= */
+
+    function togglePeople(open) {
+        state.peopleOpen = open;
+        $id("peoplePanel").style.display = open ? "flex" : "none";
+        if (open) {
+            if (state.chatOpen) toggleChat(false);
+            refreshAttendance();
+        }
+    }
+
+    $id("peopleBtn").addEventListener("click", function () { togglePeople(!state.peopleOpen); });
+    $id("peopleCloseBtn").addEventListener("click", function () { togglePeople(false); });
+
+    //Ask the server for the join/leave log; the reply arrives as an
+    //"attendance" frame and lands in renderAttendance()
+    function refreshAttendance() {
+        if (!state.peopleOpen) return;
+        sendFrame({ type: "attendance" });
+    }
+
+    function attendanceTime(unixTime) {
+        return new Date(unixTime * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    }
+
+    function attendanceEntry(record) {
+        var entry = document.createElement("div");
+        entry.className = "attendance-entry" + (record.present ? " present" : "");
+        var times = record.present
+            ? "joined " + attendanceTime(record.joinedat)
+            : attendanceTime(record.joinedat) + " - " + attendanceTime(record.leftat);
+        entry.innerHTML =
+            '<i class="' + (record.present ? "user icon" : "sign-out icon") + '"></i>' +
+            '<span class="attendee-name">' + escapeHtml(record.username) + '</span>' +
+            (state.room && record.username === state.room.host ? '<span class="host-tag">Host</span>' : "") +
+            '<span class="attendee-times">' + escapeHtml(times) + '</span>';
+        return entry;
+    }
+
+    function renderAttendance(records) {
+        var box = $id("attendanceList");
+        box.innerHTML = "";
+        var present = records.filter(function (r) { return r.present; });
+        var past = records.filter(function (r) { return !r.present; });
+
+        var groupPresent = document.createElement("div");
+        groupPresent.className = "attendance-group";
+        groupPresent.textContent = "In meeting (" + present.length + ")";
+        box.appendChild(groupPresent);
+        present.forEach(function (record) { box.appendChild(attendanceEntry(record)); });
+
+        if (past.length > 0) {
+            var groupPast = document.createElement("div");
+            groupPast.className = "attendance-group";
+            groupPast.textContent = "Left the meeting (" + past.length + ")";
+            box.appendChild(groupPast);
+            past.forEach(function (record) { box.appendChild(attendanceEntry(record)); });
+        }
+    }
+
+    /* ================= New message popup ================= */
+
+    var toastTimer = null;
+
+    function showMessageToast(title, body) {
+        if (state.chatOpen) return; //already reading the chat
+        var toast = $id("msgToast");
+        toast.querySelector(".toast-title span").textContent = title;
+        toast.querySelector(".toast-body").textContent = body;
+        toast.style.display = "block";
+        if (toastTimer) clearTimeout(toastTimer);
+        toastTimer = setTimeout(hideMessageToast, 6000);
+    }
+
+    function hideMessageToast() {
+        if (toastTimer) {
+            clearTimeout(toastTimer);
+            toastTimer = null;
+        }
+        $id("msgToast").style.display = "none";
+    }
+
+    $id("msgToast").addEventListener("click", function () {
+        hideMessageToast();
+        toggleChat(true);
+    });
 
     function sendChat() {
         var input = $id("chatText");
@@ -825,7 +994,10 @@
             '<div class="msg-meta">' + escapeHtml(msg.username) + " - " + chatTimestamp(msg.time) + '</div>' +
             '<div class="msg-body">' + escapeHtml(msg.text) + '</div>';
         appendChatNode(node);
-        if (!own) bumpUnread();
+        if (!own) {
+            bumpUnread();
+            showMessageToast(msg.username, msg.text);
+        }
     }
 
     function addFileMessage(msg) {
@@ -836,15 +1008,39 @@
             "&fileid=" + encodeURIComponent(msg.fileid);
         var node = document.createElement("div");
         node.className = "chat-msg" + (own ? " own" : "");
+
+        //Images render inline so nobody has to download them; clicking the
+        //preview opens the full-size image in a new tab (inline=1 keeps the
+        //browser from forcing a download). Everything else stays a link.
+        var body;
+        if (isImageName(msg.name)) {
+            var inlineHref = href + "&inline=1";
+            body =
+                '<a target="_blank" rel="noopener" href="' + inlineHref + '" title="Open full size">' +
+                '<img class="chat-image" src="' + inlineHref + '" alt="' + escapeAttr(msg.name) + '">' +
+                '</a>' +
+                '<a class="file-link" href="' + href + '" download>' +
+                '<i class="download icon"></i>' + escapeHtml(msg.name) +
+                '</a> <span class="file-size">(' + formatBytes(msg.size) + ')</span>';
+        } else {
+            body =
+                '<a class="file-link" target="_blank" rel="noopener" href="' + href + '" download>' +
+                '<i class="file outline icon"></i>' + escapeHtml(msg.name) +
+                '</a> <span class="file-size">(' + formatBytes(msg.size) + ')</span>';
+        }
         node.innerHTML =
             '<div class="msg-meta">' + escapeHtml(msg.username) + " - " + chatTimestamp(msg.time) + '</div>' +
-            '<div class="msg-body">' +
-            '<a class="file-link" target="_blank" rel="noopener" href="' + href + '" download>' +
-            '<i class="file outline icon"></i>' + escapeHtml(msg.name) +
-            '</a> <span class="file-size">(' + formatBytes(msg.size) + ')</span>' +
-            '</div>';
+            '<div class="msg-body">' + body + '</div>';
         appendChatNode(node);
-        if (!own) bumpUnread();
+        var preview = node.querySelector(".chat-image");
+        if (preview) {
+            //Keep the newest message visible once the preview finishes loading
+            preview.addEventListener("load", scrollChat);
+        }
+        if (!own) {
+            bumpUnread();
+            showMessageToast(msg.username, "Shared " + (isImageName(msg.name) ? "an image: " : "a file: ") + msg.name);
+        }
     }
 
     function addSystemChat(text) {
@@ -860,22 +1056,22 @@
         $id("attachInput").click();
     });
 
-    $id("attachInput").addEventListener("change", function () {
-        var file = this.files[0];
-        this.value = "";
+    //Upload a file (or pasted image blob) and announce it to the room
+    function uploadAndAnnounce(file, displayName) {
         if (!file) return;
         if (!state.ws || state.ws.readyState !== WebSocket.OPEN) {
             addSystemChat("Reconnecting - please try sharing the file again in a moment");
             return;
         }
+        var name = displayName || file.name;
 
         var form = new FormData();
         form.append("roomid", state.room.id);
         form.append("password", state.password);
-        form.append("file", file);
+        form.append("file", file, name);
 
         $id("uploadStatus").style.display = "";
-        $id("uploadStatusText").textContent = "Uploading " + file.name + "...";
+        $id("uploadStatusText").textContent = "Uploading " + name + "...";
 
         fetch(API.upload, { method: "POST", body: form }).then(function (r) {
             return r.json();
@@ -890,6 +1086,29 @@
             $id("uploadStatus").style.display = "none";
             addSystemChat("Upload failed");
         });
+    }
+
+    $id("attachInput").addEventListener("change", function () {
+        var file = this.files[0];
+        this.value = "";
+        uploadAndAnnounce(file);
+    });
+
+    //Ctrl+V in the meeting attaches a copied image (screenshot, copied
+    //picture, ...) to the chat
+    document.addEventListener("paste", function (e) {
+        if (!state.connected) return;
+        var items = (e.clipboardData && e.clipboardData.items) || [];
+        for (var i = 0; i < items.length; i++) {
+            if (items[i].kind !== "file" || items[i].type.indexOf("image/") !== 0) continue;
+            var blob = items[i].getAsFile();
+            if (!blob) continue;
+            e.preventDefault();
+            if (!state.chatOpen) toggleChat(true);
+            var ext = (items[i].type.split("/")[1] || "png").split("+")[0];
+            uploadAndAnnounce(blob, "pasted-image-" + Date.now() + "." + ext);
+            return;
+        }
     });
 
     /* ================= Teardown ================= */
@@ -931,10 +1150,13 @@
 
         $id("videoGrid").innerHTML = "";
         $id("chatMessages").innerHTML = "";
+        $id("attendanceList").innerHTML = "";
         $id("chatBadge").style.display = "none";
         $id("micBtn").disabled = false;
         $id("camBtn").disabled = false;
+        hideMessageToast();
         toggleChat(false);
+        togglePeople(false);
         $id("room").style.display = "none";
         $id("lobby").style.display = "flex";
         setWindowTitle("MeetRoom");

--- a/src/web/MeetRoom/index.html
+++ b/src/web/MeetRoom/index.html
@@ -102,7 +102,7 @@
                         <i class="spinner loading icon"></i> <span id="uploadStatusText">Uploading...</span>
                     </div>
                     <div class="ui small action input fluid">
-                        <input type="text" id="chatText" maxlength="4000" placeholder="Type a message...">
+                        <input type="text" id="chatText" maxlength="4000" placeholder="Type a message... (Ctrl+V pastes an image)">
                         <button id="attachBtn" class="ui icon button" title="Share a file">
                             <i class="paperclip icon"></i>
                         </button>
@@ -113,6 +113,18 @@
                     <input type="file" id="attachInput" style="display:none;">
                 </div>
             </div>
+            <div id="peoplePanel" style="display:none;">
+                <div class="chat-header">
+                    <i class="users icon"></i> Participants
+                    <i id="peopleCloseBtn" class="close icon chat-close"></i>
+                </div>
+                <div id="attendanceList"></div>
+            </div>
+        </div>
+
+        <div id="msgToast" style="display:none;" title="Click to open the chat">
+            <div class="toast-title"><i class="comment icon"></i><span></span></div>
+            <div class="toast-body"></div>
         </div>
 
         <div id="controlBar">
@@ -128,6 +140,9 @@
             <button id="chatBtn" class="ctrl-btn" title="Open chat">
                 <i class="comments icon"></i><span>Chat</span>
                 <span id="chatBadge" class="chat-badge" style="display:none;"></span>
+            </button>
+            <button id="peopleBtn" class="ctrl-btn" title="Participants and attendance">
+                <i class="users icon"></i><span>People</span>
             </button>
             <button id="inviteBtn" class="ctrl-btn" title="Copy invite info">
                 <i class="share alternate icon"></i><span>Invite</span>

--- a/src/web/SystemAO/sharedspace/spaces.html
+++ b/src/web/SystemAO/sharedspace/spaces.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta charset="UTF-8">
+    <!-- ao_module is provided by the parent frame; ao_module.js is not needed standalone -->
+    <script src="../../script/jquery.min.js"></script>
+    <title>Shared Spaces</title>
+    <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body { background: transparent; overflow-x: hidden; }
+
+    #ss-root {
+        --bg:      #f2f2f7;
+        --card:    #ffffff;
+        --border:  rgba(0,0,0,0.10);
+        --text:    #1d1d1f;
+        --dim:     #6e6e73;
+        --muted:   #aeaeb2;
+        --accent:  #007AFF;
+        --accentH: #0063d1;
+        --success: #34c759;
+        --danger:  #ff3b30;
+        --radius:  12px;
+        --shadow:  0 1px 3px rgba(0,0,0,0.07), 0 1px 8px rgba(0,0,0,0.04);
+
+        font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+        font-size: 13px;
+        color: var(--text);
+        background: var(--bg);
+        min-height: 100vh;
+        padding: 18px 18px 32px 18px;
+    }
+
+    #ss-root h1 { font-size: 1.35em; margin-bottom: 2px; }
+    #ss-root .subtitle { color: var(--dim); margin-bottom: 16px; }
+
+    .card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 14px 16px;
+        margin-bottom: 16px;
+    }
+    .card h2 { font-size: 1.05em; margin-bottom: 10px; }
+
+    .conf-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+        margin-bottom: 12px;
+    }
+    .conf-field label { display: block; color: var(--dim); margin-bottom: 4px; }
+    .conf-field input[type="number"] {
+        width: 100%;
+        padding: 6px 8px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        font-size: 13px;
+    }
+    .conf-field .checkline { display: flex; align-items: center; gap: 6px; padding-top: 7px; }
+
+    .btn {
+        display: inline-block;
+        border: none;
+        border-radius: 8px;
+        padding: 7px 14px;
+        font-size: 13px;
+        cursor: pointer;
+        background: var(--accent);
+        color: #fff;
+    }
+    .btn:hover { background: var(--accentH); }
+    .btn.secondary { background: rgba(0,0,0,0.06); color: var(--text); }
+    .btn.secondary:hover { background: rgba(0,0,0,0.12); }
+    .btn.danger { background: var(--danger); }
+    .btn.danger:hover { background: #d70015; }
+    .btn.mini { padding: 4px 10px; font-size: 12px; }
+
+    #statusMsg { display: none; margin-left: 10px; color: var(--success); }
+
+    table { width: 100%; border-collapse: collapse; }
+    th, td {
+        text-align: left;
+        padding: 7px 8px;
+        border-bottom: 1px solid var(--border);
+        white-space: nowrap;
+    }
+    th { color: var(--dim); font-weight: 600; }
+    td.name-cell { max-width: 220px; overflow: hidden; text-overflow: ellipsis; }
+    .tablewrap { overflow-x: auto; }
+    .pill {
+        display: inline-block;
+        border-radius: 10px;
+        padding: 1px 9px;
+        font-size: 12px;
+        background: rgba(0,0,0,0.06);
+        color: var(--dim);
+    }
+    .pill.public { background: rgba(52,199,89,0.15); color: #1e7d3c; }
+    .pill.private { background: rgba(255,59,48,0.12); color: #a52a22; }
+    .pill.persist { background: rgba(0,122,255,0.12); color: #0a58b6; }
+    .empty-row { color: var(--muted); text-align: center; padding: 18px 0; }
+    </style>
+</head>
+<body>
+<div id="ss-root">
+    <h1>Shared Spaces</h1>
+    <div class="subtitle">Collaboration spaces used by web apps, AGI scripts and MeetRoom meetings</div>
+
+    <div class="card">
+        <h2>Limits and Retention</h2>
+        <div class="conf-grid">
+            <div class="conf-field">
+                <label for="confMaxUpload">Max upload size (MB)</label>
+                <input type="number" id="confMaxUpload" min="1" step="1">
+            </div>
+            <div class="conf-field">
+                <label for="confMaxItems">Items per space</label>
+                <input type="number" id="confMaxItems" min="1" step="1">
+            </div>
+            <div class="conf-field">
+                <label for="confRetention">Retention (days, 0 = keep forever)</label>
+                <input type="number" id="confRetention" min="0" step="1">
+            </div>
+            <div class="conf-field">
+                <label>Persistent spaces</label>
+                <div class="checkline">
+                    <input type="checkbox" id="confAllowPersistent">
+                    <span>Allow creating persistent spaces</span>
+                </div>
+            </div>
+        </div>
+        <button class="btn" id="saveConfigBtn">Save Settings</button>
+        <span id="statusMsg">Saved</span>
+    </div>
+
+    <div class="card">
+        <h2>Live Spaces <button class="btn secondary mini" id="refreshBtn" style="float:right;">Refresh</button></h2>
+        <div class="tablewrap">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Owner</th>
+                        <th>Access</th>
+                        <th>Storage</th>
+                        <th>Items</th>
+                        <th>Docs</th>
+                        <th>Members</th>
+                        <th>Online</th>
+                        <th>Size</th>
+                        <th>Created</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody id="spacesTable"></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<script>
+    function escapeHtml(text) {
+        return $("<div>").text(text === undefined || text === null ? "" : String(text)).html();
+    }
+
+    function formatBytes(bytes) {
+        if (bytes < 1024) return bytes + " B";
+        var units = ["KB", "MB", "GB"];
+        var value = bytes;
+        for (var i = 0; i < units.length; i++) {
+            value = value / 1024;
+            if (value < 1024 || i === units.length - 1) {
+                return value.toFixed(1) + " " + units[i];
+            }
+        }
+    }
+
+    function loadConfig() {
+        $.get("/system/sharedspace/admin/config", function (data) {
+            if (data.error !== undefined) return;
+            $("#confMaxUpload").val(Math.round(data.maxupload / (1024 * 1024)));
+            $("#confMaxItems").val(data.maxitems);
+            $("#confRetention").val(data.retentiondays);
+            $("#confAllowPersistent").prop("checked", data.allowpersistent === true);
+        }, "json");
+    }
+
+    function saveConfig() {
+        $.post("/system/sharedspace/admin/setconfig", {
+            maxupload: Math.max(1, parseInt($("#confMaxUpload").val()) || 0) * 1024 * 1024,
+            maxitems: $("#confMaxItems").val(),
+            retentiondays: $("#confRetention").val(),
+            allowpersistent: $("#confAllowPersistent").prop("checked") ? "true" : "false"
+        }, function () {
+            $("#statusMsg").show().delay(1500).fadeOut();
+            loadConfig();
+        });
+    }
+
+    function accessPill(access) {
+        var cls = access === "public" ? "public" : (access === "private" ? "private" : "");
+        return '<span class="pill ' + cls + '">' + escapeHtml(access) + '</span>';
+    }
+
+    function loadSpaces() {
+        $.get("/system/sharedspace/admin/list", function (data) {
+            var tbody = $("#spacesTable");
+            tbody.empty();
+            if (data.error !== undefined || !Array.isArray(data) || data.length === 0) {
+                tbody.append('<tr><td colspan="11" class="empty-row">No live shared spaces</td></tr>');
+                return;
+            }
+            data.sort(function (a, b) { return b.createdat - a.createdat; });
+            data.forEach(function (space) {
+                var row = $("<tr>");
+                row.append($('<td class="name-cell">').attr("title", space.spaceid).text(space.name));
+                row.append($("<td>").text(space.owner));
+                row.append($("<td>").html(accessPill(space.access)));
+                row.append($("<td>").html(space.persistent ? '<span class="pill persist">persistent</span>' : '<span class="pill">ephemeral</span>'));
+                row.append($("<td>").text(space.items));
+                row.append($("<td>").text(space.docs));
+                row.append($("<td>").text(space.members));
+                row.append($("<td>").text(space.subscribers));
+                row.append($("<td>").text(formatBytes(space.diskusage)));
+                row.append($("<td>").text(new Date(space.createdat * 1000).toLocaleString()));
+                var deleteBtn = $('<button class="btn danger mini">Delete</button>').on("click", function () {
+                    if (!confirm('Delete the space "' + space.name + '" and all its content?')) return;
+                    $.post("/system/sharedspace/admin/delete", { spaceid: space.spaceid }, function () {
+                        loadSpaces();
+                    });
+                });
+                row.append($("<td>").append(deleteBtn));
+                tbody.append(row);
+            });
+        }, "json");
+    }
+
+    $("#saveConfigBtn").on("click", saveConfig);
+    $("#refreshBtn").on("click", loadSpaces);
+    loadConfig();
+    loadSpaces();
+</script>
+</body>
+</html>

--- a/src/web/Terminal/docs/api.json
+++ b/src/web/Terminal/docs/api.json
@@ -1,6 +1,6 @@
 {
   "_note": "This file is the source for the Terminal in-app documentation panel. It is derived from mod/agi/README.md. Whenever README.md is updated, this file MUST also be updated to keep the in-app help in sync.",
-  "_version": "3.3",
+  "_version": "3.4",
   "sections": [
     {
       "id": "core",
@@ -927,14 +927,14 @@
     {
       "id": "sharedspace",
       "name": "sharedspace",
-      "desc": "Shared collaboration areas where multiple users share texts, images and files together. The space ID is the access capability. MeetRoom binds one space to every meeting room.",
+      "desc": "Multi-user collaboration spaces: texts, images, files and revision-synced documents with open/public/private access control, member roles, metadata and optional persistence. Web clients get the same spaces over /system/sharedspace/* plus a realtime WebSocket channel. MeetRoom binds one space to every meeting room.",
       "load": "requirelib(\"sharedspace\");",
       "functions": [
         {
           "name": "sharedspace.createSpace",
           "sig": "sharedspace.createSpace(name)",
-          "desc": "Create a new space owned by the calling user.",
-          "ret": "object {spaceid, name, owner, items, createdat}",
+          "desc": "Create a new open, ephemeral space owned by the calling user.",
+          "ret": "object {spaceid, name, owner, access, persistent, items, docs, members, metadata, createdat}",
           "example": "requirelib(\"sharedspace\");\nvar space = sharedspace.createSpace(\"Design sync\");\nsendJSONResp(space);"
         },
         {
@@ -947,7 +947,7 @@
         {
           "name": "sharedspace.getSpaceInfo",
           "sig": "sharedspace.getSpaceInfo(spaceid)",
-          "desc": "Describe a space by ID. Returns {exists:false} for unknown IDs.",
+          "desc": "Describe a space by ID (includes myrole/ismember). Returns {exists:false} for unknown or unreadable spaces.",
           "ret": "object",
           "example": "requirelib(\"sharedspace\");\nvar info = sharedspace.getSpaceInfo(spaceid);"
         },
@@ -989,16 +989,128 @@
         {
           "name": "sharedspace.removeItem",
           "sig": "sharedspace.removeItem(spaceid, itemid)",
-          "desc": "Remove an item. Uploader or space owner only.",
+          "desc": "Remove an item. Uploader, space admin or space owner only.",
           "ret": "bool",
           "example": "requirelib(\"sharedspace\");\nsharedspace.removeItem(spaceid, itemid);"
         },
         {
           "name": "sharedspace.deleteSpace",
           "sig": "sharedspace.deleteSpace(spaceid)",
-          "desc": "Delete a space and all its items. Space owner only.",
+          "desc": "Delete a space and all its items. Space owner or space admin only.",
           "ret": "bool",
           "example": "requirelib(\"sharedspace\");\nsharedspace.deleteSpace(spaceid);"
+        },
+        {
+          "name": "sharedspace.createSpaceAdvanced",
+          "sig": "sharedspace.createSpaceAdvanced(name, options)",
+          "desc": "Create a space with options {access:'open'|'public'|'private', persistent:bool, metadata:{...}}. Persistent spaces survive restarts.",
+          "ret": "object descriptor or null",
+          "example": "requirelib(\"sharedspace\");\nvar space = sharedspace.createSpaceAdvanced(\"Team chat\", {access:\"private\", persistent:true});"
+        },
+        {
+          "name": "sharedspace.listPublicSpaces",
+          "sig": "sharedspace.listPublicSpaces()",
+          "desc": "The public space directory (every space with access 'public').",
+          "ret": "array of descriptors",
+          "example": "requirelib(\"sharedspace\");\nsendJSONResp(sharedspace.listPublicSpaces());"
+        },
+        {
+          "name": "sharedspace.listJoinedSpaces",
+          "sig": "sharedspace.listJoinedSpaces()",
+          "desc": "Spaces the calling user belongs to (owner, admin or member).",
+          "ret": "array of descriptors",
+          "example": "requirelib(\"sharedspace\");\nsendJSONResp(sharedspace.listJoinedSpaces());"
+        },
+        {
+          "name": "sharedspace.joinSpace",
+          "sig": "sharedspace.joinSpace(spaceid)",
+          "desc": "Self-join a public (or open) space as a member. Private spaces are invite-only.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.joinSpace(spaceid);"
+        },
+        {
+          "name": "sharedspace.leaveSpace",
+          "sig": "sharedspace.leaveSpace(spaceid)",
+          "desc": "Leave a space. The owner cannot leave.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.leaveSpace(spaceid);"
+        },
+        {
+          "name": "sharedspace.setAccess",
+          "sig": "sharedspace.setAccess(spaceid, access)",
+          "desc": "Change the access mode ('open', 'public' or 'private'). Managers only.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.setAccess(spaceid, \"private\");"
+        },
+        {
+          "name": "sharedspace.setMeta",
+          "sig": "sharedspace.setMeta(spaceid, key, value)",
+          "desc": "Set (empty value deletes) a metadata entry. Managers only.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.setMeta(spaceid, \"purpose\", \"chat\");"
+        },
+        {
+          "name": "sharedspace.getMeta",
+          "sig": "sharedspace.getMeta(spaceid)",
+          "desc": "Read the space metadata map.",
+          "ret": "object or null",
+          "example": "requirelib(\"sharedspace\");\nvar meta = sharedspace.getMeta(spaceid);"
+        },
+        {
+          "name": "sharedspace.addMember",
+          "sig": "sharedspace.addMember(spaceid, username, role)",
+          "desc": "Invite a user with role 'admin' or 'member' (default). Managers only.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.addMember(spaceid, \"bob\", \"member\");"
+        },
+        {
+          "name": "sharedspace.removeMember",
+          "sig": "sharedspace.removeMember(spaceid, username)",
+          "desc": "Remove a member (managers) or leave (self). The owner cannot be removed.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.removeMember(spaceid, \"bob\");"
+        },
+        {
+          "name": "sharedspace.listMembers",
+          "sig": "sharedspace.listMembers(spaceid)",
+          "desc": "Member map {username: role}. Members and managers only.",
+          "ret": "object or null",
+          "example": "requirelib(\"sharedspace\");\nvar members = sharedspace.listMembers(spaceid);"
+        },
+        {
+          "name": "sharedspace.createDoc",
+          "sig": "sharedspace.createDoc(spaceid, name)",
+          "desc": "Create a collaborative document (revision 1, empty content).",
+          "ret": "object {docid, name, creator, revision, content, createdat, updatedat, updatedby} or null",
+          "example": "requirelib(\"sharedspace\");\nvar doc = sharedspace.createDoc(spaceid, \"Meeting notes\");"
+        },
+        {
+          "name": "sharedspace.listDocs",
+          "sig": "sharedspace.listDocs(spaceid)",
+          "desc": "Document snapshots without their content.",
+          "ret": "array or null",
+          "example": "requirelib(\"sharedspace\");\nsendJSONResp(sharedspace.listDocs(spaceid));"
+        },
+        {
+          "name": "sharedspace.getDoc",
+          "sig": "sharedspace.getDoc(spaceid, docid)",
+          "desc": "One document with full content - also the recovery path after an update conflict.",
+          "ret": "object or null",
+          "example": "requirelib(\"sharedspace\");\nvar doc = sharedspace.getDoc(spaceid, docid);"
+        },
+        {
+          "name": "sharedspace.updateDoc",
+          "sig": "sharedspace.updateDoc(spaceid, docid, baserev, content)",
+          "desc": "Compare-and-swap update: content replaces the body only when baserev matches the current revision. On conflict re-fetch with getDoc, merge and retry. Debounce saves (~500ms).",
+          "ret": "{ok:true, revision} | {ok:false, conflict:true, revision} | null",
+          "example": "requirelib(\"sharedspace\");\nvar doc = sharedspace.getDoc(spaceid, docid);\nvar r = sharedspace.updateDoc(spaceid, docid, doc.revision, doc.content + \"\\nmore\");"
+        },
+        {
+          "name": "sharedspace.deleteDoc",
+          "sig": "sharedspace.deleteDoc(spaceid, docid)",
+          "desc": "Delete a document. Creator or space managers only.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.deleteDoc(spaceid, docid);"
         }
       ]
     },

--- a/src/web/Terminal/docs/api.json
+++ b/src/web/Terminal/docs/api.json
@@ -1,6 +1,6 @@
 {
   "_note": "This file is the source for the Terminal in-app documentation panel. It is derived from mod/agi/README.md. Whenever README.md is updated, this file MUST also be updated to keep the in-app help in sync.",
-  "_version": "3.0",
+  "_version": "3.3",
   "sections": [
     {
       "id": "core",
@@ -921,6 +921,134 @@
           "desc": "Remove a registered task.",
           "ret": "bool",
           "example": "requirelib(\"scheduler\");\nscheduler.unregister(\"MyApp_Sync\");"
+        }
+      ]
+    },
+    {
+      "id": "sharedspace",
+      "name": "sharedspace",
+      "desc": "Shared collaboration areas where multiple users share texts, images and files together. The space ID is the access capability. MeetRoom binds one space to every meeting room.",
+      "load": "requirelib(\"sharedspace\");",
+      "functions": [
+        {
+          "name": "sharedspace.createSpace",
+          "sig": "sharedspace.createSpace(name)",
+          "desc": "Create a new space owned by the calling user.",
+          "ret": "object {spaceid, name, owner, items, createdat}",
+          "example": "requirelib(\"sharedspace\");\nvar space = sharedspace.createSpace(\"Design sync\");\nsendJSONResp(space);"
+        },
+        {
+          "name": "sharedspace.listMySpaces",
+          "sig": "sharedspace.listMySpaces()",
+          "desc": "List the spaces owned by the calling user.",
+          "ret": "array",
+          "example": "requirelib(\"sharedspace\");\nsendJSONResp(sharedspace.listMySpaces());"
+        },
+        {
+          "name": "sharedspace.getSpaceInfo",
+          "sig": "sharedspace.getSpaceInfo(spaceid)",
+          "desc": "Describe a space by ID. Returns {exists:false} for unknown IDs.",
+          "ret": "object",
+          "example": "requirelib(\"sharedspace\");\nvar info = sharedspace.getSpaceInfo(spaceid);"
+        },
+        {
+          "name": "sharedspace.addText",
+          "sig": "sharedspace.addText(spaceid, text)",
+          "desc": "Post a text snippet (max 4000 chars) into the space.",
+          "ret": "string item ID or null",
+          "example": "requirelib(\"sharedspace\");\nvar itemid = sharedspace.addText(spaceid, \"hello everyone\");"
+        },
+        {
+          "name": "sharedspace.addFile",
+          "sig": "sharedspace.addFile(spaceid, vpath)",
+          "desc": "Copy a file from the calling user's storage into the space. Raster images (png/jpg/jpeg/gif/webp/bmp) become image items.",
+          "ret": "string item ID or null",
+          "example": "requirelib(\"sharedspace\");\nvar itemid = sharedspace.addFile(spaceid, \"user:/Photo/cat.png\");"
+        },
+        {
+          "name": "sharedspace.listItems",
+          "sig": "sharedspace.listItems(spaceid)",
+          "desc": "Chronological item list: {itemid, type, name, text, size, uploader, origin, time}.",
+          "ret": "array or null",
+          "example": "requirelib(\"sharedspace\");\nsendJSONResp(sharedspace.listItems(spaceid));"
+        },
+        {
+          "name": "sharedspace.getText",
+          "sig": "sharedspace.getText(spaceid, itemid)",
+          "desc": "Read the content of a text item.",
+          "ret": "string or null",
+          "example": "requirelib(\"sharedspace\");\nvar text = sharedspace.getText(spaceid, itemid);"
+        },
+        {
+          "name": "sharedspace.saveFileTo",
+          "sig": "sharedspace.saveFileTo(spaceid, itemid, destVpath)",
+          "desc": "Copy an image / file item into the calling user's storage.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.saveFileTo(spaceid, itemid, \"user:/Desktop/shared.png\");"
+        },
+        {
+          "name": "sharedspace.removeItem",
+          "sig": "sharedspace.removeItem(spaceid, itemid)",
+          "desc": "Remove an item. Uploader or space owner only.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.removeItem(spaceid, itemid);"
+        },
+        {
+          "name": "sharedspace.deleteSpace",
+          "sig": "sharedspace.deleteSpace(spaceid)",
+          "desc": "Delete a space and all its items. Space owner only.",
+          "ret": "bool",
+          "example": "requirelib(\"sharedspace\");\nsharedspace.deleteSpace(spaceid);"
+        }
+      ]
+    },
+    {
+      "id": "meetroom",
+      "name": "meetroom",
+      "desc": "Control interface for the MeetRoom video conferencing WebApp: create rooms, end meetings, export attendance. Requires access permission to the MeetRoom module. Every room owns a shared space carrying its chat and files.",
+      "load": "requirelib(\"meetroom\");",
+      "functions": [
+        {
+          "name": "meetroom.createRoom",
+          "sig": "meetroom.createRoom(title, password)",
+          "desc": "Create a meeting room hosted by the calling user. Both arguments optional.",
+          "ret": "object {roomid, displayid, title, host, protected, participants, createdat, spaceid}",
+          "example": "requirelib(\"meetroom\");\nvar room = meetroom.createRoom(\"Weekly standup\", \"\");\nsendJSONResp(room);"
+        },
+        {
+          "name": "meetroom.getRoomInfo",
+          "sig": "meetroom.getRoomInfo(roomid)",
+          "desc": "Describe a room. Returns {exists:false} for unknown IDs. spaceid is only included for the host.",
+          "ret": "object or null",
+          "example": "requirelib(\"meetroom\");\nvar info = meetroom.getRoomInfo(\"123456789\");"
+        },
+        {
+          "name": "meetroom.getRoomSpace",
+          "sig": "meetroom.getRoomSpace(roomid, password)",
+          "desc": "Return the room's shared space ID after passing the room password check. Post into that space with the sharedspace lib to chat into the live meeting.",
+          "ret": "string or null",
+          "example": "requirelib(\"meetroom\");\nrequirelib(\"sharedspace\");\nvar spaceid = meetroom.getRoomSpace(\"123456789\", \"\");\nif (spaceid !== null) sharedspace.addText(spaceid, \"hello meeting\");"
+        },
+        {
+          "name": "meetroom.listMyRooms",
+          "sig": "meetroom.listMyRooms()",
+          "desc": "List the live rooms hosted by the calling user.",
+          "ret": "array",
+          "example": "requirelib(\"meetroom\");\nsendJSONResp(meetroom.listMyRooms());"
+        },
+        {
+          "name": "meetroom.endRoom",
+          "sig": "meetroom.endRoom(roomid)",
+          "desc": "End the meeting for everyone. Host only.",
+          "ret": "bool",
+          "example": "requirelib(\"meetroom\");\nmeetroom.endRoom(\"123456789\");"
+        },
+        {
+          "name": "meetroom.getAttendance",
+          "sig": "meetroom.getAttendance(roomid)",
+          "desc": "Export the attendance log: {username, joinedat, leftat, present} per join; leftat is 0 while connected. Host or connected participant only.",
+          "ret": "array or null",
+          "example": "requirelib(\"meetroom\");\nvar log = meetroom.getAttendance(\"123456789\");\nsendJSONResp(log);"
         }
       ]
     },


### PR DESCRIPTION
## Summary

This PR introduces SharedSpace, a new in-memory collaboration system where multiple users can share texts, images, and files together. It includes full integration with MeetRoom to bind a shared space to every meeting room, allowing scripts to read meeting chat and post content into live meetings.

## Key Changes

### New SharedSpace Module (`mod/sharedspace`)
- **Core functionality**: In-memory spaces with random ID-based access control (capability-based security)
- **Item types**: Text snippets (max 4000 chars), images (raster formats only), and files (up to 128MB configurable)
- **Storage**: Blob items stored on disk in temporary storage; spaces and blobs don't survive server restart
- **Concurrency**: Thread-safe operations with mutex protection
- **Limits**: Configurable per-space item limits (default 1024) and per-blob size limits

### MeetRoom Integration
- **Attendance tracking**: New `AttendanceRecord` type logs every join/leave with timestamps
- **Space binding**: Each room owns a shared space that mirrors chat messages and file uploads
- **Bidirectional sync**: Items posted into a room's space from outside (e.g., AGI scripts) are delivered to the meeting via `SetSpaceItemHandler`
- **Origin tagging**: Items are tagged with their source (`OriginMeetRoom` for room-generated, `agiOriginTag` for script-posted) to prevent echo loops

### AGI Script Libraries
- **`sharedspace` library**: Full API for creating spaces, posting texts/files, listing items, and managing space lifecycle
- **`meetroom` library**: Control interface for creating/ending rooms, checking room status, and accessing attendance logs
- **Space capability exposure**: Space IDs are only revealed to authorized callers (room host or password-verified users)

### MeetRoom UI Enhancements
- **Attendance panel**: New sidebar showing current participants and join/leave history with timestamps
- **Image rendering**: Inline display of uploaded images in chat (raster formats only, SVG excluded for security)
- **Sound effects**: Synthesized chimes for join/leave events using WebAudio API
- **Message toast**: Notification popup for new chat messages when panel is closed
- **Image extensions whitelist**: Client-side validation matching server-side raster format restrictions

### Testing
- Comprehensive test coverage for SharedSpace (item limits, permissions, blob storage)
- MeetRoom tests for attendance tracking and space binding
- AGI library tests for room description and attendance serialization

## Notable Implementation Details

- **Security**: Space IDs act as capabilities; no authentication required if you know the ID. SVG uploads deliberately excluded to prevent script execution from user-uploaded content.
- **Cleanup**: Blob storage is wiped on manager creation to ensure no leftover files from previous runs
- **Chronological ordering**: Items are stored in order of creation across mixed success/failure operations
- **Permission model**: Only item uploaders or space owners can remove items; only space owners can delete spaces
- **AGI integration**: Both libraries gate access through existing module permissions (MeetRoom) or user credentials (SharedSpace)

https://claude.ai/code/session_0186iLM3a3oY85KQqPiLHXWj