### PR TITLE
Add message context menu, thread editing, and keyboard navigation

### DIFF
--- a/src/mod/agi/README.md
+++ b/src/mod/agi/README.md
@@ -431,12 +431,62 @@ Load:
 requirelib("http");
 ```
 
-### `http.get(url)`
+### `http.request(options)`
+Curl-like request giving full control over the method, headers and body. Returns
+a response object `{ok, status, statusText, headers, body, error}` (`error` is a
+non-empty string when the request could not be completed; `body` is base64 when
+`responseType` is `"base64"`).
+
+Supported `options`:
+
+| Field | Description |
+|-------|-------------|
+| `url` | Target URL (required) |
+| `method` | HTTP method, default `GET` (case-insensitive) |
+| `headers` | Object of request headers to set, e.g. `{"Authorization":"Bearer x"}` |
+| `body` | Raw text request body |
+| `json` | Object sent as a JSON body (sets `Content-Type: application/json`) |
+| `form` | Object sent as `application/x-www-form-urlencoded` |
+| `bodyBase64` | Binary request body, base64 encoded (sets `application/octet-stream`) |
+| `contentType` | Override the `Content-Type` header |
+| `username` / `password` | HTTP basic auth credentials |
+| `timeout` | Timeout in seconds (`0` / omitted = no timeout) |
+| `followRedirect` | Follow 3xx redirects (default `true`) |
+| `responseType` | `"text"` (default) or `"base64"` for binary responses |
+
+Body precedence when several are supplied: `bodyBase64` > `form` > `json` > `body`.
+
 ```javascript
-var body = http.get("https://example.com");
+var resp = http.request({
+    url: "https://example.com/api",
+    method: "POST",
+    headers: {"Authorization": "Bearer TOKEN"},
+    json: {a: 1, b: 2}
+});
+if (resp.ok){
+    console.log(resp.status, resp.body);
+}
 ```
 
-### `http.post(url, jsonString)`
+Convenience helpers built on `http.request` (all return the response object):
+`http.put(url, body, headers, contentType)`,
+`http.patch(url, body, headers, contentType)`,
+`http.delete(url, headers)`,
+`http.postForm(url, formObject, headers)` and
+`http.postJSON(url, object, headers)`.
+
+### `http.get(url, headers)`
+`headers` is optional. Without it, returns the body string (or `null` on error)
+for backward compatibility; with it, returns the response body string.
+```javascript
+var body = http.get("https://example.com");
+var body2 = http.get("https://example.com", {"Authorization": "Bearer x"});
+```
+
+### `http.post(url, body, headers, contentType)`
+`headers` and `contentType` are optional. Without them the body is sent as JSON
+(backward compatible); with them the given headers / content type are used.
+Returns the response body string.
 ```javascript
 var body = http.post("https://example.com/api", JSON.stringify({a:1}));
 ```

--- a/src/mod/agi/agi.go
+++ b/src/mod/agi/agi.go
@@ -39,7 +39,7 @@ import (
 */
 
 var (
-	AgiVersion string = "3.4" //Defination of the agi runtime version. Update this when new function is added
+	AgiVersion string = "3.5" //Defination of the agi runtime version. Update this when new function is added
 
 	//AGI Internal Error Standard
 	errExitcall = errors.New("errExit")

--- a/src/mod/agi/agi.http.go
+++ b/src/mod/agi/agi.http.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/robertkrimen/otto"
 	"imuslab.com/arozos/mod/agi/static"
@@ -23,14 +25,149 @@ import (
 	This is a library for allowing AGI script to make HTTP Request from the VM
 	Returning either the head or the body of the request
 
+	In addition to the classic helpers (get / post / head / download / getb64 /
+	getCode / redirect), the library exposes a curl-like http.request(options)
+	function that lets a script pick the method, set arbitrary request headers,
+	send a raw / JSON / url-encoded form / binary (base64) body, use HTTP basic
+	auth, set a timeout and control redirect following, then read back the
+	status code, response headers and body of the reply.
+
 	Author: tobychui
 */
+
+// httpRequestOptions mirrors the JS options object passed to http.request. It
+// covers the most common parameters curl supports (method, headers, request
+// body in several shapes, basic auth, timeout and redirect handling).
+type httpRequestOptions struct {
+	URL            string            `json:"url"`            //Target URL (required)
+	Method         string            `json:"method"`         //HTTP method, default GET
+	Headers        map[string]string `json:"headers"`        //Request headers to set
+	Body           string            `json:"body"`           //Raw text request body
+	BodyBase64     string            `json:"bodyBase64"`     //Binary request body, base64 encoded
+	Form           map[string]string `json:"form"`           //application/x-www-form-urlencoded body
+	JSON           json.RawMessage   `json:"json"`           //JSON request body (sets Content-Type)
+	ContentType    string            `json:"contentType"`    //Override the Content-Type header
+	Username       string            `json:"username"`       //HTTP basic auth username
+	Password       string            `json:"password"`       //HTTP basic auth password
+	Timeout        float64           `json:"timeout"`        //Timeout in seconds (0 = no timeout)
+	FollowRedirect *bool             `json:"followRedirect"` //Follow 3xx redirects (default true)
+	ResponseType   string            `json:"responseType"`   //"text" (default) or "base64" for binary
+}
+
+// httpResponse is the object returned by http.request describing the reply.
+type httpResponse struct {
+	Ok         bool                `json:"ok"`         //True when the status code is in the 2xx range
+	Status     int                 `json:"status"`     //HTTP status code
+	StatusText string              `json:"statusText"` //HTTP status line text
+	Headers    map[string][]string `json:"headers"`    //Response headers
+	Body       string              `json:"body"`       //Response body (text, or base64 when responseType is "base64")
+	Error      string              `json:"error"`      //Non-empty when the request could not be completed
+}
 
 func (g *Gateway) HTTPLibRegister() {
 	err := g.RegisterLib("http", g.injectHTTPFunctions)
 	if err != nil {
 		logger.PrintAndLog("Agi", fmt.Sprint(err), nil)
 		os.Exit(1)
+	}
+}
+
+// buildHTTPRequestBody resolves the request body and default Content-Type from
+// the given options. Body precedence is: bodyBase64 > form > json > body.
+func buildHTTPRequestBody(opt httpRequestOptions) (io.Reader, string, error) {
+	switch {
+	case opt.BodyBase64 != "":
+		raw, err := base64.StdEncoding.DecodeString(opt.BodyBase64)
+		if err != nil {
+			return nil, "", errors.New("invalid bodyBase64: " + err.Error())
+		}
+		return bytes.NewReader(raw), "application/octet-stream", nil
+	case len(opt.Form) > 0:
+		values := url.Values{}
+		for k, v := range opt.Form {
+			values.Set(k, v)
+		}
+		return strings.NewReader(values.Encode()), "application/x-www-form-urlencoded", nil
+	case len(opt.JSON) > 0:
+		return bytes.NewReader(opt.JSON), "application/json", nil
+	case opt.Body != "":
+		return strings.NewReader(opt.Body), "", nil
+	default:
+		return nil, "", nil
+	}
+}
+
+// doHTTPRequest builds and executes an HTTP request from the given options and
+// returns a populated httpResponse. Any transport-level failure is reported via
+// the Error field rather than as a Go error so scripts always get an object.
+func doHTTPRequest(opt httpRequestOptions) httpResponse {
+	if strings.TrimSpace(opt.URL) == "" {
+		return httpResponse{Error: "missing request url"}
+	}
+
+	method := strings.ToUpper(strings.TrimSpace(opt.Method))
+	if method == "" {
+		method = "GET"
+	}
+
+	body, defaultContentType, err := buildHTTPRequestBody(opt)
+	if err != nil {
+		return httpResponse{Error: err.Error()}
+	}
+
+	req, err := http.NewRequest(method, opt.URL, body)
+	if err != nil {
+		return httpResponse{Error: err.Error()}
+	}
+
+	//Apply a default Content-Type for the chosen body, then let explicit
+	//headers / the contentType option override it.
+	if defaultContentType != "" {
+		req.Header.Set("Content-Type", defaultContentType)
+	}
+	req.Header.Set("User-Agent", "arozos-http-client/1.1")
+	for k, v := range opt.Headers {
+		req.Header.Set(k, v)
+	}
+	if strings.TrimSpace(opt.ContentType) != "" {
+		req.Header.Set("Content-Type", opt.ContentType)
+	}
+	if opt.Username != "" || opt.Password != "" {
+		req.SetBasicAuth(opt.Username, opt.Password)
+	}
+
+	client := &http.Client{}
+	if opt.Timeout > 0 {
+		client.Timeout = time.Duration(opt.Timeout * float64(time.Second))
+	}
+	if opt.FollowRedirect != nil && !*opt.FollowRedirect {
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return httpResponse{Error: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	bodyContent, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return httpResponse{Error: err.Error()}
+	}
+
+	bodyString := string(bodyContent)
+	if strings.ToLower(strings.TrimSpace(opt.ResponseType)) == "base64" {
+		bodyString = base64.StdEncoding.EncodeToString(bodyContent)
+	}
+
+	return httpResponse{
+		Ok:         resp.StatusCode >= 200 && resp.StatusCode < 300,
+		Status:     resp.StatusCode,
+		StatusText: resp.Status,
+		Headers:    resp.Header,
+		Body:       bodyString,
 	}
 }
 
@@ -41,6 +178,26 @@ func (g *Gateway) injectHTTPFunctions(payload *static.AgiLibInjectionPayload) {
 	//scriptPath := payload.ScriptPath
 	w := payload.Writer
 	//r := payload.Request
+
+	//_http_request(optionsJSON) => response object as JSON string. This is the
+	//curl-like entry point backing http.request and all method helpers.
+	vm.Set("_http_request", func(call otto.FunctionCall) otto.Value {
+		opt := httpRequestOptions{}
+		optJSON := getOttoStringArg(call, 0)
+		if s := strings.TrimSpace(optJSON); s != "" && s != "undefined" && s != "null" {
+			if err := json.Unmarshal([]byte(optJSON), &opt); err != nil {
+				out, _ := json.Marshal(httpResponse{Error: "invalid request options: " + err.Error()})
+				rv, _ := vm.ToValue(string(out))
+				return rv
+			}
+		}
+
+		resp := doHTTPRequest(opt)
+		out, _ := json.Marshal(resp)
+		rv, _ := vm.ToValue(string(out))
+		return rv
+	})
+
 	vm.Set("_http_get", func(call otto.FunctionCall) otto.Value {
 		//Get URL from function variable
 		url, err := call.Argument(0).ToString()
@@ -276,11 +433,53 @@ func (g *Gateway) injectHTTPFunctions(payload *static.AgiLibInjectionPayload) {
 		return otto.TrueValue()
 	})
 
-	//Wrap all the native code function into an imagelib class
+	//Wrap all the native code function into an http class
 	vm.Run(`
 		var http = {};
-		http.get = _http_get;
-		http.post = _http_post;
+
+		//http.request(options) => response object {ok, status, statusText, headers, body, error}
+		//options: {url, method, headers, body, bodyBase64, form, json, contentType,
+		//          username, password, timeout, followRedirect, responseType}
+		http.request = function(options){
+			return JSON.parse(_http_request(JSON.stringify(options || {})));
+		};
+
+		//Classic helpers. http.get / http.post now accept optional headers.
+		http.get = function(url, headers){
+			if (typeof headers == "undefined"){
+				//Backward-compatible fast path: returns body string (or null on error)
+				return _http_get(url);
+			}
+			return http.request({url: url, method: "GET", headers: headers}).body;
+		};
+		http.post = function(url, body, headers, contentType){
+			if (typeof headers == "undefined" && typeof contentType == "undefined"){
+				//Backward-compatible fast path: JSON body, returns body string
+				return _http_post(url, body);
+			}
+			return http.request({
+				url: url, method: "POST", body: body,
+				headers: headers, contentType: contentType
+			}).body;
+		};
+
+		//Method + body-shape convenience helpers built on http.request.
+		http.put = function(url, body, headers, contentType){
+			return http.request({url: url, method: "PUT", body: body, headers: headers, contentType: contentType});
+		};
+		http.patch = function(url, body, headers, contentType){
+			return http.request({url: url, method: "PATCH", body: body, headers: headers, contentType: contentType});
+		};
+		http.delete = function(url, headers){
+			return http.request({url: url, method: "DELETE", headers: headers});
+		};
+		http.postForm = function(url, form, headers){
+			return http.request({url: url, method: "POST", form: form, headers: headers});
+		};
+		http.postJSON = function(url, obj, headers){
+			return http.request({url: url, method: "POST", json: obj, headers: headers});
+		};
+
 		http.head = _http_head;
 		http.download = _http_download;
 		http.getb64 = _http_getb64;

--- a/src/mod/agi/agi.http_test.go
+++ b/src/mod/agi/agi.http_test.go
@@ -1,0 +1,291 @@
+package agi
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/robertkrimen/otto"
+	"imuslab.com/arozos/mod/agi/static"
+	user "imuslab.com/arozos/mod/user"
+)
+
+// ─── body builder ────────────────────────────────────────────────────────────
+
+func TestBuildHTTPRequestBody(t *testing.T) {
+	//bodyBase64 takes precedence and decodes to raw bytes
+	t.Run("base64", func(t *testing.T) {
+		raw := []byte{0x00, 0x01, 0x02, 0xff}
+		opt := httpRequestOptions{BodyBase64: base64.StdEncoding.EncodeToString(raw)}
+		r, ct, err := buildHTTPRequestBody(opt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ct != "application/octet-stream" {
+			t.Errorf("unexpected content-type: %q", ct)
+		}
+		got, _ := io.ReadAll(r)
+		if string(got) != string(raw) {
+			t.Errorf("binary body not decoded correctly: %v", got)
+		}
+	})
+
+	t.Run("invalid base64", func(t *testing.T) {
+		_, _, err := buildHTTPRequestBody(httpRequestOptions{BodyBase64: "!!!not base64!!!"})
+		if err == nil {
+			t.Error("expected error for invalid base64 body")
+		}
+	})
+
+	t.Run("form", func(t *testing.T) {
+		opt := httpRequestOptions{Form: map[string]string{"a": "1", "b": "hello world"}}
+		r, ct, err := buildHTTPRequestBody(opt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ct != "application/x-www-form-urlencoded" {
+			t.Errorf("unexpected content-type: %q", ct)
+		}
+		got, _ := io.ReadAll(r)
+		values, _ := url.ParseQuery(string(got))
+		if values.Get("a") != "1" || values.Get("b") != "hello world" {
+			t.Errorf("form not encoded correctly: %q", string(got))
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		opt := httpRequestOptions{JSON: json.RawMessage(`{"x":1}`)}
+		r, ct, err := buildHTTPRequestBody(opt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ct != "application/json" {
+			t.Errorf("unexpected content-type: %q", ct)
+		}
+		got, _ := io.ReadAll(r)
+		if strings.TrimSpace(string(got)) != `{"x":1}` {
+			t.Errorf("json body mismatch: %q", string(got))
+		}
+	})
+
+	t.Run("raw", func(t *testing.T) {
+		opt := httpRequestOptions{Body: "plain text"}
+		r, ct, err := buildHTTPRequestBody(opt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ct != "" {
+			t.Errorf("raw body should carry no default content-type, got %q", ct)
+		}
+		got, _ := io.ReadAll(r)
+		if string(got) != "plain text" {
+			t.Errorf("raw body mismatch: %q", string(got))
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		r, ct, err := buildHTTPRequestBody(httpRequestOptions{})
+		if err != nil || r != nil || ct != "" {
+			t.Errorf("empty options should yield no body, got r=%v ct=%q err=%v", r, ct, err)
+		}
+	})
+}
+
+// ─── request execution ───────────────────────────────────────────────────────
+
+func TestDoHTTPRequestMethodHeadersAndBody(t *testing.T) {
+	var gotMethod, gotHeader, gotBody, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotHeader = r.Header.Get("X-Custom")
+		gotContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("X-Reply", "pong")
+		w.WriteHeader(201)
+		io.WriteString(w, "created")
+	}))
+	defer srv.Close()
+
+	resp := doHTTPRequest(httpRequestOptions{
+		URL:     srv.URL,
+		Method:  "put",
+		Headers: map[string]string{"X-Custom": "yes"},
+		Body:    "the payload",
+	})
+
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+	if gotMethod != "PUT" {
+		t.Errorf("method not applied/uppercased, got %q", gotMethod)
+	}
+	if gotHeader != "yes" {
+		t.Errorf("custom header not sent, got %q", gotHeader)
+	}
+	if gotBody != "the payload" {
+		t.Errorf("body not sent, got %q", gotBody)
+	}
+	if gotContentType != "" {
+		t.Errorf("raw body should not set a content-type, got %q", gotContentType)
+	}
+	if resp.Status != 201 || !resp.Ok {
+		t.Errorf("status/ok mismatch: status=%d ok=%v", resp.Status, resp.Ok)
+	}
+	if resp.Body != "created" {
+		t.Errorf("response body mismatch: %q", resp.Body)
+	}
+	if len(resp.Headers["X-Reply"]) == 0 || resp.Headers["X-Reply"][0] != "pong" {
+		t.Errorf("response headers not captured: %v", resp.Headers)
+	}
+}
+
+func TestDoHTTPRequestFormAndContentTypeOverride(t *testing.T) {
+	var gotContentType, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	//Form body sets the urlencoded content type by default.
+	resp := doHTTPRequest(httpRequestOptions{URL: srv.URL, Method: "POST", Form: map[string]string{"k": "v"}})
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+	if gotContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("form content-type not defaulted, got %q", gotContentType)
+	}
+	if values, _ := url.ParseQuery(gotBody); values.Get("k") != "v" {
+		t.Errorf("form body mismatch: %q", gotBody)
+	}
+
+	//Explicit contentType option overrides the default.
+	doHTTPRequest(httpRequestOptions{URL: srv.URL, Method: "POST", Body: "x", ContentType: "text/csv"})
+	if gotContentType != "text/csv" {
+		t.Errorf("contentType override not applied, got %q", gotContentType)
+	}
+}
+
+func TestDoHTTPRequestBinaryResponse(t *testing.T) {
+	raw := []byte{0x10, 0x20, 0x30, 0xff, 0x00}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(raw)
+	}))
+	defer srv.Close()
+
+	resp := doHTTPRequest(httpRequestOptions{URL: srv.URL, ResponseType: "base64"})
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(resp.Body)
+	if err != nil {
+		t.Fatalf("response body was not valid base64: %v", err)
+	}
+	if string(decoded) != string(raw) {
+		t.Errorf("binary response mismatch: %v", decoded)
+	}
+}
+
+func TestDoHTTPRequestBasicAuth(t *testing.T) {
+	var gotUser, gotPass string
+	var ok bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotPass, ok = r.BasicAuth()
+		io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	doHTTPRequest(httpRequestOptions{URL: srv.URL, Username: "alice", Password: "s3cr3t"})
+	if !ok || gotUser != "alice" || gotPass != "s3cr3t" {
+		t.Errorf("basic auth not applied: user=%q pass=%q ok=%v", gotUser, gotPass, ok)
+	}
+}
+
+func TestDoHTTPRequestNoFollowRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/dest", http.StatusFound)
+			return
+		}
+		io.WriteString(w, "final")
+	}))
+	defer srv.Close()
+
+	follow := false
+	resp := doHTTPRequest(httpRequestOptions{URL: srv.URL + "/start", FollowRedirect: &follow})
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+	if resp.Status != http.StatusFound {
+		t.Errorf("expected 302 when not following redirect, got %d", resp.Status)
+	}
+	if len(resp.Headers["Location"]) == 0 || !strings.HasSuffix(resp.Headers["Location"][0], "/dest") {
+		t.Errorf("expected Location header, got %v", resp.Headers)
+	}
+}
+
+func TestDoHTTPRequestMissingURL(t *testing.T) {
+	resp := doHTTPRequest(httpRequestOptions{})
+	if resp.Error == "" {
+		t.Error("expected an error when url is missing")
+	}
+}
+
+// ─── JS object exposure ─────────────────────────────────────────────────────
+
+func TestInjectHTTPLib_JSObjectExposed(t *testing.T) {
+	g := minimalGateway()
+	vm := otto.New()
+	payload := &static.AgiLibInjectionPayload{VM: vm, User: &user.User{Username: "alice"}}
+	g.injectHTTPFunctions(payload)
+
+	for _, method := range []string{"request", "get", "post", "put", "patch", "delete", "postForm", "postJSON", "head", "download", "getb64", "getCode", "redirect"} {
+		val, err := vm.Run(`typeof http.` + method)
+		if err != nil {
+			t.Fatalf("evaluating http.%s: %v", method, err)
+		}
+		s, _ := val.ToString()
+		if s != "function" {
+			t.Errorf("http.%s should be a function, got %q", method, s)
+		}
+	}
+}
+
+func TestHTTPRequestFromVM(t *testing.T) {
+	var gotMethod, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		io.WriteString(w, "hello vm")
+	}))
+	defer srv.Close()
+
+	g := minimalGateway()
+	vm := otto.New()
+	payload := &static.AgiLibInjectionPayload{VM: vm, User: &user.User{Username: "alice"}}
+	g.injectHTTPFunctions(payload)
+
+	val, err := vm.Run(`
+		var resp = http.request({url: "` + srv.URL + `", method: "POST", body: "vm-body"});
+		resp.status + "|" + resp.ok + "|" + resp.body;
+	`)
+	if err != nil {
+		t.Fatalf("vm run error: %v", err)
+	}
+	out, _ := val.ToString()
+	if out != "200|true|hello vm" {
+		t.Errorf("unexpected VM response object: %q", out)
+	}
+	if gotMethod != "POST" || gotBody != "vm-body" {
+		t.Errorf("request not sent as expected: method=%q body=%q", gotMethod, gotBody)
+	}
+}

--- a/src/mod/agi/agi.llm.go
+++ b/src/mod/agi/agi.llm.go
@@ -58,8 +58,10 @@ const (
 	//key field was left untouched. When received, the stored key is kept.
 	llmKeyMask = "********"
 
-	//llmRequestTimeout is the maximum time to wait for a completion.
-	llmRequestTimeout = 120 * time.Second
+	//llmRequestTimeout is the maximum time to wait for a completion. Large
+	//reasoning / agentic models can legitimately take many minutes to reply,
+	//so this is set generously to 60 minutes to avoid cutting long calls short.
+	llmRequestTimeout = 60 * time.Minute
 )
 
 // llmMetricsMux guards read-modify-write cycles on the metrics record so

--- a/src/web/Chatspace/app.css
+++ b/src/web/Chatspace/app.css
@@ -215,7 +215,7 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
     font-size: 13px;
 }
 
-.sr-row:hover { background: #f0eef1; }
+.sr-row:hover, .sr-row.selected { background: #f0eef1; }
 .sr-row .sr-convo { font-weight: 700; white-space: nowrap; }
 .sr-row .sr-snippet { color: var(--cs-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
 .sr-row .sr-time { color: var(--cs-muted); font-size: 11px; white-space: nowrap; }
@@ -1424,8 +1424,12 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
     font-size: 14px;
 }
 
-.pick-row:hover { background: var(--cs-hover); }
-.pick-row .avatar { width: 26px; height: 26px; border-radius: 6px; overflow: hidden; }
+.pick-row:hover, .pick-row.kbfocus { background: var(--cs-hover); }
+/* position:relative + overflow:visible so the presence dot can overlay the
+   avatar corner instead of floating as a separate column between avatar/name */
+.pick-row .avatar { width: 26px; height: 26px; border-radius: 6px; position: relative; }
+.pick-row .avatar > .cs-avatar-img, .pick-row .avatar > .avatar-fallback { border-radius: 6px; overflow: hidden; }
+.pick-row .avatar .presence-dot { position: absolute; right: -3px; bottom: -3px; margin: 0; border: 2px solid #fff; }
 .pick-row .pick-name { flex: 1; font-weight: 600; }
 .pick-row .pick-check { color: var(--cs-green); visibility: hidden; }
 .pick-row.picked .pick-check { visibility: visible; }

--- a/src/web/Chatspace/app.css
+++ b/src/web/Chatspace/app.css
@@ -221,6 +221,12 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 .sr-row .sr-time { color: var(--cs-muted); font-size: 11px; white-space: nowrap; }
 .sr-empty { padding: 14px; color: var(--cs-muted); font-size: 13px; }
 
+/* Search empty-state hint (shown when the box is focused but blank) */
+.sr-hint { padding: 16px 14px 12px 14px; border-bottom: 1px solid var(--cs-border); }
+.sr-hint-title { font-weight: 700; font-size: 14px; color: var(--cs-text); display: flex; align-items: center; gap: 6px; }
+.sr-hint-title i.icon { color: var(--cs-muted); font-size: 13px; margin: 0; }
+.sr-hint-sub { margin-top: 4px; font-size: 12.5px; color: var(--cs-muted); line-height: 1.4; }
+
 .tb-right { display: flex; }
 
 /* ================= Body grid ================= */
@@ -319,7 +325,9 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
     align-items: center;
     gap: 4px;
     font-size: 14px;
-    padding: 3px 16px;
+    /* left pad matches an item row (margin 8 + padding 16) so the collapse
+       caret sits in the same column as the # / lock / + row icons */
+    padding: 3px 16px 3px 24px;
     color: var(--cs-onpurple-dim);
     cursor: pointer;
     user-select: none;
@@ -1208,8 +1216,10 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 .rp-section h4 { margin: 0 0 4px 0; font-size: 13px; }
 .rp-section .rp-value { font-size: 13.5px; }
 .rp-section .rp-sub { font-size: 12px; color: var(--cs-muted); margin-top: 2px; }
-.rp-section .rp-editlink { font-size: 12px; color: var(--cs-link); cursor: pointer; margin-left: 8px; font-weight: 600; }
-.rp-section .rp-editlink:hover { text-decoration: underline; }
+/* Global so the Edit link keeps its gap in the details modal too, not just
+   inside .rp-section (otherwise it renders as "Add a topicEdit"). */
+.rp-editlink { font-size: 12px; color: var(--cs-link); cursor: pointer; margin-left: 8px; font-weight: 600; }
+.rp-editlink:hover { text-decoration: underline; }
 
 .rp-action-row {
     display: flex;

--- a/src/web/Chatspace/app.css
+++ b/src/web/Chatspace/app.css
@@ -756,6 +756,38 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 
 .dl-menu-btn { background: none; }
 
+/* message right-click context menu */
+#msgContextMenu {
+    position: fixed;
+    background: #fff;
+    border: 1px solid var(--cs-border);
+    border-radius: 10px;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+    z-index: 500;
+    padding: 6px 0;
+    width: 240px;
+    max-width: calc(100vw - 16px);
+}
+
+.cm-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 7px 14px;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--cs-text);
+}
+
+.cm-row:hover { background: var(--cs-hover); }
+.cm-row i.icon { width: 18px; text-align: center; margin: 0; font-size: 14px; color: var(--cs-muted); flex-shrink: 0; }
+.cm-label { flex: 1; }
+.cm-key { font-size: 12px; color: var(--cs-muted); flex-shrink: 0; }
+.cm-row.danger { color: #c22f2f; }
+.cm-row.danger i.icon { color: #c22f2f; }
+.cm-row.danger:hover { background: #fdeaea; }
+.cm-sep { border-top: 1px solid var(--cs-border); margin: 5px 0; }
+
 /* video / audio / text previews */
 .media-preview { display: block; }
 
@@ -781,7 +813,7 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 .media-foot .file-size { font-size: 12px; color: var(--cs-muted); }
 .media-foot .dl-menu-btn { margin-left: -4px; }
 
-.text-preview-wrap { max-width: 520px; }
+.text-preview-wrap { max-width: min(520px, 100%); }
 
 .text-preview {
     font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
@@ -830,7 +862,10 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 
 .msg-img {
     display: block;
-    max-width: 360px;
+    /* min(...,100%) keeps the 360px cap in the wide pane but never exceeds a
+       narrow container (e.g. the thread panel), which used to force a
+       horizontal scrollbar */
+    max-width: min(360px, 100%);
     max-height: 280px;
     border-radius: 12px;
     border: 1px solid var(--cs-border);

--- a/src/web/Chatspace/app.css
+++ b/src/web/Chatspace/app.css
@@ -949,7 +949,11 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 /* thread summary bar */
 
 .msg-thread-bar {
-    display: inline-flex;
+    /* block-level (own line) so it sits below an inline-block image preview
+       instead of floating to its right, but width:fit-content keeps the
+       compact pill shape */
+    display: flex;
+    width: fit-content;
     align-items: center;
     gap: 8px;
     margin-top: 4px;

--- a/src/web/Chatspace/app.css
+++ b/src/web/Chatspace/app.css
@@ -1410,6 +1410,7 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
     border-bottom: 1px solid #f0f0f0;
 }
 
+.browse-row.kbfocus { background: var(--cs-hover); }
 .browse-row .browse-name { font-weight: 800; font-size: 14.5px; }
 .browse-row .browse-name i.icon { font-size: 12px; color: var(--cs-muted); }
 .browse-row .browse-sub { font-size: 12.5px; color: var(--cs-muted); margin-top: 2px; }

--- a/src/web/Chatspace/app.css
+++ b/src/web/Chatspace/app.css
@@ -424,9 +424,15 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
     flex-shrink: 0;
 }
 
-.ch-left { display: flex; align-items: center; gap: 6px; min-width: 0; }
+/* overflow:hidden stops the name / topic from spilling over the right-hand
+   action buttons (star, members, huddle) when the pane is narrow. */
+.ch-left { display: flex; align-items: center; gap: 6px; min-width: 0; overflow: hidden; }
 
 #chNameBtn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;              /* let the channel name truncate instead of pushing siblings out */
     font-size: 17.5px;
     font-weight: 900;
     color: var(--cs-text);
@@ -436,7 +442,8 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 }
 
 #chNameBtn:hover { background: var(--cs-hover); }
-#chNameBtn i.icon { font-size: 11px; color: var(--cs-muted); }
+#chNameBtn i.icon { font-size: 11px; color: var(--cs-muted); flex-shrink: 0; }
+#chName { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 
 #chStarBtn {
     color: var(--cs-muted);
@@ -444,6 +451,7 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
     height: 28px;
     border-radius: 6px;
     font-size: 14px;
+    flex-shrink: 0;
 }
 
 #chStarBtn:hover { background: var(--cs-hover); }
@@ -458,6 +466,7 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
     text-overflow: ellipsis;
     cursor: pointer;
     min-width: 0;
+    flex-shrink: 100;         /* the secondary topic yields space before the name truncates */
 }
 
 #chTopic:hover { text-decoration: underline; }

--- a/src/web/Chatspace/app.css
+++ b/src/web/Chatspace/app.css
@@ -48,13 +48,18 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 
 #app {
     display: grid;
-    grid-template-columns: 68px 1fr;
+    /* minmax(0, 1fr) floors the body track at 0 instead of its min-content;
+       without it the sidebar + content + right (thread) panel min-widths
+       force the track wider than the viewport, pushing the panel - and its
+       close button - off the right edge on narrow / floatWindow widths. */
+    grid-template-columns: 68px minmax(0, 1fr);
     grid-template-rows: 44px 1fr;
     grid-template-areas:
         "topbar topbar"
         "rail body";
     height: 100vh;
     width: 100vw;
+    overflow: hidden;
 }
 
 /* ================= Left rail ================= */
@@ -224,6 +229,9 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
     grid-area: body;
     display: flex;
     min-height: 0;
+    /* Allow the flex row to shrink to its grid track so the thread panel
+       and its close button stay within the viewport when space is tight. */
+    min-width: 0;
     padding: 0 4px 4px 0;
     gap: 4px;
 }

--- a/src/web/Chatspace/app.js
+++ b/src/web/Chatspace/app.js
@@ -1236,16 +1236,14 @@
         starred.forEach(function (convo) { starredHtml += convoItemHtml(convo); });
         $id("sbStarredList").innerHTML = starredHtml;
 
+        //Starred conversations are surfaced in the Starred shortcut section
+        //but still listed under their own Channels / Direct messages section.
         var chHtml = "";
-        channels.forEach(function (convo) {
-            if (!isStarred(convo.id)) chHtml += convoItemHtml(convo);
-        });
+        channels.forEach(function (convo) { chHtml += convoItemHtml(convo); });
         $id("sbChannelList").innerHTML = chHtml;
 
         var dmHtml = "";
-        dms.forEach(function (convo) {
-            if (!isStarred(convo.id)) dmHtml += convoItemHtml(convo);
-        });
+        dms.forEach(function (convo) { dmHtml += convoItemHtml(convo); });
         $id("sbDmList").innerHTML = dmHtml;
 
         //Collapse states
@@ -1777,7 +1775,9 @@
                 openProfile(el.getAttribute("data-profile"));
             });
         });
-        Array.prototype.forEach.call(node.querySelectorAll(".mention"), function (el) {
+        //Only real-user mentions carry data-user and open a profile; broadcast
+        //(@everyone/@channel) and the @ai handle are not people, so skip them.
+        Array.prototype.forEach.call(node.querySelectorAll(".mention[data-user]"), function (el) {
             el.addEventListener("click", function (e) {
                 e.stopPropagation();
                 openProfile(el.getAttribute("data-user"));
@@ -3214,10 +3214,51 @@
 
     var searchTimer = null;
 
+    //Wire jump-on-click for every result / recent row in the search dropdown
+    function wireSearchRows(box) {
+        Array.prototype.forEach.call(box.querySelectorAll(".sr-row"), function (row) {
+            row.addEventListener("click", function () {
+                box.style.display = "none";
+                $id("searchInput").value = "";
+                var convoId = row.getAttribute("data-convo");
+                var msgId = row.getAttribute("data-msg");
+                if (msgId) jumpToMessage(convoId, msgId);
+                else setActive(convoId);
+            });
+        });
+    }
+
+    //Slack-style empty state shown when the search box is focused but blank:
+    //a short hint plus recent conversations as quick jumps.
+    function showSearchEmptyState() {
+        var box = $id("searchResults");
+        var html = '<div class="sr-hint">' +
+            '<div class="sr-hint-title"><i class="search icon"></i>Search messages, files and more</div>' +
+            '<div class="sr-hint-sub">Looking for a particular message, file or conversation? ' +
+            'If it happened in Chatspace, you can find it here.</div></div>';
+        var recents = joinedConvos().slice();
+        recents.sort(function (a, b) {
+            var ta = a.roots.length ? a.roots[a.roots.length - 1].time : 0;
+            var tb = b.roots.length ? b.roots[b.roots.length - 1].time : 0;
+            return tb - ta;
+        });
+        recents = recents.slice(0, 6);
+        if (recents.length > 0) {
+            html += '<div class="sr-group">Recent</div>';
+            recents.forEach(function (convo) {
+                html += '<div class="sr-row" data-convo="' + escapeAttr(convo.id) + '">' +
+                    '<span class="sr-convo">' + (convo.kind === "dm" ? "" : "#") + escapeHtml(convoLabel(convo)) + '</span></div>';
+            });
+        }
+        box.innerHTML = html;
+        box.style.display = "";
+        wireSearchRows(box);
+    }
+
     function runSearch() {
         var query = $id("searchInput").value.trim().toLowerCase();
         var box = $id("searchResults");
-        if (query === "") { box.style.display = "none"; return; }
+        if (query === "") { showSearchEmptyState(); return; }
 
         var convoHits = [];
         var msgHits = [];
@@ -3257,16 +3298,7 @@
         if (html === "") html = '<div class="sr-empty">No results for "' + escapeHtml(query) + '"</div>';
         box.innerHTML = html;
         box.style.display = "";
-        Array.prototype.forEach.call(box.querySelectorAll(".sr-row"), function (row) {
-            row.addEventListener("click", function () {
-                box.style.display = "none";
-                $id("searchInput").value = "";
-                var convoId = row.getAttribute("data-convo");
-                var msgId = row.getAttribute("data-msg");
-                if (msgId) jumpToMessage(convoId, msgId);
-                else setActive(convoId);
-            });
-        });
+        wireSearchRows(box);
     }
 
     /* ================= Rail views ================= */
@@ -3320,7 +3352,8 @@
             searchTimer = setTimeout(runSearch, 200);
         });
         $id("searchInput").addEventListener("focus", function () {
-            if (this.value.trim() !== "") runSearch();
+            //Show results when there is a query, otherwise the empty-state hint
+            runSearch();
         });
 
         //Sidebar

--- a/src/web/Chatspace/app.js
+++ b/src/web/Chatspace/app.js
@@ -2979,6 +2979,7 @@
 
     function openBrowseModal() {
         $id("browseFilter").value = "";
+        browseKb = 0;
         renderBrowseList();
         openModal("browseModal");
         //Refresh the public directory while the modal is open
@@ -3030,6 +3031,41 @@
                 previewChannel(btn.getAttribute("data-preview"));
             });
         });
+        Array.prototype.forEach.call(document.querySelectorAll("#browseList .browse-row"), function (row, idx) {
+            row.addEventListener("mouseenter", function () { browseKb = idx; applyBrowseFocus(); });
+        });
+        applyBrowseFocus();
+    }
+
+    //Keyboard control for the Browse channels list: arrows move the cursor,
+    //Enter triggers the highlighted row's Open / View button.
+    var browseKb = 0;
+
+    function applyBrowseFocus() {
+        var rows = $id("browseList").querySelectorAll(".browse-row");
+        if (browseKb > rows.length - 1) browseKb = rows.length - 1;
+        if (browseKb < 0) browseKb = 0;
+        for (var i = 0; i < rows.length; i++) rows[i].classList.toggle("kbfocus", i === browseKb);
+    }
+
+    function browseKeydown(e) {
+        var rows = $id("browseList").querySelectorAll(".browse-row");
+        if (rows.length === 0) return;
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            browseKb = (browseKb + 1) % rows.length;
+            applyBrowseFocus();
+            rows[browseKb].scrollIntoView({ block: "nearest" });
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            browseKb = (browseKb - 1 + rows.length) % rows.length;
+            applyBrowseFocus();
+            rows[browseKb].scrollIntoView({ block: "nearest" });
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            var btn = rows[browseKb] && rows[browseKb].querySelector("button[data-open],button[data-preview]");
+            if (btn) btn.click();
+        }
     }
 
     //Open a public channel the user has not joined: read-only preview with
@@ -3594,7 +3630,8 @@
         $id("ncName").addEventListener("keyup", function (e) {
             if (e.key === "Enter") submitCreateChannel();
         });
-        $id("browseFilter").addEventListener("input", renderBrowseList);
+        $id("browseFilter").addEventListener("input", function () { browseKb = 0; renderBrowseList(); });
+        $id("browseFilter").addEventListener("keydown", browseKeydown);
         $id("browseCreateBtn").addEventListener("click", function () {
             closeModal("browseModal");
             openCreateModal();

--- a/src/web/Chatspace/app.js
+++ b/src/web/Chatspace/app.js
@@ -2099,17 +2099,55 @@
 
     /* ================= Right panel ================= */
 
-    function closeRightPanel() {
+    //PWA history integration: the thread / profile panel is a full-screen
+    //sub-view on mobile, so opening it pushes a single history entry. The
+    //device or browser Back button then closes the panel instead of leaving
+    //the app, matching the behaviour of a native chat client.
+    //  active   - a sentinel entry is currently on the history stack
+    //  suppress - true during an internal convo switch, so the transient
+    //             close-then-reopen reuses the sentinel instead of unwinding
+    //             and re-pushing it (which would race the async popstate).
+    var panelHist = { active: false, suppress: false };
+
+    function pushPanelHistory() {
+        if (!panelHist.active) {
+            panelHist.active = true;
+            try { history.pushState({ csPanel: 1 }, ""); } catch (e) { /* history unavailable */ }
+        }
+    }
+
+    //fromPop === true when invoked from the popstate handler: the browser has
+    //already unwound our sentinel, so we must not call history.back() again.
+    function closeRightPanel(fromPop) {
+        var wasOpen = !!state.rpMode;
         state.rpMode = null;
         state.activeThread = null;
         state.rpProfileUser = null;
+        //Drop any in-progress thread-scoped edit so it cannot leak into the
+        //main composer's draft/edit state once the panel is gone.
+        if (state.editing && state.editing.thread) state.editing = null;
         $id("rightPanel").style.display = "none";
+        if (!wasOpen || panelHist.suppress) return;
+        if (fromPop) { panelHist.active = false; return; }
+        if (panelHist.active) {
+            //UI dismissal (close button / Esc / convo switch): consume the entry
+            panelHist.active = false;
+            try { history.back(); } catch (e) { /* history unavailable */ }
+        }
     }
 
     function openThread(convoId, rootId) {
-        if (state.active !== convoId) setActive(convoId);
+        //Switching convo may close a currently open thread; suppress the
+        //history unwind during that internal transition so we reuse the
+        //sentinel we are about to keep (avoids an async popstate race).
+        if (state.active !== convoId) {
+            panelHist.suppress = true;
+            setActive(convoId);
+            panelHist.suppress = false;
+        }
         state.rpMode = "thread";
         state.activeThread = rootId;
+        pushPanelHistory();
         renderRightPanel();
         restoreDraft(true);
         var input = $id("rpComposeInput");
@@ -2130,6 +2168,7 @@
     function openProfile(username) {
         state.rpMode = "profile";
         state.rpProfileUser = username;
+        pushPanelHistory();
         renderRightPanel();
     }
 
@@ -2513,7 +2552,7 @@
             showToast("Message too long", "Messages are capped at " + MAX_MSG_LEN + " characters");
             return;
         }
-        if (state.editing) {
+        if (state.editing && !state.editing.thread) {
             sendEdit(convo, state.editing.itemId, text);
             state.editing = null;
             updateComposerPlaceholder();
@@ -2534,8 +2573,14 @@
         var input = $id("rpComposeInput");
         var text = input.value.trim();
         if (text === "" || text.length > MAX_MSG_LEN) return;
-        sendMessage(convo, text, state.activeThread, $id("rpAlsoSend").checked);
+        if (state.editing && state.editing.thread) {
+            sendEdit(convo, state.editing.itemId, text);
+            state.editing = null;
+        } else {
+            sendMessage(convo, text, state.activeThread, $id("rpAlsoSend").checked);
+        }
         input.value = "";
+        autoGrow(input);
         $id("rpAlsoSend").checked = false;
         delete state.prefs.drafts[draftKey(true)];
         savePrefs();
@@ -2554,6 +2599,28 @@
         input.focus();
     }
 
+    //Edit a reply from inside the open thread panel (parity with the main
+    //composer's inline edit); keeps the edit bound to the thread composer.
+    function startEditInThread(convo, msg) {
+        state.editing = { convoId: convo.id, itemId: msg.id, thread: true };
+        var input = $id("rpComposeInput");
+        input.value = msg.text;
+        autoGrow(input);
+        input.placeholder = "Edit your reply - Enter to save, Esc to cancel";
+        refreshSendButtons();
+        input.focus();
+    }
+
+    function cancelThreadEdit() {
+        if (!state.editing || !state.editing.thread) return;
+        state.editing = null;
+        var input = $id("rpComposeInput");
+        input.value = state.prefs.drafts[draftKey(true)] || "";
+        input.placeholder = "Reply...";
+        autoGrow(input);
+        refreshSendButtons();
+    }
+
     function editLastOwnMessage() {
         var convo = activeConvo();
         if (!convo) return;
@@ -2563,6 +2630,64 @@
                 startEdit(convo, msg);
                 return;
             }
+        }
+    }
+
+    //Up-arrow-to-edit inside the thread panel: pick the last own reply
+    function editLastOwnThreadReply() {
+        var convo = activeConvo();
+        if (!convo || !state.activeThread) return;
+        var root = convo.msgs[state.activeThread];
+        if (!root) return;
+        for (var i = root.replies.length - 1; i >= 0; i--) {
+            var msg = convo.msgs[root.replies[i]];
+            if (msg && msg.user === state.username && msg.kind === "text" && !msg.bot) {
+                startEditInThread(convo, msg);
+                return;
+            }
+        }
+    }
+
+    //Shared keydown logic for both composers. `opts.thread` selects the
+    //thread composer behaviour (reply submit / thread-scoped inline edit).
+    function composerKeydown(e, opts) {
+        var input = e.currentTarget;
+        //Mention autocomplete captures navigation keys while it is open
+        if (mentionPickerOpen()) {
+            if (e.key === "ArrowDown") {
+                e.preventDefault();
+                moveMentionSelection(1);
+                return;
+            } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                moveMentionSelection(-1);
+                return;
+            } else if (e.key === "Enter" || e.key === "Tab") {
+                if (confirmMention()) { e.preventDefault(); return; }
+            } else if (e.key === "Escape") {
+                e.preventDefault();
+                e.stopPropagation();
+                closePickers();
+                return;
+            }
+        }
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            if (opts.thread) submitThreadComposer();
+            else submitComposer();
+        } else if (e.key === "Escape" && state.editing) {
+            //Cancel an in-progress inline edit (do not also close the thread)
+            e.stopPropagation();
+            if (opts.thread) cancelThreadEdit();
+            else {
+                state.editing = null;
+                input.value = state.prefs.drafts[draftKey(false)] || "";
+                updateComposerPlaceholder();
+                refreshSendButtons();
+            }
+        } else if (e.key === "ArrowUp" && input.value === "") {
+            if (opts.thread) editLastOwnThreadReply();
+            else editLastOwnMessage();
         }
     }
 
@@ -2663,6 +2788,12 @@
         popover.style.visibility = "";
     }
 
+    function anyPickerOpen() {
+        return ["iconPicker", "mentionPicker", "jumpMenu", "downloadMenu"].some(function (id) {
+            return $id(id).style.display !== "none";
+        });
+    }
+
     function closePickers() {
         $id("iconPicker").style.display = "none";
         $id("mentionPicker").style.display = "none";
@@ -2681,14 +2812,22 @@
         }
     });
 
-    //Mention autocomplete over the composer: opened by the @ button or by
-    //typing "@..." at the caret
-    var mentionMode = null; // {prefixStart} when open
+    //Mention autocomplete over a composer: opened by the @ button or by
+    //typing "@..." at the caret. The picker is fully keyboard driven -
+    //Up/Down move the highlight, Enter/Tab confirm, Esc dismisses - and it
+    //works over whichever composer (main or thread) currently has focus.
+    var mentionMode = null; // {prefixStart, input, anchor} when open
 
-    function openMentionPicker(filter, prefixStart) {
+    function mentionPickerOpen() {
+        return !!mentionMode && $id("mentionPicker").style.display !== "none";
+    }
+
+    function openMentionPicker(filter, prefixStart, input, anchor) {
         var convo = activeConvo();
         if (!convo) return;
-        mentionMode = { prefixStart: prefixStart };
+        input = input || $id("composeInput");
+        anchor = anchor || $id("composer");
+        mentionMode = { prefixStart: prefixStart, input: input, anchor: anchor };
         var picker = $id("mentionPicker");
         var lowered = (filter || "").toLowerCase();
         var candidates = [];
@@ -2719,17 +2858,42 @@
         });
         picker.innerHTML = html;
         picker.style.display = "";
-        positionPopover(picker, $id("composer"));
+        positionPopover(picker, anchor);
         Array.prototype.forEach.call(picker.querySelectorAll(".mp-row"), function (row) {
-            row.addEventListener("click", function (e) {
+            row.addEventListener("mousedown", function (e) {
+                //mousedown (not click) so the composer keeps focus/selection
+                e.preventDefault();
                 e.stopPropagation();
                 insertMention(row.getAttribute("data-name"));
             });
         });
     }
 
+    //Move the mention highlight by delta (wraps around) and keep it visible
+    function moveMentionSelection(delta) {
+        var rows = $id("mentionPicker").querySelectorAll(".mp-row");
+        if (rows.length === 0) return;
+        var cur = 0;
+        for (var i = 0; i < rows.length; i++) {
+            if (rows[i].classList.contains("selected")) { cur = i; break; }
+        }
+        rows[cur].classList.remove("selected");
+        var next = (cur + delta + rows.length) % rows.length;
+        rows[next].classList.add("selected");
+        rows[next].scrollIntoView({ block: "nearest" });
+    }
+
+    //Confirm the highlighted mention; returns false when nothing is picked
+    function confirmMention() {
+        var selected = $id("mentionPicker").querySelector(".mp-row.selected") ||
+            $id("mentionPicker").querySelector(".mp-row");
+        if (!selected) return false;
+        insertMention(selected.getAttribute("data-name"));
+        return true;
+    }
+
     function insertMention(name) {
-        var input = $id("composeInput");
+        var input = (mentionMode && mentionMode.input) || $id("composeInput");
         var caret = input.selectionStart;
         var start = mentionMode ? mentionMode.prefixStart : caret;
         input.value = input.value.substring(0, start) + "@" + name + " " + input.value.substring(caret);
@@ -2740,13 +2904,13 @@
         refreshSendButtons();
     }
 
-    function detectMentionTyping() {
-        var input = $id("composeInput");
+    function detectMentionTyping(input, anchor) {
+        input = input || $id("composeInput");
         var caret = input.selectionStart;
         var upto = input.value.substring(0, caret);
         var match = upto.match(/(^|[\s(])@([A-Za-z0-9_.\-]*)$/);
         if (match) {
-            openMentionPicker(match[2], caret - match[2].length - 1);
+            openMentionPicker(match[2], caret - match[2].length - 1, input, anchor);
         } else if (mentionMode) {
             closePickers();
         }
@@ -3252,31 +3416,7 @@
             detectMentionTyping();
         });
         input.addEventListener("keydown", function (e) {
-            if ($id("mentionPicker").style.display !== "none") {
-                if (e.key === "Enter" || e.key === "Tab") {
-                    var selected = document.querySelector("#mentionPicker .mp-row.selected") ||
-                        document.querySelector("#mentionPicker .mp-row");
-                    if (selected) {
-                        e.preventDefault();
-                        insertMention(selected.getAttribute("data-name"));
-                        return;
-                    }
-                } else if (e.key === "Escape") {
-                    closePickers();
-                    return;
-                }
-            }
-            if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                submitComposer();
-            } else if (e.key === "Escape" && state.editing) {
-                state.editing = null;
-                input.value = state.prefs.drafts[draftKey(false)] || "";
-                updateComposerPlaceholder();
-                refreshSendButtons();
-            } else if (e.key === "ArrowUp" && input.value === "") {
-                editLastOwnMessage();
-            }
+            composerKeydown(e, { thread: false });
         });
         input.addEventListener("blur", saveDraft);
         $id("sendBtn").addEventListener("click", submitComposer);
@@ -3318,18 +3458,16 @@
             this.value = "";
         });
 
-        //Thread composer
+        //Thread composer - same keyboard affordances as the main composer
         var rpInput = $id("rpComposeInput");
         rpInput.addEventListener("input", function () {
             autoGrow(rpInput);
             refreshSendButtons();
             emitTyping(activeConvo());
+            detectMentionTyping(rpInput, $id("rpComposer"));
         });
         rpInput.addEventListener("keydown", function (e) {
-            if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                submitThreadComposer();
-            }
+            composerKeydown(e, { thread: true });
         });
         rpInput.addEventListener("blur", saveDraft);
         $id("rpSendBtn").addEventListener("click", submitThreadComposer);
@@ -3399,10 +3537,22 @@
                 return;
             }
             if (e.key === "Escape") {
+                //Close the top-most layer only, so one Esc peels back one level:
+                //popovers first, then open modals, then the thread / detail panel.
+                if (anyPickerOpen()) { closePickers(); return; }
+                var closedModal = false;
                 Array.prototype.forEach.call(document.querySelectorAll(".cs-overlay"), function (overlay) {
-                    overlay.style.display = "none";
+                    if (overlay.style.display !== "none") { overlay.style.display = "none"; closedModal = true; }
                 });
+                if (closedModal) return;
+                if (state.rpMode) { closeRightPanel(); return; }
             }
+        });
+
+        //PWA / native Back button closes the thread (or profile) panel first
+        window.addEventListener("popstate", function () {
+            if (state.rpMode) closeRightPanel(true);
+            else panelHist.active = false;
         });
 
         //Focus tracking drives read-marking and notification muting

--- a/src/web/Chatspace/app.js
+++ b/src/web/Chatspace/app.js
@@ -1820,6 +1820,15 @@
         if (media) media.addEventListener("loadedmetadata", function () {
             if (state.active === convo.id && isScrolledToBottom()) scrollMessagesToBottom();
         });
+        //Right-click context menu (mirrors the hover actions). Defer to the
+        //native menu when the user has selected text inside this message so
+        //browser copy still works.
+        node.addEventListener("contextmenu", function (e) {
+            var sel = window.getSelection();
+            if (sel && !sel.isCollapsed && sel.anchorNode && node.contains(sel.anchorNode)) return;
+            e.preventDefault();
+            openMsgContextMenu(e.clientX, e.clientY, convo, msg, node);
+        });
     }
 
     function fillTextPreview(pre, spaceid, itemid) {
@@ -1990,6 +1999,120 @@
                 else saveToArozOS(spaceid, itemid, name);
             });
         });
+    }
+
+    /* ---- message right-click context menu ---- */
+
+    var cmKeyHandler = null; //active keyboard shortcut handler while the menu is open
+
+    function clearCmKeys() {
+        if (cmKeyHandler) {
+            document.removeEventListener("keydown", cmKeyHandler, true);
+            cmKeyHandler = null;
+        }
+    }
+
+    function openMsgContextMenu(x, y, convo, msg, node) {
+        closePickers();
+        var menu = $id("msgContextMenu");
+        var inThread = !!node.closest("#rpBody");
+        var saved = isSaved(convo.id, msg.id);
+        var canEdit = msg.user === state.username && msg.kind === "text" && !msg.bot;
+        var canDel = msg.user === state.username || canManage(convo);
+
+        var items = [
+            { act: "react", icon: "smile outline", label: "Add reaction", key: "R" },
+            { act: "thread", icon: "comment outline", label: "Reply in thread", key: "T" }
+        ];
+        if (msg.kind === "text") items.push({ act: "copy", icon: "copy outline", label: "Copy text", key: "C" });
+        items.push({ sep: true });
+        items.push({ act: "save", icon: "bookmark" + (saved ? "" : " outline"), label: saved ? "Remove from Later" : "Save for later", key: "A" });
+        items.push({ act: "pin", icon: "thumbtack", label: msg.pinned ? "Unpin from conversation" : "Pin to conversation", key: "P" });
+        if (canEdit || canDel) items.push({ sep: true });
+        if (canEdit) items.push({ act: "edit", icon: "pencil", label: "Edit message", key: "E" });
+        if (canDel) items.push({ act: "delete", icon: "trash", label: "Delete message", key: "␡", danger: true });
+
+        var html = "";
+        items.forEach(function (it) {
+            if (it.sep) { html += '<div class="cm-sep"></div>'; return; }
+            html += '<div class="cm-row' + (it.danger ? " danger" : "") + '" data-cm="' + it.act + '">' +
+                '<i class="' + it.icon + ' icon"></i><span class="cm-label">' + it.label + '</span>' +
+                '<span class="cm-key">' + it.key + '</span></div>';
+        });
+        menu.innerHTML = html;
+        menu.style.display = "";
+        positionMenuAt(menu, x, y);
+        Array.prototype.forEach.call(menu.querySelectorAll(".cm-row"), function (row) {
+            row.addEventListener("click", function (ev) {
+                ev.stopPropagation();
+                runMsgAction(row.getAttribute("data-cm"), convo, msg, node, inThread);
+            });
+        });
+
+        //The single-key shortcuts shown on the right are live while the menu
+        //is open (Slack behaviour). Ctrl/Cmd combos are left to the browser.
+        var keymap = {};
+        items.forEach(function (it) { if (it.act && it.key) keymap[it.key.toUpperCase()] = it.act; });
+        clearCmKeys();
+        cmKeyHandler = function (ev) {
+            if (menu.style.display === "none") { clearCmKeys(); return; }
+            if (ev.key === "Escape") { ev.preventDefault(); closePickers(); return; }
+            if (ev.ctrlKey || ev.metaKey || ev.altKey) return;
+            var act = (ev.key === "Delete" || ev.key === "Backspace") ? "delete" : keymap[ev.key.toUpperCase()];
+            if (act) { ev.preventDefault(); runMsgAction(act, convo, msg, node, inThread); }
+        };
+        document.addEventListener("keydown", cmKeyHandler, true);
+    }
+
+    function runMsgAction(act, convo, msg, node, inThread) {
+        clearCmKeys();
+        if (act === "react") {
+            //Keep the message as a stable anchor while the icon picker opens
+            $id("msgContextMenu").style.display = "none";
+            openIconPicker(node, function (code) { toggleReaction(convo, msg.id, code); });
+            return;
+        }
+        closePickers();
+        if (act === "thread") openThread(convo.id, msg.thread || msg.id);
+        else if (act === "copy") copyToClipboard(msg.text);
+        else if (act === "save") toggleSaved(convo.id, msg.id);
+        else if (act === "pin") togglePin(convo, msg.id);
+        else if (act === "edit") { inThread ? startEditInThread(convo, msg) : startEdit(convo, msg); }
+        else if (act === "delete") deleteMessage(convo, msg.id);
+    }
+
+    function copyToClipboard(text) {
+        function ok() { showToast("Copied", "Message text copied to the clipboard"); }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(ok, function () { legacyCopy(text, ok); });
+        } else {
+            legacyCopy(text, ok);
+        }
+    }
+
+    function legacyCopy(text, ok) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        try { if (document.execCommand("copy")) ok(); } catch (e) { /* clipboard blocked */ }
+        document.body.removeChild(ta);
+    }
+
+    //Position a fixed popover at the cursor, flipping so it stays on-screen.
+    function positionMenuAt(menu, x, y) {
+        menu.style.visibility = "hidden";
+        menu.style.left = "0px";
+        menu.style.top = "0px";
+        var w = menu.offsetWidth;
+        var h = menu.offsetHeight;
+        var left = x + w + 8 > window.innerWidth ? x - w : x;
+        var top = y + h + 8 > window.innerHeight ? y - h : y;
+        menu.style.left = Math.max(8, left) + "px";
+        menu.style.top = Math.max(8, top) + "px";
+        menu.style.visibility = "";
     }
 
     /* ---- day divider "Jump to..." menu ---- */
@@ -2791,7 +2914,7 @@
     }
 
     function anyPickerOpen() {
-        return ["iconPicker", "mentionPicker", "jumpMenu", "downloadMenu"].some(function (id) {
+        return ["iconPicker", "mentionPicker", "jumpMenu", "downloadMenu", "msgContextMenu"].some(function (id) {
             return $id(id).style.display !== "none";
         });
     }
@@ -2801,12 +2924,15 @@
         $id("mentionPicker").style.display = "none";
         $id("jumpMenu").style.display = "none";
         $id("downloadMenu").style.display = "none";
+        $id("msgContextMenu").style.display = "none";
+        clearCmKeys();
         mentionMode = null;
     }
 
     document.addEventListener("click", function (e) {
         if (!$id("iconPicker").contains(e.target) && !$id("mentionPicker").contains(e.target) &&
-            !$id("jumpMenu").contains(e.target) && !$id("downloadMenu").contains(e.target)) {
+            !$id("jumpMenu").contains(e.target) && !$id("downloadMenu").contains(e.target) &&
+            !$id("msgContextMenu").contains(e.target)) {
             closePickers();
         }
         if (!$id("searchBox").contains(e.target)) {

--- a/src/web/Chatspace/app.js
+++ b/src/web/Chatspace/app.js
@@ -3060,8 +3060,8 @@
             if (excluded && excluded[name]) return;
             if (lowered && name.toLowerCase().indexOf(lowered) < 0) return;
             html += '<div class="pick-row' + (picked[name] ? " picked" : "") + '" data-name="' + escapeAttr(name) + '">' +
-                '<span class="avatar">' + avatarHtml(name, 11) + '</span>' +
-                '<span class="presence-dot' + (isOnline(name) ? " online" : "") + '" style="margin:0;border-color:#fff;"></span>' +
+                '<span class="avatar">' + avatarHtml(name, 11) +
+                '<span class="presence-dot' + (isOnline(name) ? " online" : "") + '"></span></span>' +
                 '<span class="pick-name">' + escapeHtml(name) + '</span>' +
                 '<i class="check icon pick-check"></i></div>';
         });
@@ -3072,9 +3072,41 @@
     function openDmModal() {
         dmPicked = {};
         $id("dmFilter").value = "";
+        pickKb.dmUserList = 0;
         renderDmPicker();
         openModal("dmModal");
         $id("dmFilter").focus();
+    }
+
+    //Keyboard cursor for the people/channel picker lists (arrows + Enter).
+    var pickKb = { dmUserList: 0, inviteUserList: 0 };
+
+    function applyPickFocus(listId) {
+        var rows = $id(listId).querySelectorAll(".pick-row");
+        var idx = pickKb[listId] || 0;
+        if (idx > rows.length - 1) idx = rows.length - 1;
+        if (idx < 0) idx = 0;
+        pickKb[listId] = idx;
+        for (var i = 0; i < rows.length; i++) rows[i].classList.toggle("kbfocus", i === idx);
+    }
+
+    function pickerKeydown(e, listId) {
+        var rows = $id(listId).querySelectorAll(".pick-row");
+        if (rows.length === 0) return;
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            pickKb[listId] = (pickKb[listId] + 1) % rows.length;
+            applyPickFocus(listId);
+            rows[pickKb[listId]].scrollIntoView({ block: "nearest" });
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            pickKb[listId] = (pickKb[listId] - 1 + rows.length) % rows.length;
+            applyPickFocus(listId);
+            rows[pickKb[listId]].scrollIntoView({ block: "nearest" });
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            if (rows[pickKb[listId]]) rows[pickKb[listId]].click();
+        }
     }
 
     function renderDmPicker() {
@@ -3088,6 +3120,7 @@
                 renderDmPicker();
             });
         });
+        applyPickFocus("dmUserList");
     }
 
     function openDmWith(usernames) {
@@ -3109,6 +3142,7 @@
         inviteConvo = convo;
         invitePicked = {};
         $id("inviteFilter").value = "";
+        pickKb.inviteUserList = 0;
         $id("inviteTitle").textContent = "Add people to " + (convo.kind === "dm" ? "the conversation" : "#" + convoLabel(convo));
         renderInvitePicker();
         openModal("inviteModal");
@@ -3127,6 +3161,7 @@
                 renderInvitePicker();
             });
         });
+        applyPickFocus("inviteUserList");
     }
 
     function submitInvite() {
@@ -3216,16 +3251,62 @@
 
     //Wire jump-on-click for every result / recent row in the search dropdown
     function wireSearchRows(box) {
-        Array.prototype.forEach.call(box.querySelectorAll(".sr-row"), function (row) {
-            row.addEventListener("click", function () {
-                box.style.display = "none";
-                $id("searchInput").value = "";
-                var convoId = row.getAttribute("data-convo");
-                var msgId = row.getAttribute("data-msg");
-                if (msgId) jumpToMessage(convoId, msgId);
-                else setActive(convoId);
-            });
+        Array.prototype.forEach.call(box.querySelectorAll(".sr-row"), function (row, idx) {
+            row.addEventListener("mouseenter", function () { setSearchSelection(idx); });
+            row.addEventListener("click", function () { activateSearchRow(row); });
         });
+        searchSel = 0;
+        applySearchSelection();
+    }
+
+    var searchSel = 0; //keyboard cursor into the search dropdown rows
+
+    function searchRows() { return $id("searchResults").querySelectorAll(".sr-row"); }
+
+    function applySearchSelection() {
+        var rows = searchRows();
+        for (var i = 0; i < rows.length; i++) {
+            rows[i].classList.toggle("selected", i === searchSel);
+        }
+    }
+
+    function setSearchSelection(idx) {
+        searchSel = idx;
+        applySearchSelection();
+    }
+
+    function moveSearchSelection(delta) {
+        var rows = searchRows();
+        if (rows.length === 0) return;
+        searchSel = (searchSel + delta + rows.length) % rows.length;
+        applySearchSelection();
+        rows[searchSel].scrollIntoView({ block: "nearest" });
+    }
+
+    function activateSearchRow(row) {
+        $id("searchResults").style.display = "none";
+        $id("searchInput").value = "";
+        var convoId = row.getAttribute("data-convo");
+        var msgId = row.getAttribute("data-msg");
+        if (!convoId) return;
+        if (msgId) jumpToMessage(convoId, msgId);
+        else setActive(convoId);
+    }
+
+    //Keyboard control for the search box: arrows move the highlight, Enter
+    //opens it, Escape dismisses the dropdown.
+    function searchKeydown(e) {
+        var box = $id("searchResults");
+        if (box.style.display === "none") return;
+        if (e.key === "ArrowDown") { e.preventDefault(); moveSearchSelection(1); }
+        else if (e.key === "ArrowUp") { e.preventDefault(); moveSearchSelection(-1); }
+        else if (e.key === "Enter") {
+            var rows = searchRows();
+            if (rows[searchSel]) { e.preventDefault(); activateSearchRow(rows[searchSel]); }
+        } else if (e.key === "Escape") {
+            box.style.display = "none";
+            $id("searchInput").blur();
+        }
     }
 
     //Slack-style empty state shown when the search box is focused but blank:
@@ -3355,6 +3436,7 @@
             //Show results when there is a query, otherwise the empty-state hint
             runSearch();
         });
+        $id("searchInput").addEventListener("keydown", searchKeydown);
 
         //Sidebar
         $id("sbComposeBtn").addEventListener("click", openDmModal);
@@ -3517,11 +3599,13 @@
             closeModal("browseModal");
             openCreateModal();
         });
-        $id("dmFilter").addEventListener("input", renderDmPicker);
+        $id("dmFilter").addEventListener("input", function () { pickKb.dmUserList = 0; renderDmPicker(); });
+        $id("dmFilter").addEventListener("keydown", function (e) { pickerKeydown(e, "dmUserList"); });
         $id("dmStartBtn").addEventListener("click", function () {
             openDmWith(Object.keys(dmPicked));
         });
-        $id("inviteFilter").addEventListener("input", renderInvitePicker);
+        $id("inviteFilter").addEventListener("input", function () { pickKb.inviteUserList = 0; renderInvitePicker(); });
+        $id("inviteFilter").addEventListener("keydown", function (e) { pickerKeydown(e, "inviteUserList"); });
         $id("inviteAddBtn").addEventListener("click", submitInvite);
 
         //Quick switcher

--- a/src/web/Chatspace/app.js
+++ b/src/web/Chatspace/app.js
@@ -1117,8 +1117,10 @@
             return stash(store, '<i class="' + ICON_BY_CODE[code] + ' icon cs-ic" title=":' + code + ':"></i>');
         });
         //Mentions: real users, broadcast tokens (@everyone/@channel) and
-        //the built-in @ai assistant
-        html = html.replace(/(^|[^A-Za-z0-9_.\-])@([A-Za-z0-9_.\-]+)/g, function (m, lead, name) {
+        //the built-in @ai assistant. The name class includes "@" so email
+        //style usernames (e.g. admin@example.com) are captured whole instead
+        //of stopping at the embedded "@" and only highlighting "admin".
+        html = html.replace(/(^|[^A-Za-z0-9_.\-@])@([A-Za-z0-9_.\-@]+)/g, function (m, lead, name) {
             if (BROADCAST_MENTIONS[name.toLowerCase()]) {
                 return lead + stash(store, '<span class="mention mention-me">@' + escapeHtml(name) + '</span>');
             }
@@ -2908,7 +2910,7 @@
         input = input || $id("composeInput");
         var caret = input.selectionStart;
         var upto = input.value.substring(0, caret);
-        var match = upto.match(/(^|[\s(])@([A-Za-z0-9_.\-]*)$/);
+        var match = upto.match(/(^|[\s(])@([A-Za-z0-9_.\-@]*)$/);
         if (match) {
             openMentionPicker(match[2], caret - match[2].length - 1, input, anchor);
         } else if (mentionMode) {

--- a/src/web/Chatspace/index.html
+++ b/src/web/Chatspace/index.html
@@ -335,8 +335,9 @@
                     Shift+Enter for a new line, Up arrow to edit your last message
                     (works in threads too), Esc to close a menu or the thread panel.
                     While typing an @mention use Up / Down to pick a person and
-                    Enter or Tab to insert them. On mobile the Back button closes
-                    the open thread.</p>
+                    Enter or Tab to insert them. In search and the channel / people
+                    pickers, Up / Down move the highlight and Enter opens or selects
+                    it. On mobile the Back button closes the open thread.</p>
             </div>
         </div>
     </div>

--- a/src/web/Chatspace/index.html
+++ b/src/web/Chatspace/index.html
@@ -332,7 +332,11 @@
                     ```code block```, &gt; quote, - bulleted lists, :thumbsup: icon
                     shortcodes and @username mentions.</p>
                 <p><b>Shortcuts:</b> Ctrl+K jump to a conversation, Enter to send,
-                    Shift+Enter for a new line, Up arrow to edit your last message.</p>
+                    Shift+Enter for a new line, Up arrow to edit your last message
+                    (works in threads too), Esc to close a menu or the thread panel.
+                    While typing an @mention use Up / Down to pick a person and
+                    Enter or Tab to insert them. On mobile the Back button closes
+                    the open thread.</p>
             </div>
         </div>
     </div>

--- a/src/web/Chatspace/index.html
+++ b/src/web/Chatspace/index.html
@@ -394,6 +394,8 @@
     <div id="iconPicker" style="display:none;"></div>
     <!-- Mention autocomplete popover -->
     <div id="mentionPicker" style="display:none;"></div>
+    <!-- Message right-click context menu -->
+    <div id="msgContextMenu" style="display:none;"></div>
 
     <!-- Toasts -->
     <div id="toastZone"></div>

--- a/src/web/Chatspace/sw.js
+++ b/src/web/Chatspace/sw.js
@@ -8,7 +8,7 @@
     be served stale from a cache.
 */
 
-var CACHE_NAME = "chatspace-shell-v1";
+var CACHE_NAME = "chatspace-shell-v2";
 var SHELL_ASSETS = [
     "index.html",
     "app.css",

--- a/src/web/Terminal/docs/api.json
+++ b/src/web/Terminal/docs/api.json
@@ -354,18 +354,39 @@
    "load": "requirelib(\"http\");",
    "functions": [
     {
+     "name": "http.request",
+     "sig": "http.request(options)",
+     "desc": "Curl-like request. options: {url, method, headers, body, json, form, bodyBase64, contentType, username, password, timeout, followRedirect, responseType}. Returns a response object {ok, status, statusText, headers, body, error}. Body precedence: bodyBase64 > form > json > body; responseType 'base64' returns a binary body base64 encoded.",
+     "ret": "object",
+     "example": "requirelib(\"http\");\nvar resp = http.request({url:\"https://example.com/api\", method:\"POST\", headers:{\"Authorization\":\"Bearer x\"}, json:{a:1}});\nif (resp.ok){ console.log(resp.status, resp.body); }"
+    },
+    {
      "name": "http.get",
-     "sig": "http.get(url)",
-     "desc": "Perform an HTTP GET and return the response body as a string.",
+     "sig": "http.get(url, headers)",
+     "desc": "Perform an HTTP GET and return the response body as a string. headers is optional.",
      "ret": "string",
      "example": "requirelib(\"http\");\nvar body = http.get(\"https://example.com/api\");"
     },
     {
      "name": "http.post",
-     "sig": "http.post(url, jsonString)",
-     "desc": "Perform an HTTP POST with JSON body and return the response body.",
+     "sig": "http.post(url, body, headers, contentType)",
+     "desc": "Perform an HTTP POST and return the response body. Without headers/contentType the body is sent as JSON (backward compatible).",
      "ret": "string",
      "example": "requirelib(\"http\");\nvar resp = http.post(\"https://example.com/api\", JSON.stringify({a:1}));"
+    },
+    {
+     "name": "http.put / http.patch / http.delete",
+     "sig": "http.put(url, body, headers, contentType)",
+     "desc": "Method helpers built on http.request; each returns the response object. http.delete(url, headers) sends no body.",
+     "ret": "object",
+     "example": "requirelib(\"http\");\nvar resp = http.put(\"https://example.com/api/1\", JSON.stringify({a:1}), {\"Content-Type\":\"application/json\"});"
+    },
+    {
+     "name": "http.postForm / http.postJSON",
+     "sig": "http.postForm(url, formObject, headers)",
+     "desc": "POST helpers built on http.request. postForm sends application/x-www-form-urlencoded; postJSON sends a JSON body. Both return the response object.",
+     "ret": "object",
+     "example": "requirelib(\"http\");\nvar resp = http.postForm(\"https://example.com/api\", {a:1, b:2});"
     },
     {
      "name": "http.head",

--- a/src/web/UnitTest/backend/http.request.js
+++ b/src/web/UnitTest/backend/http.request.js
@@ -1,0 +1,43 @@
+/*
+    http.request Curl-like request with full control over method, headers and body.
+
+    options: {url, method, headers, body, json, form, bodyBase64, contentType,
+              username, password, timeout, followRedirect, responseType}
+    returns: {ok, status, statusText, headers, body, error}
+*/
+
+requirelib("http")
+
+//POST a JSON body with a custom header and read back the full response object
+var resp = http.request({
+    url: "http://localhost:8080/system/file_system/listDir",
+    method: "POST",
+    headers: {
+        "X-Requested-With": "arozos-unittest"
+    },
+    json: {
+        dir: "user:/Desktop",
+        sort: "default"
+    },
+    timeout: 30
+});
+
+//Convenience helpers built on http.request
+//  http.postForm(url, formObject, headers) => url-encoded form body
+//  http.postJSON(url, object, headers)     => JSON body
+//  http.put / http.patch / http.delete     => method helpers
+var formResp = http.postForm("http://localhost:8080/system/file_system/listDir", {
+    dir: "user:/Desktop",
+    sort: "default"
+});
+
+//Relay the result of both calls to the client
+sendJSONResp(JSON.stringify({
+    "request-ok": resp.ok,
+    "request-status": resp.status,
+    "request-statusText": resp.statusText,
+    "request-body": resp.body,
+    "request-error": resp.error,
+    "postForm-status": formResp.status,
+    "postForm-body": formResp.body
+}));


### PR DESCRIPTION
## Summary
This PR adds a comprehensive right-click context menu for messages, enables editing replies within threads, improves keyboard navigation across multiple UI components, and fixes several layout and mention-handling issues.

## Key Changes

### Message Context Menu
- Added right-click context menu for messages with actions: react, reply in thread, copy text, save/unsave, pin/unpin, edit, and delete
- Menu intelligently shows/hides actions based on permissions (edit/delete only for message author or moderators)
- Single-key shortcuts (R, T, C, A, P, E, Delete) are live while menu is open, matching Slack behavior
- Menu respects text selection—native browser context menu appears when user has selected text within the message
- Implemented `positionMenuAt()` to keep menu on-screen by flipping position when near viewport edges

### Thread Editing
- Users can now edit their own replies within the thread panel using the same inline edit UX as the main composer
- Up-arrow-to-edit works in thread composer to pick the last own reply (`editLastOwnThreadReply()`)
- Thread-scoped edits are properly isolated and cleared when the thread panel closes
- Shared `composerKeydown()` logic handles keyboard behavior for both main and thread composers

### Keyboard Navigation Enhancements
- **Search results**: Arrow keys navigate, Enter activates, Esc dismisses
- **Browse channels modal**: Arrow keys move highlight, Enter opens/previews channel
- **DM/Invite picker lists**: Arrow keys navigate user list, Enter toggles selection
- **Mention autocomplete**: Arrow keys move selection, Enter/Tab confirms, works over either composer
- Consistent focus management with `scrollIntoView()` to keep highlighted items visible

### Mention Handling Improvements
- Fixed regex to include `@` in mention character class: `[A-Za-z0-9_.\-@]+`
- Allows email-style usernames (e.g., `admin@example.com`) to be captured whole instead of splitting at the embedded `@`
- Updated mention picker to work with either main or thread composer via `mentionMode.input` and `mentionMode.anchor`

### Right Panel (Thread/Profile) History Integration
- Added PWA history integration so opening thread/profile panel pushes a history entry
- Device/browser Back button now closes the panel instead of leaving the app
- Proper handling of internal conversation switches to avoid history race conditions
- `panelHist` state tracks active sentinel and suppresses unwinding during transitions

### Sidebar Changes
- Starred conversations now appear in both the Starred section AND their original Channels/Direct Messages sections (removed duplicate-hiding logic)
- Improved visual hierarchy with better padding alignment for section headers

### Layout & CSS Fixes
- Fixed grid layout to prevent thread panel from being pushed off-screen on narrow viewports using `minmax(0, 1fr)`
- Added `min-width: 0` to flex containers to allow proper text truncation
- Fixed channel header layout to prevent name/topic from spilling over action buttons
- Improved media preview sizing with `min(360px, 100%)` to respect narrow containers
- Fixed thread summary bar to display as block-level instead of inline-flex
- Fixed avatar/presence-dot positioning in picker lists

### Search Improvements
- Added empty-state hint when search box is focused but empty, showing recent conversations
- Keyboard-driven search with arrow navigation and Enter to activate
- Consistent row selection styling

### Other Improvements
- Added `copyToClipboard()` with fallback for older browsers
- Improved Escape key handling to close top-most layer only (popovers → modals → thread panel)
- Better mention picker interaction using `mousedown` instead of `click` to preserve composer focus
- Updated service worker cache version for new features

## Implementation Details
- Context menu uses fixed positioning with viewport-aware placement
- Keyboard handlers use event capture phase for proper event ordering
- Mention picker and other UI components now track which input/anchor they're bound to
- Thread editing state is properly scoped and cleared to prevent leaking into main composer
- History API wrapped in try-catch for environments where it's unavailable

https://claude.ai/code/session_01CfKyJV4zkj4AyME6XjH5q6