### PR TITLE
Fix Windows hardware info when wmic.exe is missing

### DIFF
--- a/src/mod/disk/smart/helper.go
+++ b/src/mod/disk/smart/helper.go
@@ -3,6 +3,7 @@ package smart
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"imuslab.com/arozos/mod/info/logger"
@@ -19,38 +20,91 @@ func execCommand(executable string, args ...string) string {
 	return string(output)
 }
 
-func wmicGetinfo(wmicName string, itemName string) []string {
-	//get systeminfo
-	var InfoStorage []string
+// wmicClassName maps classic `wmic` aliases to CIM / Win32 class names.
+func wmicClassName(wmicName string) string {
+	if len(wmicName) > 6 && wmicName[0:6] == "Win32_" {
+		return wmicName
+	}
+	switch strings.ToLower(wmicName) {
+	case "cpu":
+		return "Win32_Processor"
+	case "os":
+		return "Win32_OperatingSystem"
+	case "computersystem":
+		return "Win32_ComputerSystem"
+	case "diskdrive":
+		return "Win32_DiskDrive"
+	case "nic":
+		return "Win32_NetworkAdapter"
+	case "logicaldisk":
+		return "Win32_LogicalDisk"
+	case "memorychip":
+		return "Win32_PhysicalMemory"
+	default:
+		return "Win32_" + wmicName
+	}
+}
 
-	cmd := exec.Command("chcp", "65001")
+// cimGetinfo reads a WMI property via PowerShell Get-CimInstance.
+// Modern Windows 11 no longer ships `wmic.exe` by default.
+func cimGetinfo(wmicName string, itemName string) []string {
+	className := wmicClassName(wmicName)
+	psClass := strings.ReplaceAll(className, "'", "''")
+	psItem := strings.ReplaceAll(itemName, "'", "''")
+	script := fmt.Sprintf(
+		"Get-CimInstance -ClassName '%s' | ForEach-Object { $p = $_.PSObject.Properties['%s']; if ($null -ne $p -and $null -ne $p.Value) { [string]$p.Value } }",
+		psClass, psItem,
+	)
+	cmd := exec.Command("powershell.exe",
+		"-NoProfile",
+		"-NonInteractive",
+		"-WindowStyle", "Hidden",
+		"-ExecutionPolicy", "Bypass",
+		"-Command", script,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil
+	}
+	var info []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(strings.ReplaceAll(line, "\r", ""))
+		if line != "" {
+			info = append(info, line)
+		}
+	}
+	return info
+}
 
-	cmd = exec.Command("wmic", wmicName, "list", "full", "/format:list")
+func legacyWmicGetinfo(wmicName string, itemName string) []string {
+	var info []string
+	cmd := exec.Command("wmic", wmicName, "list", "full", "/format:list")
 	if wmicName == "os" {
 		cmd = exec.Command("wmic", wmicName, "get", "*", "/format:list")
 	}
-
-	if len(wmicName) > 6 {
-		if wmicName[0:6] == "Win32_" {
-			cmd = exec.Command("wmic", "path", wmicName, "get", "*", "/format:list")
-		}
+	if len(wmicName) > 6 && wmicName[0:6] == "Win32_" {
+		cmd = exec.Command("wmic", "path", wmicName, "get", "*", "/format:list")
 	}
 	out, _ := cmd.CombinedOutput()
-	strOut := string(out)
-
-	strSplitedOut := strings.Split(strOut, "\n")
-	for _, strConfig := range strSplitedOut {
+	for _, strConfig := range strings.Split(string(out), "\n") {
 		if strings.Contains(strConfig, "=") {
-			strSplitedConfig := strings.SplitN(strConfig, "=", 2)
-			if strSplitedConfig[0] == itemName {
-				strSplitedConfigReplaced := strings.Replace(strSplitedConfig[1], "\r", "", -1)
-				InfoStorage = append(InfoStorage, strSplitedConfigReplaced)
+			parts := strings.SplitN(strConfig, "=", 2)
+			if parts[0] == itemName {
+				info = append(info, strings.Replace(parts[1], "\r", "", -1))
 			}
 		}
+	}
+	return info
+}
 
+func wmicGetinfo(wmicName string, itemName string) []string {
+	if runtime.GOOS == "windows" {
+		if info := cimGetinfo(wmicName, itemName); len(info) > 0 {
+			return info
+		}
+		if info := legacyWmicGetinfo(wmicName, itemName); len(info) > 0 {
+			return info
+		}
 	}
-	if len(InfoStorage) == 0 {
-		InfoStorage = append(InfoStorage, "Undefined")
-	}
-	return InfoStorage
+	return []string{"Undefined"}
 }

--- a/src/mod/disk/smart/smart_test.go
+++ b/src/mod/disk/smart/smart_test.go
@@ -166,7 +166,7 @@ func TestNewSmartListenerUnsupported(t *testing.T) {
 	}
 }
 
-// TestWmicGetinfoWindowsOnly runs wmic helper only on Windows.
+// TestWmicGetinfoWindowsOnly runs wmic/CIM helper only on Windows.
 func TestWmicGetinfoWindowsOnly(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("wmicGetinfo is Windows-only")
@@ -174,6 +174,24 @@ func TestWmicGetinfoWindowsOnly(t *testing.T) {
 	result := wmicGetinfo("os", "Caption")
 	if len(result) == 0 {
 		t.Error("expected at least one result from wmicGetinfo")
+	}
+	if result[0] == "Undefined" || result[0] == "" {
+		t.Fatalf("wmicGetinfo(os, Caption) = %v; CIM fallback should return a real caption when wmic.exe is missing", result)
+	}
+}
+
+// TestWmicGetinfoWindowsDiskDrive covers the diskdrive Model/Size path used by fillCapacity.
+func TestWmicGetinfoWindowsDiskDrive(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows only")
+	}
+	models := wmicGetinfo("diskdrive", "Model")
+	if len(models) == 0 || models[0] == "Undefined" || models[0] == "" {
+		t.Fatalf("wmicGetinfo(diskdrive, Model) = %v", models)
+	}
+	sizes := wmicGetinfo("diskdrive", "Size")
+	if len(sizes) == 0 || sizes[0] == "Undefined" || sizes[0] == "" {
+		t.Fatalf("wmicGetinfo(diskdrive, Size) = %v", sizes)
 	}
 }
 

--- a/src/mod/info/hardwareinfo/hardwareinfo.go
+++ b/src/mod/info/hardwareinfo/hardwareinfo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"imuslab.com/arozos/mod/info/logger"
@@ -87,40 +88,98 @@ func (s *Server) GetArOZInfo(w http.ResponseWriter, r *http.Request) {
 	utils.SendJSONResponse(w, string(jsonData))
 }
 
-func wmicGetinfo(wmicName string, itemName string) []string {
-	//get systeminfo
-	var InfoStorage []string
+// wmicClassName maps classic `wmic` aliases to CIM / Win32 class names.
+func wmicClassName(wmicName string) string {
+	if len(wmicName) > 6 && wmicName[0:6] == "Win32_" {
+		return wmicName
+	}
+	switch strings.ToLower(wmicName) {
+	case "cpu":
+		return "Win32_Processor"
+	case "os":
+		return "Win32_OperatingSystem"
+	case "computersystem":
+		return "Win32_ComputerSystem"
+	case "diskdrive":
+		return "Win32_DiskDrive"
+	case "nic":
+		return "Win32_NetworkAdapter"
+	case "logicaldisk":
+		return "Win32_LogicalDisk"
+	case "memorychip":
+		return "Win32_PhysicalMemory"
+	default:
+		return "Win32_" + wmicName
+	}
+}
 
-	cmd := exec.Command("chcp", "65001")
+// cimGetinfo reads a WMI property via PowerShell Get-CimInstance.
+// Modern Windows 11 (24H2+) no longer ships `wmic.exe` by default; CIM is the
+// supported replacement and exposes the same Win32_* properties.
+func cimGetinfo(wmicName string, itemName string) []string {
+	className := wmicClassName(wmicName)
+	psClass := strings.ReplaceAll(className, "'", "''")
+	psItem := strings.ReplaceAll(itemName, "'", "''")
+	script := fmt.Sprintf(
+		"Get-CimInstance -ClassName '%s' | ForEach-Object { $p = $_.PSObject.Properties['%s']; if ($null -ne $p -and $null -ne $p.Value) { [string]$p.Value } }",
+		psClass, psItem,
+	)
+	cmd := exec.Command("powershell.exe",
+		"-NoProfile",
+		"-NonInteractive",
+		"-WindowStyle", "Hidden",
+		"-ExecutionPolicy", "Bypass",
+		"-Command", script,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil
+	}
+	var info []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(strings.ReplaceAll(line, "\r", ""))
+		if line != "" {
+			info = append(info, line)
+		}
+	}
+	return info
+}
 
-	cmd = exec.Command("wmic", wmicName, "list", "full", "/format:list")
+// legacyWmicGetinfo keeps the original `wmic` path for older Windows hosts
+// that still ship the binary (pre-removal / optional Feature on Demand).
+func legacyWmicGetinfo(wmicName string, itemName string) []string {
+	var info []string
+
+	cmd := exec.Command("wmic", wmicName, "list", "full", "/format:list")
 	if wmicName == "os" {
 		cmd = exec.Command("wmic", wmicName, "get", "*", "/format:list")
 	}
-
-	if len(wmicName) > 6 {
-		if wmicName[0:6] == "Win32_" {
-			cmd = exec.Command("wmic", "path", wmicName, "get", "*", "/format:list")
-		}
+	if len(wmicName) > 6 && wmicName[0:6] == "Win32_" {
+		cmd = exec.Command("wmic", "path", wmicName, "get", "*", "/format:list")
 	}
 	out, _ := cmd.CombinedOutput()
-	strOut := string(out)
-
-	strSplitedOut := strings.Split(strOut, "\n")
-	for _, strConfig := range strSplitedOut {
+	for _, strConfig := range strings.Split(string(out), "\n") {
 		if strings.Contains(strConfig, "=") {
-			strSplitedConfig := strings.SplitN(strConfig, "=", 2)
-			if strSplitedConfig[0] == itemName {
-				strSplitedConfigReplaced := strings.Replace(strSplitedConfig[1], "\r", "", -1)
-				InfoStorage = append(InfoStorage, strSplitedConfigReplaced)
+			parts := strings.SplitN(strConfig, "=", 2)
+			if parts[0] == itemName {
+				info = append(info, strings.Replace(parts[1], "\r", "", -1))
 			}
 		}
+	}
+	return info
+}
 
+func wmicGetinfo(wmicName string, itemName string) []string {
+	if runtime.GOOS == "windows" {
+		// Prefer CIM: wmic.exe was removed from many Windows 11 installs.
+		if info := cimGetinfo(wmicName, itemName); len(info) > 0 {
+			return info
+		}
+		if info := legacyWmicGetinfo(wmicName, itemName); len(info) > 0 {
+			return info
+		}
 	}
-	if len(InfoStorage) == 0 {
-		InfoStorage = append(InfoStorage, "Undefined")
-	}
-	return InfoStorage
+	return []string{"Undefined"}
 }
 
 func filterGrepResults(result string, sep string) string {

--- a/src/mod/info/hardwareinfo/hardwareinfo_test.go
+++ b/src/mod/info/hardwareinfo/hardwareinfo_test.go
@@ -204,14 +204,56 @@ func TestGetRamInfoHandler(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestWmicGetinfoNonWindows verifies that wmicGetinfo returns a default
-// "Undefined" slice when wmic is not available (i.e., non-Windows).
+// "Undefined" slice when wmic/CIM are not available (i.e., non-Windows).
 func TestWmicGetinfoNonWindows(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping non-Windows wmic test on Windows")
 	}
 	result := wmicGetinfo("os", "Caption")
-	// On non-Windows, wmic doesn't exist; the function should return ["Undefined"]
+	// On non-Windows, wmic/CIM don't apply; the function should return ["Undefined"]
 	if len(result) == 0 {
 		t.Error("wmicGetinfo() returned empty slice, expected at least one element")
+	}
+	if result[0] != "Undefined" {
+		t.Errorf("wmicGetinfo() = %v, want [Undefined] on non-Windows", result)
+	}
+}
+
+// TestWmicGetinfoWindowsOsCaption verifies hardware info works on modern
+// Windows 11 where wmic.exe is removed: CIM must still return OS Caption.
+func TestWmicGetinfoWindowsOsCaption(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows only")
+	}
+	result := wmicGetinfo("os", "Caption")
+	if len(result) == 0 || result[0] == "Undefined" || result[0] == "" {
+		t.Fatalf("wmicGetinfo(os, Caption) = %v, want a real OS caption (CIM fallback)", result)
+	}
+	if !strings.Contains(strings.ToLower(result[0]), "windows") {
+		t.Errorf("unexpected Caption %q, expected it to mention Windows", result[0])
+	}
+}
+
+// TestWmicGetinfoWindowsCpuAndDisk covers the other aliases used by
+// PrintSystemHardwareDebugMessage / sysinfo_window.go.
+func TestWmicGetinfoWindowsCpuAndDisk(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows only")
+	}
+	cpu := wmicGetinfo("cpu", "Name")
+	if len(cpu) == 0 || cpu[0] == "Undefined" || cpu[0] == "" {
+		t.Fatalf("wmicGetinfo(cpu, Name) = %v", cpu)
+	}
+	mem := wmicGetinfo("ComputerSystem", "TotalPhysicalMemory")
+	if len(mem) == 0 || mem[0] == "Undefined" || mem[0] == "" {
+		t.Fatalf("wmicGetinfo(ComputerSystem, TotalPhysicalMemory) = %v", mem)
+	}
+	disk := wmicGetinfo("diskdrive", "Model")
+	if len(disk) == 0 || disk[0] == "Undefined" || disk[0] == "" {
+		t.Fatalf("wmicGetinfo(diskdrive, Model) = %v", disk)
+	}
+	win32 := wmicGetinfo("Win32_USBHub", "Description")
+	if len(win32) == 0 {
+		t.Fatalf("wmicGetinfo(Win32_USBHub, Description) returned empty")
 	}
 }


### PR DESCRIPTION
## Summary
On Windows 11 (build 26200 here), `wmic.exe` is gone from PATH. `wmicGetinfo` in hardwareinfo and disk/smart then always returned `Undefined`, so System Info / SMART disk listing showed no real CPU, OS, memory, or disk data.

This change prefers PowerShell `Get-CimInstance` for the same Win32_* properties, and keeps classic `wmic` as a fallback for older hosts that still have it.

## Changes
- `src/mod/info/hardwareinfo/hardwareinfo.go`: CIM-first `wmicGetinfo`, legacy wmic fallback
- `src/mod/disk/smart/helper.go`: same helper (SMART disk Model/Size path)
- Tests: assert real Caption/CPU/disk values on Windows instead of accepting `Undefined`

## AI assistance
Prepared with Cursor/Grok assistance. Reviewed and verified on a real Windows 11 box before opening.

## Evidence
Host: Windows 11 Pro, build 10.0.26200.0 (amd64). `where wmic` finds nothing.

Before (HEAD helper):
```
wmicGetinfo(os, Caption) = [Undefined]
```

After (re-verified 2026-07-23 after maintainer review question):
```
go test ./mod/info/hardwareinfo/ -count=1 -run 'TestWmicGetinfoWindows|TestGetCPUInfoHandler|TestGetRamInfoHandler' -v
--- PASS: TestGetCPUInfoHandler (4.42s)
--- PASS: TestGetRamInfoHandler (0.43s)
--- PASS: TestWmicGetinfoWindowsOsCaption (1.03s)
--- PASS: TestWmicGetinfoWindowsCpuAndDisk (2.58s)

go test ./mod/disk/smart/ -count=1 -run TestWmicGetinfoWindows -v
--- PASS: TestWmicGetinfoWindowsOnly (0.87s)
--- PASS: TestWmicGetinfoWindowsDiskDrive (0.77s)
```

Product-path handlers used by System Info (same process path as Settings; no full UI boot):
```
GetCPUInfo JSON: {"Model":"AMD Ryzen 5 7500F 6-Core Processor","Freq":"3701","Instruction":"AMD64 Family 25 Model 97 Stepping 2","Hardware":"unknown","Revision":"unknown"}
GetRamInfo body: 68719476736
```

## What was not tested
- Full ArozOS UI boot + System Settings browser click-through (handlers covered above; browser screenshot not yet)
- Hosts that still ship `wmic.exe` (fallback path preserved but not exercised here)
