### PR TITLE
Fix CPU frequency and hardware model detection on LoongArch64

### DIFF
--- a/src/mod/info/hardwareinfo/sysinfo.go
+++ b/src/mod/info/hardwareinfo/sysinfo.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -108,7 +109,7 @@ func GetUSB(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
-	cmdin := `cat /proc/cpuinfo | grep -m1 "model name"`
+	cmdin := `cat /proc/cpuinfo | grep -m1 "[mM]odel [nN]ame"`
 	cmd := exec.Command("bash", "-c", cmdin)
 	hardware, err := cmd.CombinedOutput()
 	if err != nil {
@@ -126,7 +127,7 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 	cmd = exec.Command("bash", "-c", cmdin)
 	speed, err := cmd.CombinedOutput()
 	if err != nil {
-		cmdin = `cat /proc/cpuinfo | grep -m1 "cpu MHz"`
+		cmdin = `cat /proc/cpuinfo | grep -m1 "[cC][pP][uU] MHz"`
 		cmd = exec.Command("bash", "-c", cmdin)
 		intelSpeed, err := cmd.CombinedOutput()
 		if err != nil {
@@ -135,13 +136,16 @@ func GetCPUInfo(w http.ResponseWriter, r *http.Request) {
 		speed = intelSpeed
 	}
 
-	cmdin = `cat /proc/cpuinfo | grep -m1 "Hardware"`
-	cmd = exec.Command("bash", "-c", cmdin)
-	cpuhardware, err := cmd.CombinedOutput()
-	if err != nil {
+	//On LoongArch, /proc/cpuinfo has a "Hardware Watchpoint" field, which is not the hardware model we need.
+	if runtime.GOARCH != "loong64" {
+		cmdin = `cat /proc/cpuinfo | grep -m1 "Hardware"`
+		cmd = exec.Command("bash", "-c", cmdin)
+		cpuhardware, err := cmd.CombinedOutput()
+		if err != nil {
 
-	} else {
-		hardware = cpuhardware
+		} else {
+			hardware = cpuhardware
+		}
 	}
 
 	//On ARM


### PR DESCRIPTION
## Description

Fix CPU frequency and hardware model detection on LoongArch64.

On LoongArch64, `/proc/cpuinfo` uses `Model Name` and `CPU MHz` with uppercase letters. This change makes the matching case-insensitive so these fields can be detected correctly.

Additionally, `/proc/cpuinfo` on LoongArch64 contains a `Hardware Watchpoint` field, which does not represent the hardware model we need. Therefore, the `Hardware` field detection is skipped on LoongArch64.

The `/proc/cpuinfo` format was verified against the LoongArch-specific implementation in the Linux kernel:
https://github.com/torvalds/linux/blob/master/arch/loongarch/kernel/proc.c

## Testing

- Tested on LoongArch64: CPU frequency and hardware model are displayed correctly.
- Tested on amd64 and ARM: existing CPU information detection behavior is not affected by this change.

<img width="1920" height="1080" alt="Screenshot_2026_07_21_21_51_34_maim" src="https://github.com/user-attachments/assets/b3e32c28-4887-4931-980f-dc78fcb4f23b" />
